### PR TITLE
Apply path fix to mailer helper

### DIFF
--- a/app/helpers/waste_carriers_engine/mailer_helper.rb
+++ b/app/helpers/waste_carriers_engine/mailer_helper.rb
@@ -9,7 +9,7 @@ module WasteCarriersEngine
     def email_image_tag(image, **options)
       path = "/app/assets/images/#{image}"
 
-      full_path = Rails.root.join(path)
+      full_path = File.join(Rails.root, path)
 
       full_path = "#{Gem.loaded_specs['waste_carriers_engine'].full_gem_path}#{path}" unless File.exist?(full_path)
 


### PR DESCRIPTION
https://github.com/DEFRA/waste-exemptions-back-office-ta/pull/308

Whilst working on another task in another project we identified that the way we were generating the path in the mailer was invalid.

Where path is `"/app/assets/images/waste_exemptions_engine/logo_ea.png"` we expected `Rails.root.join(path)` to return something like `"/vagrant/waste-exemptions-back-office-ta/app/assets/images/logo_ea.png"`.

When we got in there with `binding.pry` though we found this

```bash
[1] pry(#<#<Class:0x000055c9347abc20>>)> path
=> "/app/assets/images/logo_ea.png"
[2] pry(#<#<Class:0x000055c9347abc20>>)> Rails.root.join(path)
=> #<Pathname:/app/assets/images/logo_ea.png>
[3] pry(#<#<Class:0x000055c9347abc20>>)> Rails.root
=> #<Pathname:/vagrant/waste-exemptions-back-office-ta>
[4] pry(#<#<Class:0x000055c9347abc20>>)> File.join(Rails.root, path)
=> "/vagrant/waste-exemptions-back-office-ta/app/assets/images/logo_ea.png"
[5] pry(#<#<Class:0x000055c9347abc20>>)> File.exist?(File.join(Rails.root, path))
=> true
[6] pry(#<#<Class:0x000055c9347abc20>>)> File.exist?(Rails.root.join(path))
=> false
```

In the context of the engine the current issue wouldn't have come to light as everything is in the engine, so even if the code worked as expected it would always return false. But so the knowledge isn't lost we're still applying the fix.