### PR TITLE
Move privacy policy and cookie pages into engine

### DIFF
--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -1,0 +1,87 @@
+<% content_for :title, "Cookies" %>
+
+<div class="text">
+  <h1 class="heading-large">Cookies</h1>
+  <p>The 'Register as a Waste Carrier' service puts small files (known as ‘cookies’) on to your computer.</p>
+  <p>These cookies are used to:</p>
+
+  <ul class="list list-bullet">
+    <li>help us understand how you use the service, so we can make improvements </li>
+    <li>remember what notifications you’ve seen so that you’re not shown them more than once</li>
+    <li>temporarily store the information you enter</li>
+  </ul>
+
+  <p>Find out more about <a rel="external" href="http://www.aboutcookies.org/">how to manage cookies</a></p>
+
+  <h2 class="heading-medium">Google Analytics cookie</h2>
+
+  <p>We use Google Analytics to collect information about how you use the service. This information helps us to improve the service.</p>
+  <p>The Google analytics cookie collects and stores information about:</p>
+
+  <ul class="list list-bullet">
+    <li>the pages you visit - how long you spend on each page</li>
+    <li>how you got to the service</li>
+    <li>what you click on while you’re using the service</li>
+  </ul>
+
+  <table summary="Google analytics cookie collection" role="presentation">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Purpose</th>
+        <th>Expires</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>_ga</td>
+        <td>Used to identify unique users and inform referring sites, visitor and session counts</td>
+        <td>2 years</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p>Google isn't allowed to use or share our analytics data with anyone.</p>
+
+  <h2 class="heading-medium">Session cookie</h2>
+
+  <p>We store session cookies on your computer to help keep your information secure while you use the service.</p>
+
+
+  <table summary="Session cookies" role="presentation">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Purpose</th>
+        <th>Expires</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>_registrations_session</td>
+        <td>Used for session management and authentication</td>
+        <td>After 20 minutes of inactivity, or when you close your browser</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2 class="heading-medium">Introductory message cookie</h2>
+  <p>When you first use the service, you may see a cookie message appear at the top of the screen. Once you’ve seen the message, we store a cookie on your computer so it knows not to show it again. </p>
+
+  <table summary="Introductory message cookie" role="presentation">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Purpose</th>
+        <th>Expires</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>seen_cookie_message</td>
+        <td>Stores a message to let us know that you have seen our cookie message</td>
+        <td>1 month</td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,0 +1,100 @@
+<% content_for :title, "Privacy policy" %>
+
+<div class="text">
+  <h1 class="heading-large">
+    Waste carriers, brokers and dealers privacy policy
+  </h1>
+
+  <h2 class="heading-medium">
+    How we use your personal information
+  </h2>
+  <p>
+    We are the Environment Agency and we run the Waste Carriers, Brokers and Dealers service. We are the data controller for this service. A data controller determines how and why personal data (personal information) is processed.
+  </p>
+  <p>
+    Our <a rel="external" href="https://www.gov.uk/government/organisations/environment-agency/about/personal-information-charter">personal information charter</a> explains your rights and how we deal with your personal information. You can access the charter using the link or go to GOV.UK and search 'Environment Agency personal information charter'.
+  </p>
+
+  <h2 class="heading-medium">
+    The data we need
+  </h2>
+  <p>
+    The personal data we collect about you includes:
+  </p>
+  <ul class="list list-bullet">
+    <li>the name and address of your business or organisation</li>
+    <li>contact details</li>
+    <li>date of birth</li>
+    <li>details of relevant criminal convictions</li>
+  </ul>
+  <p>
+    We are allowed to process your personal data because we have official authority to register waste carriers, brokers and dealers. The lawful basis for processing your personal data is to exercise our official authority that is set out in law.
+  </p>
+  <p>
+    We process personal data relating to criminal convictions and offences under the same official authority.
+  </p>
+
+  <h2 class="heading-medium">
+    What we do with your personal data
+  </h2>
+
+  <p>
+    We collect and store this data in order to process your transaction and register you as a waste carrier, broker or dealer. We do not store payment details. If you do not provide the information requested, we cannot register you as a waste carrier, broker or dealer.
+  </p>
+  <p>
+    We will use the personal data you provide about criminal convictions for making a decision about whether you can register as a waste carrier. If you disclose that a person in the company’s management has a relevant criminal conviction, your application to register as a waste carrier could be refused.
+  </p>
+  <p>
+    We put some of the information from your registration on a public register. Only the name and address of your organisation will appear on the public register.
+  </p>
+  <p>
+    We will not share or disclose any further personal data to any party outside the Environment Agency without your explicit consent unless we are lawfully able to do so.
+  </p>
+  <p>
+    We store and process your personal data on our servers within the European Economic Area (EEA). We will not transfer your personal data outside the EEA.
+  </p>
+  <p>
+    We do not use your personal data to make an automated decision or for automated profiling.
+  </p>
+
+  <h2 class="heading-medium">
+    How long we keep your personal data
+  </h2>
+  <p>
+    Personal data in an upper-tier registration is kept for 7 years after a registration has ended.
+  </p>
+  <p>
+    Lower-tier registrations are non-expiring, and personal data is retained unless you request it is removed. To request that your personal data is removed, please contact the Environment Agency helpline on 03708 506 506.
+  </p>
+
+  <h2 class="heading-medium">
+    Contact details
+  </h2>
+  <p>
+    Our Data Protection Officer (DPO) is responsible for independent advice and monitoring of the Environment Agency’s use of personal information.
+  </p>
+  <p>
+    If you have any concerns or queries about how we process personal data, or if you would like to make a complaint or request relating to data protection, please contact:
+  </p>
+  <p>
+    Address:<br>
+    Data Protection Officer<br>
+    Environment Agency<br>
+    Horizon House<br>
+    Deanery Road<br>
+    Bristol<br>
+    BS1 5AH
+  </p>
+  <p>
+    Email: <a rel="external" href="mailto:dataprotection@environment-agency.gov.uk">dataprotection@environment-agency.gov.uk</a>
+  </p>
+  <p>
+    The Information Commissioner's Office (ICO) is the supervisory authority for data protection legislation. The <a rel="external" href="https://ico.org.uk/your-data-matters">ICO website</a> has a full list of your rights under data protection legislation.
+  </p>
+  <p>
+    You have the right to <a rel="external" href="https://ico.org.uk/make-a-complaint">lodge a complaint with the ICO</a> at any time.
+  </p>
+  <div class="app-c-published-dates">
+    This notice was last updated on 25 April 2019.
+  </div>
+</div>

--- a/spec/requests/waste_carriers_engine/pages_spec.rb
+++ b/spec/requests/waste_carriers_engine/pages_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "Pages", type: :request do
+    %i[cookies privacy].each do |page|
+      it "displays the correct page" do
+        get page_path(page)
+
+        expect(response).to have_http_status(200)
+        expect(response).to render_template(page)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-396

This resolves a bug in the front office where the footer links are broken. These links are going to /pages/pagename (where the static pages built in the front office are located) and not /fo/pages/pagename. The result is that they work locally but fail on production where routing between apps is dependant on /fo being included in the URL.

We could fix this by changing routing in the front office - however, if we just move the pages to the engine, then that has the additional benefit of resolving https://eaflood.atlassian.net/browse/RUBY-109