### PR TITLE
Install defra-ruby-validators

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)
       countries
+      defra_ruby_validators
       high_voltage (~> 3.0)
       jbuilder (~> 2.0)
       jquery-rails
@@ -83,6 +84,12 @@ GEM
     debug_inspector (0.0.3)
     defra_ruby_style (0.1.2)
       rubocop
+    defra_ruby_validators (2.0.0)
+      activemodel
+      os_map_ref
+      phonelib
+      rest-client (~> 2.0)
+      validates_email_format_of
     devise (4.6.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -91,7 +98,7 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.3)
     docile (1.3.2)
-    domain_name (0.5.20180417)
+    domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.5)
     dotenv-rails (2.7.5)
@@ -150,7 +157,7 @@ GEM
     method_source (0.9.2)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2018.0812)
+    mime-types-data (3.2019.0331)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
@@ -170,6 +177,7 @@ GEM
       sawyer (~> 0.8.0, >= 0.5.3)
     origin (2.3.1)
     orm_adapter (0.5.0)
+    os_map_ref (0.5.0)
     parallel (1.17.0)
     parser (2.6.3.0)
       ast (~> 2.4.0)
@@ -287,7 +295,7 @@ GEM
     uk_postcode (2.1.4)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.5)
+    unf_ext (0.0.7.6)
     unicode-display_width (1.6.0)
     unicode_utils (1.4.0)
     useragent (0.16.10)

--- a/lib/waste_carriers_engine/engine.rb
+++ b/lib/waste_carriers_engine/engine.rb
@@ -3,6 +3,7 @@
 require "aasm"
 require "mongoid"
 require "high_voltage"
+require "defra_ruby_validators"
 
 module WasteCarriersEngine
   class Engine < ::Rails::Engine

--- a/waste_carriers_engine.gemspec
+++ b/waste_carriers_engine.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |s|
   s.add_dependency "high_voltage", "~> 3.0"
 
   # Validations
+  s.add_dependency "defra_ruby_validators"
   s.add_dependency "phonelib"
   s.add_dependency "uk_postcode"
   s.add_dependency "validates_email_format_of"


### PR DESCRIPTION
We want to share validators between WCR and WEX whenever possible. This PR installs the defra-ruby-validators gem so we can start reusing validators.