### PR TITLE
Forms refactoring - Tidy up

### DIFF
--- a/app/forms/waste_carriers_engine/address_form.rb
+++ b/app/forms/waste_carriers_engine/address_form.rb
@@ -6,6 +6,8 @@ module WasteCarriersEngine
     attr_accessor :temp_address
     attr_accessor :addresses
 
+    validates :addresses, presence: true
+
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating
       self.addresses = add_or_replace_address(params[:temp_address])
@@ -13,8 +15,6 @@ module WasteCarriersEngine
 
       super(attributes, params[:reg_identifier])
     end
-
-    validates :addresses, presence: true
 
     private
 
@@ -51,7 +51,7 @@ module WasteCarriersEngine
       address.assign_attributes(address_type: address_type)
 
       # Update the transient object's nested addresses, replacing any existing address of the same type
-      updated_addresses = @transient_registration.addresses
+      updated_addresses = transient_registration.addresses
       updated_addresses.delete(saved_address) if saved_address
       updated_addresses << address
       updated_addresses

--- a/app/forms/waste_carriers_engine/bank_transfer_form.rb
+++ b/app/forms/waste_carriers_engine/bank_transfer_form.rb
@@ -10,7 +10,8 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
-      self.total_to_pay = @transient_registration.total_to_pay
+
+      self.total_to_pay = transient_registration.total_to_pay
     end
 
     def submit(params)

--- a/app/forms/waste_carriers_engine/base_form.rb
+++ b/app/forms/waste_carriers_engine/base_form.rb
@@ -18,6 +18,9 @@ module WasteCarriersEngine
       true
     end
 
+    validates :reg_identifier, "waste_carriers_engine/reg_identifier": true
+    validate :transient_registration_valid?
+
     def initialize(transient_registration)
       # Get values from transient registration so form will be pre-filled
       @transient_registration = transient_registration
@@ -39,9 +42,6 @@ module WasteCarriersEngine
         false
       end
     end
-
-    validates :reg_identifier, "waste_carriers_engine/reg_identifier": true
-    validate :transient_registration_valid?
 
     private
 

--- a/app/forms/waste_carriers_engine/business_type_form.rb
+++ b/app/forms/waste_carriers_engine/business_type_form.rb
@@ -8,6 +8,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
+
       self.business_type = transient_registration.business_type
     end
 

--- a/app/forms/waste_carriers_engine/business_type_form.rb
+++ b/app/forms/waste_carriers_engine/business_type_form.rb
@@ -4,9 +4,11 @@ module WasteCarriersEngine
   class BusinessTypeForm < BaseForm
     attr_accessor :business_type
 
+    validates :business_type, "defra_ruby/validators/business_type": { allow_overseas: true }
+
     def initialize(transient_registration)
       super
-      self.business_type = @transient_registration.business_type
+      self.business_type = transient_registration.business_type
     end
 
     def submit(params)
@@ -16,7 +18,5 @@ module WasteCarriersEngine
 
       super(attributes, params[:reg_identifier])
     end
-
-    validates :business_type, "defra_ruby/validators/business_type": { allow_overseas: true }
   end
 end

--- a/app/forms/waste_carriers_engine/cannot_renew_company_no_change_form.rb
+++ b/app/forms/waste_carriers_engine/cannot_renew_company_no_change_form.rb
@@ -2,10 +2,6 @@
 
 module WasteCarriersEngine
   class CannotRenewCompanyNoChangeForm < BaseForm
-    def initialize(transient_registration)
-      super
-    end
-
     # Override BaseForm method as users shouldn't be able to submit this form
     def submit; end
   end

--- a/app/forms/waste_carriers_engine/cannot_renew_lower_tier_form.rb
+++ b/app/forms/waste_carriers_engine/cannot_renew_lower_tier_form.rb
@@ -2,10 +2,6 @@
 
 module WasteCarriersEngine
   class CannotRenewLowerTierForm < BaseForm
-    def initialize(transient_registration)
-      super
-    end
-
     # Override BaseForm method as users shouldn't be able to submit this form
     def submit; end
   end

--- a/app/forms/waste_carriers_engine/cannot_renew_type_change_form.rb
+++ b/app/forms/waste_carriers_engine/cannot_renew_type_change_form.rb
@@ -2,10 +2,6 @@
 
 module WasteCarriersEngine
   class CannotRenewTypeChangeForm < BaseForm
-    def initialize(transient_registration)
-      super
-    end
-
     # Override BaseForm method as users shouldn't be able to submit this form
     def submit; end
   end

--- a/app/forms/waste_carriers_engine/cards_form.rb
+++ b/app/forms/waste_carriers_engine/cards_form.rb
@@ -20,6 +20,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
+      
       self.temp_cards = transient_registration.temp_cards || 0
     end
 

--- a/app/forms/waste_carriers_engine/cards_form.rb
+++ b/app/forms/waste_carriers_engine/cards_form.rb
@@ -9,9 +9,18 @@ module WasteCarriersEngine
       false
     end
 
+    validates(
+      :temp_cards,
+      numericality: {
+        only_integer: true,
+        greater_than_or_equal_to: 0,
+        less_than_or_equal_to: MAX_TEMP_CARDS
+      }
+    )
+
     def initialize(transient_registration)
       super
-      self.temp_cards = @transient_registration.temp_cards || 0
+      self.temp_cards = transient_registration.temp_cards || 0
     end
 
     def submit(params)
@@ -26,14 +35,5 @@ module WasteCarriersEngine
 
       super(attributes, params[:reg_identifier])
     end
-
-    validates(
-      :temp_cards,
-      numericality: {
-        only_integer: true,
-        greater_than_or_equal_to: 0,
-        less_than_or_equal_to: MAX_TEMP_CARDS
-      }
-    )
   end
 end

--- a/app/forms/waste_carriers_engine/cards_form.rb
+++ b/app/forms/waste_carriers_engine/cards_form.rb
@@ -20,7 +20,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
-      
+
       self.temp_cards = transient_registration.temp_cards || 0
     end
 

--- a/app/forms/waste_carriers_engine/cbd_type_form.rb
+++ b/app/forms/waste_carriers_engine/cbd_type_form.rb
@@ -4,9 +4,12 @@ module WasteCarriersEngine
   class CbdTypeForm < BaseForm
     attr_accessor :registration_type
 
