### PR TITLE
Fix accidental line break in manual address partial

### DIFF
--- a/app/views/waste_carriers_engine/shared/_manual_address.html.erb
+++ b/app/views/waste_carriers_engine/shared/_manual_address.html.erb
@@ -16,8 +16,7 @@
       <%= t(".house_number_label") %>
       <span class='form-hint'><%= t(".house_number_hint") %></span>
     <% end %>
-    <
-    %= f.text_field :house_number, value: form.house_number, class: "form-control" %>
+    <%= f.text_field :house_number, value: form.house_number, class: "form-control" %>
   </fieldset>
 </div>
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-397

This was resulting in the field not displaying correctly, making it impossible to fill in a valid form.