### PR TITLE
Forms refactoring: Submit with assign and validation

### DIFF
--- a/app/forms/waste_carriers_engine/bank_transfer_form.rb
+++ b/app/forms/waste_carriers_engine/bank_transfer_form.rb
@@ -10,6 +10,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
+
       self.total_to_pay = @transient_registration.total_to_pay
     end
 

--- a/app/forms/waste_carriers_engine/base_form.rb
+++ b/app/forms/waste_carriers_engine/base_form.rb
@@ -30,7 +30,7 @@ module WasteCarriersEngine
     end
 
     # TODO: Remove `reg_identifier` param
-    def submit(attributes, _reg_identifier=nil)
+    def submit(attributes, _reg_identifier = nil)
       attributes = strip_whitespace(attributes)
 
       transient_registration.assign_attributes(attributes)

--- a/app/forms/waste_carriers_engine/base_form.rb
+++ b/app/forms/waste_carriers_engine/base_form.rb
@@ -4,7 +4,13 @@ module WasteCarriersEngine
   class BaseForm
     include ActiveModel::Model
     include CanStripWhitespace
-    attr_accessor :reg_identifier, :transient_registration
+
+    attr_reader :transient_registration
+
+    delegate :reg_identifier, to: :transient_registration
+
+    validates :reg_identifier, "waste_carriers_engine/reg_identifier": true
+    validate :transient_registration_valid?
 
     # The standard behaviour for loading a form is to check whether the requested form matches the workflow_state for
     # the registration, and redirect to the saved workflow_state if it doesn't.
@@ -21,34 +27,25 @@ module WasteCarriersEngine
     def initialize(transient_registration)
       # Get values from transient registration so form will be pre-filled
       @transient_registration = transient_registration
-      self.reg_identifier = @transient_registration.reg_identifier
     end
 
-    def submit(attributes, reg_identifier)
-      # Additional attributes are set in individual form subclasses
-      self.reg_identifier = reg_identifier
-
+    # TODO: Remove `reg_identifier` param
+    def submit(attributes, _reg_identifier=nil)
       attributes = strip_whitespace(attributes)
 
-      # Update the transient registration with params from the registration if valid
-      if valid?
-        @transient_registration.update_attributes(attributes)
-        @transient_registration.save!
-        true
-      else
-        false
-      end
-    end
+      transient_registration.assign_attributes(attributes)
 
-    validates :reg_identifier, "waste_carriers_engine/reg_identifier": true
-    validate :transient_registration_valid?
+      return transient_registration.save! if valid?
+
+      false
+    end
 
     private
 
     def transient_registration_valid?
-      return if @transient_registration.valid?
+      return if transient_registration.valid?
 
-      @transient_registration.errors.each do |_attribute, message|
+      transient_registration.errors.each do |_attribute, message|
         errors[:base] << message
       end
     end

--- a/app/forms/waste_carriers_engine/location_form.rb
+++ b/app/forms/waste_carriers_engine/location_form.rb
@@ -17,7 +17,7 @@ module WasteCarriersEngine
       # Set the business type to overseas when required as we use this for microcopy
       attributes[:business_type] = "overseas" if location == "overseas"
 
-      super(attributes, params[:reg_identifier])
+      super(attributes)
     end
 
     validates :location, "defra_ruby/validators/location": { allow_overseas: true }

--- a/spec/forms/waste_carriers_engine/bank_transfer_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/bank_transfer_forms_spec.rb
@@ -5,8 +5,9 @@ require "rails_helper"
 module WasteCarriersEngine
   RSpec.describe BankTransferForm, type: :model do
     describe "#submit" do
+      let(:bank_transfer_form) { build(:bank_transfer_form, :has_required_data) }
+
       context "when the form is valid" do
-        let(:bank_transfer_form) { build(:bank_transfer_form, :has_required_data) }
         let(:valid_params) { { reg_identifier: bank_transfer_form.reg_identifier } }
 
         it "should submit" do
@@ -15,11 +16,12 @@ module WasteCarriersEngine
       end
 
       context "when the form is not valid" do
-        let(:bank_transfer_form) { build(:bank_transfer_form, :has_required_data) }
-        let(:invalid_params) { { reg_identifier: "foo" } }
+        before do
+          expect(bank_transfer_form).to receive(:valid?).and_return(false)
+        end
 
         it "should not submit" do