+    validates :registration_type, "waste_carriers_engine/registration_type": true
+
     def initialize(transient_registration)
       super
-      self.registration_type = @transient_registration.registration_type
+
+      self.registration_type = transient_registration.registration_type
     end
 
     def submit(params)
@@ -16,7 +19,5 @@ module WasteCarriersEngine
 
       super(attributes, params[:reg_identifier])
     end
-
-    validates :registration_type, "waste_carriers_engine/registration_type": true
   end
 end

--- a/app/forms/waste_carriers_engine/check_your_answers_form.rb
+++ b/app/forms/waste_carriers_engine/check_your_answers_form.rb
@@ -22,41 +22,6 @@ module WasteCarriersEngine
       messages
     end
 
-    def initialize(transient_registration)
-      super
-      self.business_type = @transient_registration.business_type
-      self.company_name = @transient_registration.company_name
-      self.company_no = @transient_registration.company_no
-      self.contact_address = @transient_registration.contact_address
-      self.contact_email = @transient_registration.contact_email
-      self.declared_convictions = @transient_registration.declared_convictions
-      self.first_name = @transient_registration.first_name
-      self.last_name = @transient_registration.last_name
-      self.location = @transient_registration.location
-      self.main_people = @transient_registration.main_people
-      self.phone_number = @transient_registration.phone_number
-      self.registered_address = @transient_registration.registered_address
-      self.registration_type = @transient_registration.registration_type
-      self.relevant_people = @transient_registration.relevant_people
-      self.tier = @transient_registration.tier
-
-      valid?
-    end
-
-    def submit(params)
-      attributes = {}
-
-      super(attributes, params[:reg_identifier])
-    end
-
-    def registration_type_changed?
-      @transient_registration.registration_type_changed?
-    end
-
-    def contact_name
-      "#{first_name} #{last_name}"
-    end
-
     validates :business_type, "defra_ruby/validators/business_type": {
       allow_overseas: true,
       messages: custom_error_messages(:business_type, :inclusion)
@@ -80,6 +45,41 @@ module WasteCarriersEngine
 
     validates_with KeyPeopleValidator
 
+    def initialize(transient_registration)
+      super
+      self.business_type = transient_registration.business_type
+      self.company_name = transient_registration.company_name
+      self.company_no = transient_registration.company_no
+      self.contact_address = transient_registration.contact_address
+      self.contact_email = transient_registration.contact_email
+      self.declared_convictions = transient_registration.declared_convictions
+      self.first_name = transient_registration.first_name
+      self.last_name = transient_registration.last_name
+      self.location = transient_registration.location
+      self.main_people = transient_registration.main_people
+      self.phone_number = transient_registration.phone_number
+      self.registered_address = transient_registration.registered_address
+      self.registration_type = transient_registration.registration_type
+      self.relevant_people = transient_registration.relevant_people
+      self.tier = transient_registration.tier
+
+      valid?
+    end
+
+    def submit(params)
+      attributes = {}
+
+      super(attributes, params[:reg_identifier])
+    end
+
+    def registration_type_changed?
+      transient_registration.registration_type_changed?
+    end
+
+    def contact_name
+      "#{first_name} #{last_name}"
+    end
+
     private
 
     def should_be_renewed
@@ -87,21 +87,21 @@ module WasteCarriersEngine
     end
 
     def business_type_change_valid?
-      return true if @transient_registration.business_type_change_valid?
+      return true if transient_registration.business_type_change_valid?
 
       errors.add(:business_type, :invalid_change)
       false
     end
 
     def same_company_no?
-      return true unless @transient_registration.company_no_changed?
+      return true unless transient_registration.company_no_changed?
 
       errors.add(:company_no, :changed)
       false
     end
 
     def company_no_required?
-      @transient_registration.company_no_required?
+      transient_registration.company_no_required?
     end
   end
 end

--- a/app/forms/waste_carriers_engine/company_address_form.rb
+++ b/app/forms/waste_carriers_engine/company_address_form.rb
@@ -8,8 +8,8 @@ module WasteCarriersEngine
     def initialize(transient_registration)
       super
       # We only use this for the correct microcopy
-      self.business_type = @transient_registration.business_type
-      self.temp_company_postcode = @transient_registration.temp_company_postcode
+      self.business_type = transient_registration.business_type
+      self.temp_company_postcode = transient_registration.temp_company_postcode
 
       look_up_addresses
       preselect_existing_address
@@ -22,7 +22,7 @@ module WasteCarriersEngine
     end
 
     def saved_address
-      @transient_registration.registered_address
+      transient_registration.registered_address
     end
 
     def address_type

--- a/app/forms/waste_carriers_engine/company_address_manual_form.rb
+++ b/app/forms/waste_carriers_engine/company_address_manual_form.rb
@@ -6,11 +6,11 @@ module WasteCarriersEngine
     private
 
     def saved_temp_postcode
-      @transient_registration.temp_company_postcode
+      transient_registration.temp_company_postcode
     end
 
     def existing_address
-      @transient_registration.registered_address
+      transient_registration.registered_address
     end
 
     def address_type

--- a/app/forms/waste_carriers_engine/company_name_form.rb
+++ b/app/forms/waste_carriers_engine/company_name_form.rb
@@ -4,11 +4,13 @@ module WasteCarriersEngine
   class CompanyNameForm < BaseForm
     attr_accessor :business_type, :company_name
 
+    validates :company_name, "waste_carriers_engine/company_name": true
+
     def initialize(transient_registration)
       super
       # We only use this for the correct microcopy
-      self.business_type = @transient_registration.business_type
-      self.company_name = @transient_registration.company_name
+      self.business_type = transient_registration.business_type
+      self.company_name = transient_registration.company_name
     end
 
     def submit(params)
@@ -18,7 +20,5 @@ module WasteCarriersEngine
 
       super(attributes, params[:reg_identifier])
     end
-
-    validates :company_name, "waste_carriers_engine/company_name": true
   end
 end

--- a/app/forms/waste_carriers_engine/company_postcode_form.rb
+++ b/app/forms/waste_carriers_engine/company_postcode_form.rb
@@ -4,11 +4,13 @@ module WasteCarriersEngine
   class CompanyPostcodeForm < PostcodeForm
     attr_accessor :business_type, :temp_company_postcode
 
+    validates :temp_company_postcode, "waste_carriers_engine/postcode": true
+
     def initialize(transient_registration)
       super
-      self.temp_company_postcode = @transient_registration.temp_company_postcode
+      self.temp_company_postcode = transient_registration.temp_company_postcode
       # We only use this for the correct microcopy
-      self.business_type = @transient_registration.business_type
+      self.business_type = transient_registration.business_type
     end
 
     def submit(params)
@@ -17,11 +19,9 @@ module WasteCarriersEngine
       attributes = { temp_company_postcode: temp_company_postcode }
 
       # While we won't proceed if the postcode isn't valid, we always save it in case it's needed for manual entry
-      @transient_registration.update_attributes(attributes)
+      transient_registration.update_attributes(attributes)
 
       super(attributes, params[:reg_identifier])
     end
-
-    validates :temp_company_postcode, "waste_carriers_engine/postcode": true
   end
 end

--- a/app/forms/waste_carriers_engine/company_postcode_form.rb
+++ b/app/forms/waste_carriers_engine/company_postcode_form.rb
@@ -8,7 +8,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
-      
+
       self.temp_company_postcode = transient_registration.temp_company_postcode
       # We only use this for the correct microcopy
       self.business_type = transient_registration.business_type

--- a/app/forms/waste_carriers_engine/company_postcode_form.rb
+++ b/app/forms/waste_carriers_engine/company_postcode_form.rb
@@ -8,6 +8,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
+      
       self.temp_company_postcode = transient_registration.temp_company_postcode
       # We only use this for the correct microcopy
       self.business_type = transient_registration.business_type

--- a/app/forms/waste_carriers_engine/construction_demolition_form.rb
+++ b/app/forms/waste_carriers_engine/construction_demolition_form.rb
@@ -8,7 +8,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
-      
+
       self.construction_waste = transient_registration.construction_waste
     end
 

--- a/app/forms/waste_carriers_engine/construction_demolition_form.rb
+++ b/app/forms/waste_carriers_engine/construction_demolition_form.rb
@@ -8,6 +8,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
+      
       self.construction_waste = transient_registration.construction_waste
     end
 

--- a/app/forms/waste_carriers_engine/construction_demolition_form.rb
+++ b/app/forms/waste_carriers_engine/construction_demolition_form.rb
@@ -4,9 +4,11 @@ module WasteCarriersEngine
   class ConstructionDemolitionForm < BaseForm
     attr_accessor :construction_waste
 
+    validates :construction_waste, "waste_carriers_engine/yes_no": true
+
     def initialize(transient_registration)
       super
-      self.construction_waste = @transient_registration.construction_waste
+      self.construction_waste = transient_registration.construction_waste
     end
 
     def submit(params)
@@ -16,7 +18,5 @@ module WasteCarriersEngine
 
       super(attributes, params[:reg_identifier])
     end
-
-    validates :construction_waste, "waste_carriers_engine/yes_no": true
   end
 end

--- a/app/forms/waste_carriers_engine/contact_address_form.rb
+++ b/app/forms/waste_carriers_engine/contact_address_form.rb
@@ -6,7 +6,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
-      self.temp_contact_postcode = @transient_registration.temp_contact_postcode
+      self.temp_contact_postcode = transient_registration.temp_contact_postcode
 
       look_up_addresses
       preselect_existing_address
@@ -19,7 +19,7 @@ module WasteCarriersEngine
     end
 
     def saved_address
-      @transient_registration.contact_address
+      transient_registration.contact_address
     end
 
     def address_type

--- a/app/forms/waste_carriers_engine/contact_address_manual_form.rb
+++ b/app/forms/waste_carriers_engine/contact_address_manual_form.rb
@@ -6,11 +6,11 @@ module WasteCarriersEngine
     private
 
     def saved_temp_postcode
-      @transient_registration.temp_contact_postcode
+      transient_registration.temp_contact_postcode
     end
 
     def existing_address
-      @transient_registration.contact_address
+      transient_registration.contact_address
     end
 
     def address_type

--- a/app/forms/waste_carriers_engine/contact_email_form.rb
+++ b/app/forms/waste_carriers_engine/contact_email_form.rb
@@ -9,7 +9,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
-      
+
       self.contact_email = transient_registration.contact_email
       self.confirmed_email = transient_registration.contact_email
     end

--- a/app/forms/waste_carriers_engine/contact_email_form.rb
+++ b/app/forms/waste_carriers_engine/contact_email_form.rb
@@ -9,6 +9,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
+      
       self.contact_email = transient_registration.contact_email
       self.confirmed_email = transient_registration.contact_email
     end

--- a/app/forms/waste_carriers_engine/contact_email_form.rb
+++ b/app/forms/waste_carriers_engine/contact_email_form.rb
@@ -4,10 +4,13 @@ module WasteCarriersEngine
   class ContactEmailForm < BaseForm
     attr_accessor :contact_email, :confirmed_email
 
+    validates :contact_email, :confirmed_email, "defra_ruby/validators/email": true
+    validates :confirmed_email, "waste_carriers_engine/matching_email": { compare_to: :contact_email }
+
     def initialize(transient_registration)
       super
-      self.contact_email = @transient_registration.contact_email
-      self.confirmed_email = @transient_registration.contact_email
+      self.contact_email = transient_registration.contact_email
+      self.confirmed_email = transient_registration.contact_email
     end
 
     def submit(params)
@@ -19,8 +22,5 @@ module WasteCarriersEngine
 
       super(attributes, params[:reg_identifier])
     end
-
-    validates :contact_email, :confirmed_email, "defra_ruby/validators/email": true
-    validates :confirmed_email, "waste_carriers_engine/matching_email": { compare_to: :contact_email }
   end
 end

--- a/app/forms/waste_carriers_engine/contact_name_form.rb
+++ b/app/forms/waste_carriers_engine/contact_name_form.rb
@@ -4,10 +4,12 @@ module WasteCarriersEngine
   class ContactNameForm < BaseForm
     attr_accessor :first_name, :last_name
 
+    validates :first_name, :last_name, "waste_carriers_engine/person_name": true
+
     def initialize(transient_registration)
       super
-      self.first_name = @transient_registration.first_name
-      self.last_name = @transient_registration.last_name
+      self.first_name = transient_registration.first_name
+      self.last_name = transient_registration.last_name
     end
 
     def submit(params)
@@ -21,7 +23,5 @@ module WasteCarriersEngine
 
       super(attributes, params[:reg_identifier])
     end
-
-    validates :first_name, :last_name, "waste_carriers_engine/person_name": true
   end
 end

--- a/app/forms/waste_carriers_engine/contact_name_form.rb
+++ b/app/forms/waste_carriers_engine/contact_name_form.rb
@@ -8,6 +8,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
+      
       self.first_name = transient_registration.first_name
       self.last_name = transient_registration.last_name
     end

--- a/app/forms/waste_carriers_engine/contact_name_form.rb
+++ b/app/forms/waste_carriers_engine/contact_name_form.rb
@@ -8,7 +8,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
-      
+
       self.first_name = transient_registration.first_name
       self.last_name = transient_registration.last_name
     end

--- a/app/forms/waste_carriers_engine/contact_phone_form.rb
+++ b/app/forms/waste_carriers_engine/contact_phone_form.rb
@@ -8,7 +8,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
-      
+
       self.phone_number = transient_registration.phone_number
     end
 

--- a/app/forms/waste_carriers_engine/contact_phone_form.rb
+++ b/app/forms/waste_carriers_engine/contact_phone_form.rb
@@ -4,9 +4,11 @@ module WasteCarriersEngine
   class ContactPhoneForm < BaseForm
     attr_accessor :phone_number
 
+    validates :phone_number, "defra_ruby/validators/phone_number": true
+
     def initialize(transient_registration)
       super
-      self.phone_number = @transient_registration.phone_number
+      self.phone_number = transient_registration.phone_number
     end
 
     def submit(params)
@@ -16,7 +18,5 @@ module WasteCarriersEngine
 
       super(attributes, params[:reg_identifier])
     end
-
-    validates :phone_number, "defra_ruby/validators/phone_number": true
   end
 end

--- a/app/forms/waste_carriers_engine/contact_phone_form.rb
+++ b/app/forms/waste_carriers_engine/contact_phone_form.rb
@@ -8,6 +8,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
+      
       self.phone_number = transient_registration.phone_number
     end
 

--- a/app/forms/waste_carriers_engine/contact_postcode_form.rb
+++ b/app/forms/waste_carriers_engine/contact_postcode_form.rb
@@ -8,6 +8,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
+      
       self.temp_contact_postcode = transient_registration.temp_contact_postcode
     end
 

--- a/app/forms/waste_carriers_engine/contact_postcode_form.rb
+++ b/app/forms/waste_carriers_engine/contact_postcode_form.rb
@@ -8,7 +8,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
-      
+
       self.temp_contact_postcode = transient_registration.temp_contact_postcode
     end
 

--- a/app/forms/waste_carriers_engine/contact_postcode_form.rb
+++ b/app/forms/waste_carriers_engine/contact_postcode_form.rb
@@ -4,9 +4,11 @@ module WasteCarriersEngine
   class ContactPostcodeForm < PostcodeForm
     attr_accessor :temp_contact_postcode
 
+    validates :temp_contact_postcode, "waste_carriers_engine/postcode": true
+
     def initialize(transient_registration)
       super
-      self.temp_contact_postcode = @transient_registration.temp_contact_postcode
+      self.temp_contact_postcode = transient_registration.temp_contact_postcode
     end
 
     def submit(params)
@@ -15,11 +17,9 @@ module WasteCarriersEngine
       attributes = { temp_contact_postcode: temp_contact_postcode }
 
       # While we won't proceed if the postcode isn't valid, we always save it in case it's needed for manual entry
-      @transient_registration.update_attributes(attributes)
+      transient_registration.update_attributes(attributes)
 
       super(attributes, params[:reg_identifier])
     end
-
-    validates :temp_contact_postcode, "waste_carriers_engine/postcode": true
   end
 end

--- a/app/forms/waste_carriers_engine/conviction_details_form.rb
+++ b/app/forms/waste_carriers_engine/conviction_details_form.rb
@@ -4,6 +4,8 @@ module WasteCarriersEngine
   class ConvictionDetailsForm < PersonForm
     include CanLimitNumberOfRelevantPeople
 
+    validates_with RelevantPersonValidator
+
     def position?
       true
     end
@@ -12,8 +14,6 @@ module WasteCarriersEngine
       :relevant
     end
 
-    validates_with RelevantPersonValidator
-
     private
 
     # Adding the new person directly to @transient_registration.key_people immediately updates the object,
@@ -21,7 +21,7 @@ module WasteCarriersEngine
     def list_of_people_to_keep
       people = []
 
-      @transient_registration.key_people.each do |person|
+      transient_registration.key_people.each do |person|
         # We need to copy the person before adding to the array to avoid 'conflicting modifications' Mongo error (10151)
         people << person.clone
       end

--- a/app/forms/waste_carriers_engine/declaration_form.rb
+++ b/app/forms/waste_carriers_engine/declaration_form.rb
@@ -12,6 +12,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
+      
       self.declaration = transient_registration.declaration
     end
 

--- a/app/forms/waste_carriers_engine/declaration_form.rb
+++ b/app/forms/waste_carriers_engine/declaration_form.rb
@@ -8,9 +8,11 @@ module WasteCarriersEngine
       false
     end
 
+    validates :declaration, inclusion: { in: [1] }
+
     def initialize(transient_registration)
       super
-      self.declaration = @transient_registration.declaration
+      self.declaration = transient_registration.declaration
     end
 
     def submit(params)
@@ -20,7 +22,5 @@ module WasteCarriersEngine
 
       super(attributes, params[:reg_identifier])
     end
-
-    validates :declaration, inclusion: { in: [1] }
   end
 end

--- a/app/forms/waste_carriers_engine/declaration_form.rb
+++ b/app/forms/waste_carriers_engine/declaration_form.rb
@@ -12,7 +12,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
-      
+
       self.declaration = transient_registration.declaration
     end
 

--- a/app/forms/waste_carriers_engine/declare_convictions_form.rb
+++ b/app/forms/waste_carriers_engine/declare_convictions_form.rb
@@ -4,9 +4,11 @@ module WasteCarriersEngine
   class DeclareConvictionsForm < BaseForm
     attr_accessor :declared_convictions
 
+    validates :declared_convictions, "waste_carriers_engine/yes_no": true
+
     def initialize(transient_registration)
       super
-      self.declared_convictions = @transient_registration.declared_convictions
+      self.declared_convictions = transient_registration.declared_convictions
     end
 
     def submit(params)
@@ -16,7 +18,5 @@ module WasteCarriersEngine
 
       super(attributes, params[:reg_identifier])
     end
-
-    validates :declared_convictions, "waste_carriers_engine/yes_no": true
   end
 end

--- a/app/forms/waste_carriers_engine/declare_convictions_form.rb
+++ b/app/forms/waste_carriers_engine/declare_convictions_form.rb
@@ -8,7 +8,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
-      
+
       self.declared_convictions = transient_registration.declared_convictions
     end
 

--- a/app/forms/waste_carriers_engine/declare_convictions_form.rb
+++ b/app/forms/waste_carriers_engine/declare_convictions_form.rb
@@ -8,6 +8,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
+      
       self.declared_convictions = transient_registration.declared_convictions
     end
 

--- a/app/forms/waste_carriers_engine/location_form.rb
+++ b/app/forms/waste_carriers_engine/location_form.rb
@@ -4,9 +4,11 @@ module WasteCarriersEngine
   class LocationForm < BaseForm
     attr_accessor :location
 
+    validates :location, "defra_ruby/validators/location": { allow_overseas: true }
+
     def initialize(transient_registration)
       super
-      self.location = @transient_registration.location
+      self.location = transient_registration.location
     end
 
     def submit(params)
@@ -19,7 +21,5 @@ module WasteCarriersEngine
 
       super(attributes, params[:reg_identifier])
     end
-
-    validates :location, "defra_ruby/validators/location": { allow_overseas: true }
   end
 end

--- a/app/forms/waste_carriers_engine/location_form.rb
+++ b/app/forms/waste_carriers_engine/location_form.rb
@@ -8,6 +8,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
+      
       self.location = transient_registration.location
     end
 

--- a/app/forms/waste_carriers_engine/location_form.rb
+++ b/app/forms/waste_carriers_engine/location_form.rb
@@ -8,7 +8,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
-      
+
       self.location = transient_registration.location
     end
 

--- a/app/forms/waste_carriers_engine/main_people_form.rb
+++ b/app/forms/waste_carriers_engine/main_people_form.rb
@@ -6,29 +6,29 @@ module WasteCarriersEngine
 
     attr_accessor :business_type
 
+    validates_with MainPersonValidator
+
     def initialize(transient_registration)
       super
       # We only use this for the correct microcopy
-      self.business_type = @transient_registration.business_type
+      self.business_type = transient_registration.business_type
 
       # If there's only one main person, we can pre-fill the fields so users can easily edit them
-      prefill_form if can_only_have_one_main_person? && @transient_registration.main_people.present?
+      prefill_form if can_only_have_one_main_person? && transient_registration.main_people.present?
     end
 
     def person_type
       :key
     end
 
-    validates_with MainPersonValidator
-
     private
 
     def prefill_form
-      self.first_name = @transient_registration.main_people.first.first_name
-      self.last_name = @transient_registration.main_people.first.last_name
-      self.dob_day = @transient_registration.main_people.first.dob_day
-      self.dob_month = @transient_registration.main_people.first.dob_month
-      self.dob_year = @transient_registration.main_people.first.dob_year
+      self.first_name = transient_registration.main_people.first.first_name
+      self.last_name = transient_registration.main_people.first.last_name
+      self.dob_day = transient_registration.main_people.first.dob_day
+      self.dob_month = transient_registration.main_people.first.dob_month
+      self.dob_year = transient_registration.main_people.first.dob_year
     end
 
     # Adding the new main person directly to @transient_registration.key_people immediately updates the object,
@@ -39,9 +39,9 @@ module WasteCarriersEngine
       # If there's only one main person allowed, we want to discard any existing main people, but keep people with
       # relevant convictions. Otherwise, we copy all the key_people, regardless of type.
       existing_people = if can_only_have_one_main_person?
-                          @transient_registration.relevant_people
+                          transient_registration.relevant_people
                         else
-                          @transient_registration.key_people
+                          transient_registration.key_people
                         end
 
       existing_people.each do |person|

--- a/app/forms/waste_carriers_engine/main_people_form.rb
+++ b/app/forms/waste_carriers_engine/main_people_form.rb
@@ -10,6 +10,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
+
       # We only use this for the correct microcopy
       self.business_type = transient_registration.business_type
 

--- a/app/forms/waste_carriers_engine/manual_address_form.rb
+++ b/app/forms/waste_carriers_engine/manual_address_form.rb
@@ -8,15 +8,23 @@ module WasteCarriersEngine
     # We pass the following attributes in to create a new Address
     attr_accessor :house_number, :address_line_1, :address_line_2, :town_city, :postcode, :country
 
+    validates :house_number, presence: true, length: { maximum: 200 }
+    validates :address_line_1, presence: true, length: { maximum: 160 }
+    validates :address_line_2, length: { maximum: 70 }
+    validates :town_city, presence: true, length: { maximum: 30 }
+    validates :postcode, length: { maximum: 30 }
+    validates :country, presence: true, if: :overseas?
+    validates :country, length: { maximum: 50 }
+
     def initialize(transient_registration)
       super
       # We use this for the correct microcopy and to determine what fields to show
-      self.business_type = @transient_registration.business_type
+      self.business_type = transient_registration.business_type
 
       # Check if the user reached this page through an OS Places error
       # Then wipe the temp attribute as we only need it for routing
-      self.os_places_error = @transient_registration.temp_os_places_error
-      @transient_registration.update_attributes(temp_os_places_error: nil)
+      self.os_places_error = transient_registration.temp_os_places_error
+      transient_registration.update_attributes(temp_os_places_error: nil)
 
       # Prefill the existing address unless the temp_postcode has changed from the existing address's postcode
       # Otherwise, just fill in the temp_postcode
@@ -35,14 +43,6 @@ module WasteCarriersEngine
 
       super(attributes, params[:reg_identifier])
     end
-
-    validates :house_number, presence: true, length: { maximum: 200 }
-    validates :address_line_1, presence: true, length: { maximum: 160 }
-    validates :address_line_2, length: { maximum: 70 }
-    validates :town_city, presence: true, length: { maximum: 30 }
-    validates :postcode, length: { maximum: 30 }
-    validates :country, presence: true, if: :overseas?
-    validates :country, length: { maximum: 50 }
 
     def overseas?
       business_type == "overseas"
@@ -71,11 +71,11 @@ module WasteCarriersEngine
     end
 
     def add_or_replace_address(params)
-      address = Address.create_from_manual_entry(params, @transient_registration.overseas?)
+      address = Address.create_from_manual_entry(params, transient_registration.overseas?)
       address.assign_attributes(address_type: address_type)
 
       # Update the transient object's nested addresses, replacing any existing registered address
-      updated_addresses = @transient_registration.addresses
+      updated_addresses = transient_registration.addresses
       updated_addresses.delete(existing_address) if existing_address
       updated_addresses << address
       updated_addresses

--- a/app/forms/waste_carriers_engine/manual_address_form.rb
+++ b/app/forms/waste_carriers_engine/manual_address_form.rb
@@ -18,6 +18,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
+      
       # We use this for the correct microcopy and to determine what fields to show
       self.business_type = transient_registration.business_type
 

--- a/app/forms/waste_carriers_engine/manual_address_form.rb
+++ b/app/forms/waste_carriers_engine/manual_address_form.rb
@@ -18,7 +18,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
-      
+
       # We use this for the correct microcopy and to determine what fields to show
       self.business_type = transient_registration.business_type
 

--- a/app/forms/waste_carriers_engine/other_businesses_form.rb
+++ b/app/forms/waste_carriers_engine/other_businesses_form.rb
@@ -8,7 +8,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
-      
+
       self.other_businesses = transient_registration.other_businesses
     end
 

--- a/app/forms/waste_carriers_engine/other_businesses_form.rb
+++ b/app/forms/waste_carriers_engine/other_businesses_form.rb
@@ -8,6 +8,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
+      
       self.other_businesses = transient_registration.other_businesses
     end
 

--- a/app/forms/waste_carriers_engine/other_businesses_form.rb
+++ b/app/forms/waste_carriers_engine/other_businesses_form.rb
@@ -4,9 +4,11 @@ module WasteCarriersEngine
   class OtherBusinessesForm < BaseForm
     attr_accessor :other_businesses
 
+    validates :other_businesses, "waste_carriers_engine/yes_no": true
+
     def initialize(transient_registration)
       super
-      self.other_businesses = @transient_registration.other_businesses
+      self.other_businesses = transient_registration.other_businesses
     end
 
     def submit(params)
@@ -16,7 +18,5 @@ module WasteCarriersEngine
 
       super(attributes, params[:reg_identifier])
     end
-
-    validates :other_businesses, "waste_carriers_engine/yes_no": true
   end
 end

--- a/app/forms/waste_carriers_engine/payment_summary_form.rb
+++ b/app/forms/waste_carriers_engine/payment_summary_form.rb
@@ -12,7 +12,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
-      
+
       self.temp_payment_method = transient_registration.temp_payment_method
 
       self.type_change = transient_registration.registration_type_changed?

--- a/app/forms/waste_carriers_engine/payment_summary_form.rb
+++ b/app/forms/waste_carriers_engine/payment_summary_form.rb
@@ -12,6 +12,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
+      
       self.temp_payment_method = transient_registration.temp_payment_method
 
       self.type_change = transient_registration.registration_type_changed?

--- a/app/forms/waste_carriers_engine/payment_summary_form.rb
+++ b/app/forms/waste_carriers_engine/payment_summary_form.rb
@@ -4,18 +4,20 @@ module WasteCarriersEngine
   class PaymentSummaryForm < BaseForm
     attr_accessor :temp_payment_method, :type_change, :registration_cards, :registration_card_charge, :total_charge
 
+    validates :temp_payment_method, inclusion: { in: %w[card bank_transfer] }
+
     def self.can_navigate_flexibly?
       false
     end
 
     def initialize(transient_registration)
       super
-      self.temp_payment_method = @transient_registration.temp_payment_method
+      self.temp_payment_method = transient_registration.temp_payment_method
 
-      self.type_change = @transient_registration.registration_type_changed?
-      self.registration_cards = @transient_registration.temp_cards || 0
-      self.registration_card_charge = @transient_registration.total_registration_card_charge
-      self.total_charge = @transient_registration.total_to_pay
+      self.type_change = transient_registration.registration_type_changed?
+      self.registration_cards = transient_registration.temp_cards || 0
+      self.registration_card_charge = transient_registration.total_registration_card_charge
+      self.total_charge = transient_registration.total_to_pay
     end
 
     def submit(params)
@@ -25,7 +27,5 @@ module WasteCarriersEngine
 
       super(attributes, params[:reg_identifier])
     end
-
-    validates :temp_payment_method, inclusion: { in: %w[card bank_transfer] }
   end
 end

--- a/app/forms/waste_carriers_engine/person_form.rb
+++ b/app/forms/waste_carriers_engine/person_form.rb
@@ -7,7 +7,6 @@ module WasteCarriersEngine
 
     validate :old_enough?
 
-
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating
       self.first_name = params[:first_name]

--- a/app/forms/waste_carriers_engine/person_form.rb
+++ b/app/forms/waste_carriers_engine/person_form.rb
@@ -5,6 +5,8 @@ module WasteCarriersEngine
     attr_accessor :first_name, :last_name, :position, :dob_day, :dob_month, :dob_year, :dob
     attr_accessor :new_person
 
+    validate :old_enough?
+
     def initialize(transient_registration)
       super
     end
@@ -27,8 +29,6 @@ module WasteCarriersEngine
 
       super(attributes, params[:reg_identifier])
     end
-
-    validate :old_enough?
 
     # Used to switch on usage of the :position attribute for validation and form-filling
     def position?

--- a/app/forms/waste_carriers_engine/person_form.rb
+++ b/app/forms/waste_carriers_engine/person_form.rb
@@ -7,9 +7,6 @@ module WasteCarriersEngine
 
     validate :old_enough?
 
-    def initialize(transient_registration)
-      super
-    end
 
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating

--- a/app/forms/waste_carriers_engine/register_in_northern_ireland_form.rb
+++ b/app/forms/waste_carriers_engine/register_in_northern_ireland_form.rb
@@ -2,10 +2,6 @@
 
 module WasteCarriersEngine
   class RegisterInNorthernIrelandForm < BaseForm
-    def initialize(transient_registration)
-      super
-    end
-
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating
       attributes = {}

--- a/app/forms/waste_carriers_engine/register_in_scotland_form.rb
+++ b/app/forms/waste_carriers_engine/register_in_scotland_form.rb
@@ -2,10 +2,6 @@
 
 module WasteCarriersEngine
   class RegisterInScotlandForm < BaseForm
-    def initialize(transient_registration)
-      super
-    end
-
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating
       attributes = {}

--- a/app/forms/waste_carriers_engine/register_in_wales_form.rb
+++ b/app/forms/waste_carriers_engine/register_in_wales_form.rb
@@ -2,10 +2,6 @@
 
 module WasteCarriersEngine
   class RegisterInWalesForm < BaseForm
-    def initialize(transient_registration)
-      super
-    end
-
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating
       attributes = {}

--- a/app/forms/waste_carriers_engine/registration_number_form.rb
+++ b/app/forms/waste_carriers_engine/registration_number_form.rb
@@ -4,11 +4,13 @@ module WasteCarriersEngine
   class RegistrationNumberForm < BaseForm
     attr_accessor :company_no, :business_type
 
+    validates :company_no, "defra_ruby/validators/companies_house_number": true
+
     def initialize(transient_registration)
       super
-      self.company_no = @transient_registration.company_no
+      self.company_no = transient_registration.company_no
       # We only use this for the correct microcopy
-      self.business_type = @transient_registration.business_type
+      self.business_type = transient_registration.business_type
     end
 
     def submit(params)
@@ -20,8 +22,6 @@ module WasteCarriersEngine
 
       super(attributes, params[:reg_identifier])
     end
-
-    validates :company_no, "defra_ruby/validators/companies_house_number": true
 
     private
 

--- a/app/forms/waste_carriers_engine/registration_number_form.rb
+++ b/app/forms/waste_carriers_engine/registration_number_form.rb
@@ -8,6 +8,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
+      
       self.company_no = transient_registration.company_no
       # We only use this for the correct microcopy
       self.business_type = transient_registration.business_type

--- a/app/forms/waste_carriers_engine/registration_number_form.rb
+++ b/app/forms/waste_carriers_engine/registration_number_form.rb
@@ -8,7 +8,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
-      
+
       self.company_no = transient_registration.company_no
       # We only use this for the correct microcopy
       self.business_type = transient_registration.business_type

--- a/app/forms/waste_carriers_engine/renewal_complete_form.rb
+++ b/app/forms/waste_carriers_engine/renewal_complete_form.rb
@@ -10,6 +10,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
+      
       self.certificate_link = build_certificate_link
       self.contact_email = transient_registration.contact_email
       self.projected_renewal_end_date = transient_registration.projected_renewal_end_date

--- a/app/forms/waste_carriers_engine/renewal_complete_form.rb
+++ b/app/forms/waste_carriers_engine/renewal_complete_form.rb
@@ -11,9 +11,9 @@ module WasteCarriersEngine
     def initialize(transient_registration)
       super
       self.certificate_link = build_certificate_link
-      self.contact_email = @transient_registration.contact_email
-      self.projected_renewal_end_date = @transient_registration.projected_renewal_end_date
-      self.registration_type = @transient_registration.registration_type
+      self.contact_email = transient_registration.contact_email
+      self.projected_renewal_end_date = transient_registration.projected_renewal_end_date
+      self.registration_type = transient_registration.registration_type
     end
 
     # Override BaseForm method as users shouldn't be able to submit this form

--- a/app/forms/waste_carriers_engine/renewal_complete_form.rb
+++ b/app/forms/waste_carriers_engine/renewal_complete_form.rb
@@ -10,7 +10,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
-      
+
       self.certificate_link = build_certificate_link
       self.contact_email = transient_registration.contact_email
       self.projected_renewal_end_date = transient_registration.projected_renewal_end_date

--- a/app/forms/waste_carriers_engine/renewal_information_form.rb
+++ b/app/forms/waste_carriers_engine/renewal_information_form.rb
@@ -6,8 +6,8 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
-      self.type_change = @transient_registration.registration_type_changed?
-      self.total_fee = @transient_registration.fee_including_possible_type_change
+      self.type_change = transient_registration.registration_type_changed?
+      self.total_fee = transient_registration.fee_including_possible_type_change
     end
 
     def submit(params)

--- a/app/forms/waste_carriers_engine/renewal_information_form.rb
+++ b/app/forms/waste_carriers_engine/renewal_information_form.rb
@@ -6,6 +6,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
+      
       self.type_change = transient_registration.registration_type_changed?
       self.total_fee = transient_registration.fee_including_possible_type_change
     end

--- a/app/forms/waste_carriers_engine/renewal_information_form.rb
+++ b/app/forms/waste_carriers_engine/renewal_information_form.rb
@@ -6,7 +6,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
-      
+
       self.type_change = transient_registration.registration_type_changed?
       self.total_fee = transient_registration.fee_including_possible_type_change
     end

--- a/app/forms/waste_carriers_engine/renewal_received_form.rb
+++ b/app/forms/waste_carriers_engine/renewal_received_form.rb
@@ -10,6 +10,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
+      
       self.contact_email = transient_registration.contact_email
       self.pending_convictions_check = transient_registration.conviction_check_required?
       self.pending_payment = transient_registration.pending_payment?

--- a/app/forms/waste_carriers_engine/renewal_received_form.rb
+++ b/app/forms/waste_carriers_engine/renewal_received_form.rb
@@ -10,10 +10,10 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
-      self.contact_email = @transient_registration.contact_email
-      self.pending_convictions_check = @transient_registration.conviction_check_required?
-      self.pending_payment = @transient_registration.pending_payment?
-      self.pending_worldpay_payment = @transient_registration.pending_worldpay_payment?
+      self.contact_email = transient_registration.contact_email
+      self.pending_convictions_check = transient_registration.conviction_check_required?
+      self.pending_payment = transient_registration.pending_payment?
+      self.pending_worldpay_payment = transient_registration.pending_worldpay_payment?
     end
 
     # Override BaseForm method as users shouldn't be able to submit this form

--- a/app/forms/waste_carriers_engine/renewal_received_form.rb
+++ b/app/forms/waste_carriers_engine/renewal_received_form.rb
@@ -10,7 +10,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
-      
+
       self.contact_email = transient_registration.contact_email
       self.pending_convictions_check = transient_registration.conviction_check_required?
       self.pending_payment = transient_registration.pending_payment?

--- a/app/forms/waste_carriers_engine/renewal_start_form.rb
+++ b/app/forms/waste_carriers_engine/renewal_start_form.rb
@@ -6,10 +6,6 @@ module WasteCarriersEngine
       false
     end
 
-    def initialize(transient_registration)
-      super
-    end
-
     def submit(params)
       attributes = {}
 

--- a/app/forms/waste_carriers_engine/service_provided_form.rb
+++ b/app/forms/waste_carriers_engine/service_provided_form.rb
@@ -8,7 +8,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
-      
+
       self.is_main_service = transient_registration.is_main_service
     end
 

--- a/app/forms/waste_carriers_engine/service_provided_form.rb
+++ b/app/forms/waste_carriers_engine/service_provided_form.rb
@@ -4,9 +4,11 @@ module WasteCarriersEngine
   class ServiceProvidedForm < BaseForm
     attr_accessor :is_main_service
 
+    validates :is_main_service, "waste_carriers_engine/yes_no": true
+
     def initialize(transient_registration)
       super
-      self.is_main_service = @transient_registration.is_main_service
+      self.is_main_service = transient_registration.is_main_service
     end
 
     def submit(params)
@@ -16,7 +18,5 @@ module WasteCarriersEngine
 
       super(attributes, params[:reg_identifier])
     end
-
-    validates :is_main_service, "waste_carriers_engine/yes_no": true
   end
 end

--- a/app/forms/waste_carriers_engine/service_provided_form.rb
+++ b/app/forms/waste_carriers_engine/service_provided_form.rb
@@ -8,6 +8,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
+      
       self.is_main_service = transient_registration.is_main_service
     end
 

--- a/app/forms/waste_carriers_engine/tier_check_form.rb
+++ b/app/forms/waste_carriers_engine/tier_check_form.rb
@@ -8,7 +8,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
-      
+
       self.temp_tier_check = transient_registration.temp_tier_check
     end
 

--- a/app/forms/waste_carriers_engine/tier_check_form.rb
+++ b/app/forms/waste_carriers_engine/tier_check_form.rb
@@ -8,6 +8,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
+      
       self.temp_tier_check = transient_registration.temp_tier_check
     end
 

--- a/app/forms/waste_carriers_engine/tier_check_form.rb
+++ b/app/forms/waste_carriers_engine/tier_check_form.rb
@@ -4,9 +4,11 @@ module WasteCarriersEngine
   class TierCheckForm < BaseForm
     attr_accessor :temp_tier_check
 
+    validates :temp_tier_check, "waste_carriers_engine/yes_no": true
+
     def initialize(transient_registration)
       super
-      self.temp_tier_check = @transient_registration.temp_tier_check
+      self.temp_tier_check = transient_registration.temp_tier_check
     end
 
     def submit(params)
@@ -16,7 +18,5 @@ module WasteCarriersEngine
 
       super(attributes, params[:reg_identifier])
     end
-
-    validates :temp_tier_check, "waste_carriers_engine/yes_no": true
   end
 end

--- a/app/forms/waste_carriers_engine/waste_types_form.rb
+++ b/app/forms/waste_carriers_engine/waste_types_form.rb
@@ -8,6 +8,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
+      
       self.only_amf = transient_registration.only_amf
     end
 

--- a/app/forms/waste_carriers_engine/waste_types_form.rb
+++ b/app/forms/waste_carriers_engine/waste_types_form.rb
@@ -4,9 +4,11 @@ module WasteCarriersEngine
   class WasteTypesForm < BaseForm
     attr_accessor :only_amf
 
+    validates :only_amf, "waste_carriers_engine/yes_no": true
+
     def initialize(transient_registration)
       super
-      self.only_amf = @transient_registration.only_amf
+      self.only_amf = transient_registration.only_amf
     end
 
     def submit(params)
@@ -16,7 +18,5 @@ module WasteCarriersEngine
 
       super(attributes, params[:reg_identifier])
     end
-
-    validates :only_amf, "waste_carriers_engine/yes_no": true
   end
 end

--- a/app/forms/waste_carriers_engine/waste_types_form.rb
+++ b/app/forms/waste_carriers_engine/waste_types_form.rb
@@ -8,7 +8,7 @@ module WasteCarriersEngine
 
     def initialize(transient_registration)
       super
-      
+
       self.only_amf = transient_registration.only_amf
     end
 

--- a/app/forms/waste_carriers_engine/worldpay_form.rb
+++ b/app/forms/waste_carriers_engine/worldpay_form.rb
@@ -5,9 +5,5 @@ module WasteCarriersEngine
     def self.can_navigate_flexibly?
       false
     end
-
-    def initialize(transient_registration)
-      super
-    end
   end
 end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-693

There are some minor tidy-ups in this PR:
 - Get rid of `initialize` implementation on children forms that only call `super`
 - Make sure we always access `transient_registration` through its `attr_accessor` method
 - Move validations declaration to the top of the file, between class methods definitions and instance methods definitions