### PR TITLE
Fix translation error on main people form

### DIFF
--- a/app/controllers/waste_carriers_engine/person_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/person_forms_controller.rb
@@ -3,7 +3,7 @@
 module WasteCarriersEngine
   class PersonFormsController < FormsController
     def create(form_class, form)
-      if params[:commit] == I18n.t("waste_carriers_engine.#{form}s.new.add_person_link")
+      if params[:commit] == I18n.t("waste_carriers_engine.#{form}s.form.add_person_link")
         submit_and_add_another(form_class, form)
       else
         super(form_class, form)

--- a/app/views/waste_carriers_engine/conviction_details_forms/_form.html.erb
+++ b/app/views/waste_carriers_engine/conviction_details_forms/_form.html.erb
@@ -1,0 +1,31 @@
+<%= form_for(@conviction_details_form) do |f| %>
+  <%= render("waste_carriers_engine/shared/errors", object: @conviction_details_form) %>
+
+  <h1 class="heading-large"><%= t(".heading") %></h1>
+  <p><%= t(".paragraph_1") %></p>
+
+  <%= render("waste_carriers_engine/shared/person_name", form: @conviction_details_form, f: f) %>
+
+  <div class="form-group <%= "form-group-error" if @conviction_details_form.errors[:position].any? %>">
+    <fieldset id="position">
+      <% if @conviction_details_form.errors[:position].any? %>
+        <span class="error-message"><%= @conviction_details_form.errors[:position].join(", ") %></span>
+      <% end %>
+
+      <%= f.label :position, t(".position"), class: "form-label" %>
+      <%= f.text_field :position, value: @conviction_details_form.position, class: "form-control" %>
+    </fieldset>
+  </div>
+
+  <%= render("waste_carriers_engine/shared/dob", form: @conviction_details_form, f: f) %>
+
+  <%= f.hidden_field :reg_identifier, value: @conviction_details_form.reg_identifier %>
+
+  <div class="form-group">
+    <%= f.submit t(".add_person_link"), class: "button-link" %>
+  </div>
+
+  <div class="form-group">
+    <%= f.submit t(".next_button"), class: "button" %>
+  </div>
+<% end %>

--- a/app/views/waste_carriers_engine/conviction_details_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/conviction_details_forms/new.html.erb
@@ -2,37 +2,7 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= form_for(@conviction_details_form) do |f| %>
-      <%= render("waste_carriers_engine/shared/errors", object: @conviction_details_form) %>
-
-      <h1 class="heading-large"><%= t(".heading") %></h1>
-      <p><%= t(".paragraph_1") %></p>
-
-      <%= render("waste_carriers_engine/shared/person_name", form: @conviction_details_form, f: f) %>
-
-      <div class="form-group <%= "form-group-error" if @conviction_details_form.errors[:position].any? %>">
-        <fieldset id="position">
-          <% if @conviction_details_form.errors[:position].any? %>
-            <span class="error-message"><%= @conviction_details_form.errors[:position].join(", ") %></span>
-          <% end %>
-
-          <%= f.label :position, t(".position"), class: "form-label" %>
-          <%= f.text_field :position, value: @conviction_details_form.position, class: "form-control" %>
-        </fieldset>
-      </div>
-
-      <%= render("waste_carriers_engine/shared/dob", form: @conviction_details_form, f: f) %>
-
-      <%= f.hidden_field :reg_identifier, value: @conviction_details_form.reg_identifier %>
-
-      <div class="form-group">
-        <%= f.submit t(".add_person_link"), class: "button-link" %>
-      </div>
-
-      <div class="form-group">
-        <%= f.submit t(".next_button"), class: "button" %>
-      </div>
-    <% end %>
+    <%= render "waste_carriers_engine/conviction_details_forms/form" %>
   </div>
 
   <% if @conviction_details_form.number_of_existing_relevant_people > 0 %>

--- a/config/locales/forms/conviction_details_forms/en.yml
+++ b/config/locales/forms/conviction_details_forms/en.yml
@@ -3,13 +3,13 @@ en:
     conviction_details_forms:
       new:
         title: Conviction details
+        list_of_people: You have added the following people
+        delete_person_link: Delete
+      form:
         heading: Details of the person with a conviction
         paragraph_1: You need to tell us about anyone in your organisation's management who has been convicted of an environmental offence.
         position: Job title
         add_person_link: Add another person
-        next_button: Continue
-        list_of_people: You have added the following people
-        delete_person_link: Delete
         next_button: Continue
   activemodel:
     errors:

--- a/config/locales/forms/main_people_forms/en.yml
+++ b/config/locales/forms/main_people_forms/en.yml
@@ -3,6 +3,9 @@ en:
     main_people_forms:
       new:
         title: Main people
+        list_of_people: You have added the following people
+        delete_person_link: Delete
+      form:
         heading:
           localAuthority: Chief executive details
           limitedCompany: Company director details
@@ -18,9 +21,6 @@ en:
           partnership:  Enter the name and date of birth for each partner of the business.
           soleTrader: Enter the name and date of birth of the business owner.
         add_person_link: Add another person
-        next_button: Continue
-        list_of_people: You have added the following people
-        delete_person_link: Delete
         next_button: Continue
   activemodel:
     errors:

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -38,5 +38,5 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 end


### PR DESCRIPTION
Spotted a translation error following our refactoring in https://github.com/DEFRA/waste-carriers-engine/pull/428, as part of the main people form had been moved to a partial. Updating the language YAML file fixed this.

However, this fix had a knock-on effect of breaking the "Add another person" link, which relied on a specific param being submitted based on the YAML file.

Fixing this then broke the "Add another person" on the conviction details form, which did not have a partial and so had a differently-structured YAML file. Sooo I moved this to a form partial as well and now everything works again. (Phew.)

Obviously this is a clear indicator we need to do some refactoring about how this controller works! So here's a quick fix for now but I'll log an issue to come back to this.

Our request tests should be raising translation errors so they don't make it to master. This PR also updates the dummy app config to raise the errors in future.