-          expect(bank_transfer_form.submit(invalid_params)).to eq(false)
+          expect(bank_transfer_form.submit({})).to eq(false)
         end
       end
     end

--- a/spec/forms/waste_carriers_engine/base_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/base_forms_spec.rb
@@ -10,21 +10,21 @@ module WasteCarriersEngine
       it "should strip excess whitespace from attributes" do
         attributes = { company_name: " test " }
 
-        base_form.submit(attributes, base_form.reg_identifier)
+        base_form.submit(attributes)
         expect(base_form.transient_registration.company_name).to eq("test")
       end
 
       it "should strip excess whitespace from attributes within an array" do
         attributes = { key_people: [build(:key_person, :main, first_name: " test ")] }
 
-        base_form.submit(attributes, base_form.reg_identifier)
+        base_form.submit(attributes)
         expect(base_form.transient_registration.main_people.first.first_name).to eq("test")
       end
 
       it "should strip excess whitespace from attributes within a hash" do
         attributes = { metaData: { revoked_reason: " test " } }
 
-        base_form.submit(attributes, base_form.reg_identifier)
+        base_form.submit(attributes)
         expect(base_form.transient_registration.metaData.revoked_reason).to eq("test")
       end
     end
@@ -39,8 +39,8 @@ module WasteCarriersEngine
       end
 
       context "when a reg_identifier is blank" do
-        before(:each) do
-          base_form.reg_identifier = ""
+        before do
+          base_form.transient_registration.reg_identifier = nil
         end
 
         it "is not valid" do
@@ -49,8 +49,8 @@ module WasteCarriersEngine
       end
 
       context "when a reg_identifier is in the wrong format" do
-        before(:each) do
-          base_form.reg_identifier = "foo"
+        before do
+          base_form.transient_registration.reg_identifier = "foo"
         end
 
         it "is not valid" do
@@ -68,9 +68,8 @@ module WasteCarriersEngine
         # Don't use FactoryBot for this as we need to make sure it initializes with a specific object
         let(:form) { BusinessTypeForm.new(transient_registration) }
 
-        before(:each) do
+        before do
           # Make reg_identifier valid for the form, but not the transient object
-          form.reg_identifier = transient_registration.reg_identifier
           transient_registration.reg_identifier = "foo"
         end
 

--- a/spec/forms/waste_carriers_engine/cards_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/cards_forms_spec.rb
@@ -21,7 +21,11 @@ module WasteCarriersEngine
 
       context "when the form is not valid" do
         let(:cards_form) { build(:cards_form, :has_required_data) }
-        let(:invalid_params) { { reg_identifier: "foo" } }
+        let(:invalid_params) do
+          {
+            temp_cards: described_class::MAX_TEMP_CARDS + 1
+          }
+        end
 
         it "should not submit" do
           expect(cards_form.submit(invalid_params)).to eq(false)

--- a/spec/forms/waste_carriers_engine/check_your_answers_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/check_your_answers_forms_spec.rb
@@ -9,21 +9,22 @@ module WasteCarriersEngine
     end
 
     describe "#submit" do
+      let(:check_your_answers_form) { build(:check_your_answers_form, :has_required_data) }
       context "when the form is valid" do
-        let(:check_your_answers_form) { build(:check_your_answers_form, :has_required_data) }
         let(:valid_params) { { reg_identifier: check_your_answers_form.reg_identifier } }
 
         it "should submit" do
-          expect(check_your_answers_form.submit(valid_params)).to eq(true)
+          expect(check_your_answers_form.submit(valid_params)).to be_truthy
         end
       end
 
       context "when the form is not valid" do
-        let(:check_your_answers_form) { build(:check_your_answers_form, :has_required_data) }
-        let(:invalid_params) { { reg_identifier: "foo" } }
+        before do
+          expect(check_your_answers_form).to receive(:valid?).and_return(false)
+        end
 
         it "should not submit" do
-          expect(check_your_answers_form.submit(invalid_params)).to eq(false)
+          expect(check_your_answers_form.submit({})).to be_falsey
         end
       end
     end

--- a/spec/forms/waste_carriers_engine/payment_summary_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/payment_summary_forms_spec.rb
@@ -29,30 +29,28 @@ module WasteCarriersEngine
       end
     end
 
