### PR TITLE
Forms refactoring - Use strong parameters in Business type form

### DIFF
--- a/app/controllers/waste_carriers_engine/business_type_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/business_type_forms_controller.rb
@@ -9,5 +9,11 @@ module WasteCarriersEngine
     def create
       super(BusinessTypeForm, "business_type_form")
     end
+
+    private
+
+    def transient_registration_attributes
+      params.require(:business_type_form).permit(:business_type, :reg_identifier)
+    end
   end
 end

--- a/app/controllers/waste_carriers_engine/forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/forms_controller.rb
@@ -17,9 +17,9 @@ module WasteCarriersEngine
       return false unless set_up_form(form_class, form, params[form][:reg_identifier])
 
       # Submit the form by getting the instance variable we just set
-      if respond_to?(:transient_registration_attributes) # TODO: Temporary refactoring code.
+      begin # TODO: Temporary refactoring code.
         submit_form(instance_variable_get("@#{form}"), transient_registration_attributes)
-      else
+      rescue NameError
         submit_form(instance_variable_get("@#{form}"), params[form])
       end
     end

--- a/app/controllers/waste_carriers_engine/forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/forms_controller.rb
@@ -17,7 +17,8 @@ module WasteCarriersEngine
       return false unless set_up_form(form_class, form, params[form][:reg_identifier])
 
       # Submit the form by getting the instance variable we just set
-      begin # TODO: Temporary refactoring code.
+      # TODO: Temporary refactoring code.
+      begin
         submit_form(instance_variable_get("@#{form}"), transient_registration_attributes)
       rescue NameError
         submit_form(instance_variable_get("@#{form}"), params[form])

--- a/app/forms/waste_carriers_engine/business_type_form.rb
+++ b/app/forms/waste_carriers_engine/business_type_form.rb
@@ -2,20 +2,7 @@
 
 module WasteCarriersEngine
   class BusinessTypeForm < BaseForm
-    attr_accessor :business_type
-
-    def initialize(transient_registration)
-      super
-      self.business_type = @transient_registration.business_type
-    end
-
-    def submit(params)
-      # Assign the params for validation and pass them to the BaseForm method for updating
-      self.business_type = params[:business_type]
-      attributes = { business_type: business_type }
-
-      super(attributes, params[:reg_identifier])
-    end
+    delegate :business_type, to: :transient_registration
 
     validates :business_type, "defra_ruby/validators/business_type": { allow_overseas: true }
   end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-693

Use strong parameters on the business type form.
Fix temporary refactoring code which was not working when the method is defined in a child class.