### PR TITLE
Change order line item type from CHARGE_ADJUST to EDIT

### DIFF
--- a/app/models/waste_carriers_engine/order_item.rb
+++ b/app/models/waste_carriers_engine/order_item.rb
@@ -6,6 +6,12 @@ module WasteCarriersEngine
 
     embedded_in :order, class_name: "WasteCarriersEngine::Order"
 
+    TYPES = HashWithIndifferentAccess.new(
+      renew: "RENEW",
+      edit: "EDIT",
+      copy_cards: "COPY_CARDS"
+    )
+
     field :amount,                          type: Integer
     field :currency,                        type: String
     field :lastUpdated, as: :last_updated,  type: DateTime
@@ -18,7 +24,7 @@ module WasteCarriersEngine
 
       order_item[:amount] = Rails.configuration.renewal_charge
       order_item[:description] = "Renewal of registration"
-      order_item[:type] = "RENEW"
+      order_item[:type] = TYPES[:renew]
 
       order_item
     end
@@ -28,7 +34,7 @@ module WasteCarriersEngine
 
       order_item[:amount] = Rails.configuration.type_change_charge
       order_item[:description] = "changing carrier type during renewal"
-      order_item[:type] = "CHARGE_ADJUST"
+      order_item[:type] = TYPES[:edit]
 
       order_item
     end
@@ -38,7 +44,7 @@ module WasteCarriersEngine
 
       order_item[:amount] = cards * Rails.configuration.card_charge
       order_item[:description] = "#{cards} registration cards"
-      order_item[:type] = "COPY_CARDS"
+      order_item[:type] = TYPES[:copy_cards]
 
       order_item
     end

--- a/spec/models/waste_carriers_engine/order_item_spec.rb
+++ b/spec/models/waste_carriers_engine/order_item_spec.rb
@@ -13,10 +13,10 @@ module WasteCarriersEngine
     let(:transient_registration) { build(:transient_registration, :has_required_data) }
 
     describe "new_renewal_item" do
-      let(:order_item) { OrderItem.new_renewal_item }
+      let(:order_item) { described_class.new_renewal_item }
 
       it "should have a type of 'RENEW'" do
-        expect(order_item.type).to eq("RENEW")
+        expect(order_item.type).to eq(described_class::TYPES[:renew])
       end
 
       it "should set the correct amount" do
@@ -29,10 +29,10 @@ module WasteCarriersEngine
     end
 
     describe "new_type_change_item" do
-      let(:order_item) { OrderItem.new_type_change_item }
+      let(:order_item) { described_class.new_type_change_item }
 
-      it "should have a type of 'CHARGE_ADJUST'" do
-        expect(order_item.type).to eq("CHARGE_ADJUST")
+      it "should have a type of 'EDIT'" do
+        expect(order_item.type).to eq(described_class::TYPES[:edit])
       end
 
       it "should set the correct amount" do
@@ -45,10 +45,10 @@ module WasteCarriersEngine
     end
 
     describe "new_copy_cards_item" do
-      let(:order_item) { OrderItem.new_copy_cards_item(3) }
+      let(:order_item) { described_class.new_copy_cards_item(3) }
 
       it "should have a type of 'COPY_CARDS'" do
-        expect(order_item.type).to eq("COPY_CARDS")
+        expect(order_item.type).to eq(described_class::TYPES[:copy_cards])
       end
 
       it "should set the correct amount" do

--- a/spec/models/waste_carriers_engine/order_spec.rb
+++ b/spec/models/waste_carriers_engine/order_spec.rb
@@ -28,7 +28,7 @@ module WasteCarriersEngine
       end
 
       it "should include 1 renewal item" do
-        matching_item = order[:order_items].find { |item| item[:type] == "RENEW" }
+        matching_item = order[:order_items].find { |item| item[:type] == OrderItem::TYPES[:renew] }
         expect(matching_item).to_not be_nil
       end
 
@@ -58,7 +58,7 @@ module WasteCarriersEngine
 
       context "when the registration type has not changed" do
         it "should not include a type change item" do
-          matching_item = order[:order_items].find { |item| item[:type] == "CHARGE_ADJUST" }
+          matching_item = order[:order_items].find { |item| item[:type] == OrderItem::TYPES[:edit] }
           expect(matching_item).to be_nil
         end
       end
@@ -69,7 +69,7 @@ module WasteCarriersEngine
         end
 
         it "should include a type change item" do
-          matching_item = order[:order_items].find { |item| item[:type] == "CHARGE_ADJUST" }
+          matching_item = order[:order_items].find { |item| item[:type] == OrderItem::TYPES[:edit] }
           expect(matching_item).to_not be_nil
         end
 
@@ -88,7 +88,7 @@ module WasteCarriersEngine
         end
 
         it "should not include a copy cards item" do
-          matching_item = order[:order_items].find { |item| item[:type] == "COPY_CARDS" }
+          matching_item = order[:order_items].find { |item| item[:type] == OrderItem::TYPES[:copy_cards] }
           expect(matching_item).to be_nil
         end
       end
@@ -99,7 +99,7 @@ module WasteCarriersEngine
         end
 
         it "should not include a copy cards item" do
-          matching_item = order[:order_items].find { |item| item[:type] == "COPY_CARDS" }
+          matching_item = order[:order_items].find { |item| item[:type] == OrderItem::TYPES[:copy_cards] }
           expect(matching_item).to be_nil
         end
       end
@@ -110,7 +110,7 @@ module WasteCarriersEngine
         end
 
         it "should include a copy cards item" do
-          matching_item = order[:order_items].find { |item| item[:type] == "COPY_CARDS" }
+          matching_item = order[:order_items].find { |item| item[:type] == OrderItem::TYPES[:copy_cards] }
           expect(matching_item).to_not be_nil
         end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-204

This changes the line item type for CHARGE_ADJUST to EDIT in order to deliver better data to NCCC for their metric support. Carried out little refactoring on the order item types attribute.