-    context "when a valid transient registration exists" do
-      let(:payment_summary_form) { build(:payment_summary_form, :has_required_data) }
+    describe "#valid?" do
+      context "when a valid transient registration exists" do
+        let(:payment_summary_form) { build(:payment_summary_form, :has_required_data, temp_payment_method: temp_payment_method) }
 
-      describe "#temp_payment_method" do
-        context "when a temp_payment_method meets the requirements" do
+        context "when a temp_payment_method is bank_transfer" do
+          let(:temp_payment_method) { "bank_transfer" }
+
           it "is valid" do
             expect(payment_summary_form).to be_valid
           end
         end
 
-        context "when a temp_payment_method is blank" do
-          before(:each) do
-            payment_summary_form.reg_identifier = ""
-          end
+        context "when a temp_payment_method is card" do
+          let(:temp_payment_method) { "card" }
 
-          it "is not valid" do
-            expect(payment_summary_form).to_not be_valid
+          it "is valid" do
+            expect(payment_summary_form).to be_valid
           end
         end
 
-        context "when a temp_payment_method not an allowed string" do
-          before(:each) do
-            payment_summary_form.reg_identifier = "foo"
-          end
+        context "when a temp_payment_method is anything else" do
+          let(:temp_payment_method) { "I am a payment method, don't you know?" }
 
           it "is not valid" do
             expect(payment_summary_form).to_not be_valid

--- a/spec/forms/waste_carriers_engine/register_in_northern_ireland_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/register_in_northern_ireland_forms_spec.rb
@@ -5,8 +5,9 @@ require "rails_helper"
 module WasteCarriersEngine
   RSpec.describe RegisterInNorthernIrelandForm, type: :model do
     describe "#submit" do
+      let(:register_in_northern_ireland_form) { build(:register_in_northern_ireland_form, :has_required_data) }
+
       context "when the form is valid" do
