### PR TITLE
Fix Rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,31 @@
 # frozen_string_literal: true
 
-# Add your own tasks in files placed in lib/tasks ending in .rake,
-# for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
+begin
+  require "bundler/setup"
+rescue LoadError
+  puts "You must `gem install bundler` and `bundle install` to run rake tasks"
+end
 
-require File.expand_path("config/application", __dir__)
+APP_RAKEFILE = File.expand_path("spec/dummy/Rakefile", __dir__)
+load "rails/tasks/engine.rake"
 
-Rails.application.load_tasks
+load "rails/tasks/statistics.rake"
+
+Dir[File.join(File.dirname(__FILE__), "lib/tasks/**/*.rake")].each { |f| load f }
+
+Bundler::GemHelper.install_tasks
+
+# This is wrapped to prevent an error when rake is called in environments where
+# rspec may not be available, e.g. production. As such we don't need to handle
+# the error.
+# rubocop:disable Lint/HandleExceptions
+begin
+  require "rspec/core/rake_task"
+
+  RSpec::Core::RakeTask.new(:spec)
+
+  task default: :spec
+rescue LoadError
+  # no rspec available
+end
+# rubocop:enable Lint/HandleExceptions

--- a/spec/dummy/Rakefile
+++ b/spec/dummy/Rakefile
@@ -1,8 +1,6 @@
-# frozen_string_literal: true
-
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path("../config/application", __dir__)
+require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks


### PR DESCRIPTION
PR #355 and PR #354 fixed a series of issues having applied our latest and greatest [defra-ruby-style](https://github.com/DEFRA/defra-ruby-style) rules.

Part of that was changing some calls to `__FILE__` to use `__dir__` instead. Unbeknownest to us this actually broke rake and we only came to realise this when attempting to update the CHANGELOG.

In the dummy app's `Rakefile` the line was

```ruby
# Original
require File.expand_path("../config/application", __FILE__)

# What it was changed to
require File.expand_path("../config/application", __dir__)

# What it needed to be
require File.expand_path("config/application", __dir__)
```

Now this change could have just corrected the line and moved on. However a check of our other engines in WEX and FRAE showed that they were setup differently. That is to be expected because WEX and FRAE were always engines, however WCR started out as an app we converted to an engine.

So this change brings both the engine and the engine's dummy app Rakefiles inline with our other engines (TLDR; leave the dummy app as it gets generated, completely re-write the engine Rakefile 😁).