-        let(:register_in_northern_ireland_form) { build(:register_in_northern_ireland_form, :has_required_data) }
         let(:valid_params) do
           {
             reg_identifier: register_in_northern_ireland_form.reg_identifier
@@ -19,11 +20,12 @@ module WasteCarriersEngine
       end
 
       context "when the form is not valid" do
-        let(:register_in_northern_ireland_form) { build(:register_in_northern_ireland_form, :has_required_data) }
-        let(:invalid_params) { { reg_identifier: "foo" } }
+        before do
+          expect(register_in_northern_ireland_form).to receive(:valid?).and_return(false)
+        end
 
         it "should not submit" do
-          expect(register_in_northern_ireland_form.submit(invalid_params)).to eq(false)
+          expect(register_in_northern_ireland_form.submit({})).to eq(false)
         end
       end
     end

--- a/spec/forms/waste_carriers_engine/register_in_scotland_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/register_in_scotland_forms_spec.rb
@@ -5,8 +5,9 @@ require "rails_helper"
 module WasteCarriersEngine
   RSpec.describe RegisterInScotlandForm, type: :model do
     describe "#submit" do
+      let(:register_in_scotland_form) { build(:register_in_scotland_form, :has_required_data) }
+
       context "when the form is valid" do
-        let(:register_in_scotland_form) { build(:register_in_scotland_form, :has_required_data) }
         let(:valid_params) do
           {
             reg_identifier: register_in_scotland_form.reg_identifier
@@ -19,11 +20,12 @@ module WasteCarriersEngine
       end
 
       context "when the form is not valid" do
-        let(:register_in_scotland_form) { build(:register_in_scotland_form, :has_required_data) }
-        let(:invalid_params) { { reg_identifier: "foo" } }
+        before do
+          expect(register_in_scotland_form).to receive(:valid?).and_return(false)
+        end
 
         it "should not submit" do
-          expect(register_in_scotland_form.submit(invalid_params)).to eq(false)
+          expect(register_in_scotland_form.submit({})).to eq(false)
         end
       end
     end

--- a/spec/forms/waste_carriers_engine/register_in_wales_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/register_in_wales_forms_spec.rb
@@ -5,8 +5,9 @@ require "rails_helper"
 module WasteCarriersEngine
   RSpec.describe RegisterInWalesForm, type: :model do
     describe "#submit" do
+      let(:register_in_wales_form) { build(:register_in_wales_form, :has_required_data) }
+
       context "when the form is valid" do
-        let(:register_in_wales_form) { build(:register_in_wales_form, :has_required_data) }
         let(:valid_params) do
           {
             reg_identifier: register_in_wales_form.reg_identifier
@@ -19,13 +20,15 @@ module WasteCarriersEngine
       end
 
       context "when the form is not valid" do
-        let(:register_in_wales_form) { build(:register_in_wales_form, :has_required_data) }
-        let(:invalid_params) { { reg_identifier: "foo" } }
+        before do
+          expect(register_in_wales_form).to receive(:valid?).and_return(false)
+        end
 
         it "should not submit" do
-          expect(register_in_wales_form.submit(invalid_params)).to eq(false)
+          expect(register_in_wales_form.submit({})).to eq(false)
         end
       end
+
     end
   end
 end

--- a/spec/forms/waste_carriers_engine/renewal_information_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/renewal_information_forms_spec.rb
@@ -21,7 +21,7 @@ module WasteCarriersEngine
         end
 
         it "should not submit" do
-          expect(renewal_information_form.submit(valid_params)).to eq(true)
+          expect(renewal_information_form.submit({})).to eq(false)
         end
       end
     end

--- a/spec/forms/waste_carriers_engine/renewal_information_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/renewal_information_forms_spec.rb
@@ -5,8 +5,9 @@ require "rails_helper"
 module WasteCarriersEngine
   RSpec.describe RenewalInformationForm, type: :model do
     describe "#submit" do
+      let(:renewal_information_form) { build(:renewal_information_form, :has_required_data) }
+
       context "when the form is valid" do
-        let(:renewal_information_form) { build(:renewal_information_form, :has_required_data) }
         let(:valid_params) { { reg_identifier: renewal_information_form.reg_identifier } }
 
         it "should submit" do
@@ -15,11 +16,12 @@ module WasteCarriersEngine
       end
 
       context "when the form is not valid" do
-        let(:renewal_information_form) { build(:renewal_information_form, :has_required_data) }
-        let(:invalid_params) { { reg_identifier: "foo" } }
+        before do
+          expect(renewal_information_form).to receive(:valid?).and_return(false)
+        end
 
         it "should not submit" do
-          expect(renewal_information_form.submit(invalid_params)).to eq(false)
+          expect(renewal_information_form.submit(valid_params)).to eq(true)
         end
       end
     end

--- a/spec/forms/waste_carriers_engine/renewal_start_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/renewal_start_forms_spec.rb
@@ -5,22 +5,11 @@ require "rails_helper"
 module WasteCarriersEngine
   RSpec.describe RenewalStartForm, type: :model do
     describe "#submit" do
-      context "when the form is valid" do
-        let(:renewal_start_form) { build(:renewal_start_form, :has_required_data) }
-        let(:valid_params) { { reg_identifier: renewal_start_form.reg_identifier } }
+      let(:renewal_start_form) { build(:renewal_start_form, :has_required_data) }
+      let(:valid_params) { { reg_identifier: renewal_start_form.reg_identifier } }
 
-        it "should submit" do
-          expect(renewal_start_form.submit(valid_params)).to eq(true)
-        end
-      end
-
-      context "when the form is not valid" do
-        let(:renewal_start_form) { build(:renewal_start_form, :has_required_data) }
-        let(:invalid_params) { { reg_identifier: "foo" } }
-
-        it "should not submit" do
-          expect(renewal_start_form.submit(invalid_params)).to eq(false)
-        end
+      it "should submit" do
+        expect(renewal_start_form.submit(valid_params)).to eq(true)
       end
     end
   end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-693 

As a start for the form refactoring, to get the code in-line with what we have in WEX, the goal of this PR is to get the `submit` method in the `BaseForm` to use a mass-assignment strategy on the transient registration so that we can be able to both `delegate` or `assign` attributes.
The second parameter passed to the `submit` value has been killed, a refactoring will follow remiving the parameter to be passed by the children classes later. I see no point on that parameter to exists, and when / if we find that we need to assign a reg_identifier we can take advantage of mass-assignment like we will do with the rest of the parameters.
Changes on the tests are missing consistency. There are different implementations of the form specs, some uses a unit tests strategy, some other uses an integration tests strategy. I have stubbed test where the validation failure was failing due to the form having no validations on his own. There is a case where the validation were tested in isolation in a more unit-style. After discussing it with Alan we agreed to fix stuff as we can while we work on the forms refactoring, then group together and decide how we want our test suite to be structure and subsequentially come back to this specs and bring some consistency to them. This work is already captured as its own story for next sprint.