### PR TITLE
Add search scope to Registration

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -74,6 +74,13 @@ module WasteCarriersEngine
       field :title,                                            type: String
       field :total_fee,                                        type: String
 
+      scope :search_term, lambda { |term|
+        any_of({ reg_identifier: /\A#{term}\z/i },
+               { company_name: /#{term}/i },
+               { last_name: /#{term}/i },
+               "addresses.postcode": /#{term}/i)
+      }
+
       def contact_address
         return nil unless addresses.present?
 

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -25,12 +25,6 @@ module WasteCarriersEngine
     field :temp_payment_method, type: String
     field :temp_tier_check, type: String # 'yes' or 'no' - should refactor to boolean
 
-    scope :search_term, lambda { |term|
-      any_of({ reg_identifier: /\A#{term}\z/i },
-             { company_name: /#{term}/i },
-             { last_name: /#{term}/i },
-             "addresses.postcode": /#{term}/i)
-    }
     scope :in_progress, -> { where(:workflow_state.nin => %w[renewal_complete_form renewal_received_form]) }
     scope :submitted, -> { where(:workflow_state.in => %w[renewal_complete_form renewal_received_form]) }
     scope :pending_payment, -> { submitted.where(:"financeDetails.balance".gt => 0) }

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -491,5 +491,11 @@ module WasteCarriersEngine
         end
       end
     end
+
+    describe "search" do
+      it_should_behave_like "Search scopes",
+                            record_class: WasteCarriersEngine::Registration,
+                            factory: :registration
+    end
   end
 end

--- a/spec/models/waste_carriers_engine/transient_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/transient_registration_spec.rb
@@ -34,7 +34,13 @@ module WasteCarriersEngine
       end
     end
 
-    describe "scope" do
+    describe "search" do
+      it_should_behave_like "Search scopes",
+                            record_class: WasteCarriersEngine::TransientRegistration,
+                            factory: :transient_registration
+    end
+
+    describe "scopes" do
       it_should_behave_like "TransientRegistration named scopes"
     end
 

--- a/spec/support/shared_examples/search_scope.rb
+++ b/spec/support/shared_examples/search_scope.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "Search scopes" do |record_class:, factory:|
+  let(:non_matching_record) do
+    create(factory,
+           :has_required_data)
+  end
+
+  describe "#search_term" do
+    let(:term) { nil }
+    let(:scope) { record_class.search_term(term) }
+
+    it "returns everything when no search term is given" do
+      expect(scope.length).to eq(record_class.all.length)
+    end
+
+    context "when the search term is a reg_identifier" do
+      let(:matching_record) do
+        create(factory, :has_required_data)
+      end
+
+      let(:term) { matching_record.reg_identifier }
+
+      it "returns records with a matching reg_identifier" do
+        expect(scope).to include(matching_record)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(non_matching_record)
+      end
+    end
+
+    context "when the search term is a name" do
+      let(:term) { "Lee" }
+
+      let(:matching_company_name_record) do
+        create(factory, :has_required_data, company_name: "Stan Lee Waste Company")
+      end
+
+      let(:matching_person_name_record) do
+        create(factory, :has_required_data, last_name: "Lee")
+      end
+
+      it "returns records with a matching company_name" do
+        expect(scope).to include(matching_company_name_record)
+      end
+
+      it "returns records with a matching last_name" do
+        expect(scope).to include(matching_person_name_record)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(non_matching_record)
+      end
+    end
+
+    context "when the search term is a postcode" do
+      let(:term) { "SW1A 2AA" }
+
+      let(:matching_postcode_record) do
+        address = build(:address, postcode: term)
+        create(factory, :has_required_data, addresses: [address])
+      end
+
+      it "returns records with a matching postcode" do
+        expect(scope).to include(matching_postcode_record)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(non_matching_record)
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/transient_registration_scope.rb
+++ b/spec/support/shared_examples/transient_registration_scope.rb
@@ -25,68 +25,6 @@ RSpec.shared_examples "TransientRegistration named scopes" do
            workflow_state: :renewal_received_form)
   end
 
-  describe "#search_term" do
-    let(:term) { nil }
-    let(:scope) { WasteCarriersEngine::TransientRegistration.search_term(term) }
-
-    it "returns everything when no search term is given" do
-      expect(scope.length).to eq(WasteCarriersEngine::TransientRegistration.all.length)
-    end
-
-    context "when the search term is a reg_identifier" do
-      let(:term) { in_progress_renewal.reg_identifier }
-
-      it "returns renewals with a matching reg_identifier" do
-        expect(scope).to include(in_progress_renewal)
-      end
-
-      it "does not return others" do
-        expect(scope).not_to include(submitted_renewal)
-      end
-    end
-
-    context "when the search term is a name" do
-      let(:term) { "Lee" }
-
-      let(:matching_company_name_renewal) do
-        create(:transient_registration, :has_required_data, company_name: "Stan Lee Waste Company")
-      end
-
-      let(:matching_person_name_renewal) do
-        create(:transient_registration, :has_required_data, last_name: "Lee")
-      end
-
-      it "returns renewals with a matching company_name" do
-        expect(scope).to include(matching_company_name_renewal)
-      end
-
-      it "returns renewals with a matching last_name" do
-        expect(scope).to include(matching_person_name_renewal)
-      end
-
-      it "does not return others" do
-        expect(scope).not_to include(in_progress_renewal)
-      end
-    end
-
-    context "when the search term is a postcode" do
-      let(:term) { "SW1A 2AA" }
-
-      let(:matching_postcode_renewal) do
-        address = build(:address, postcode: term)
-        create(:transient_registration, :has_required_data, addresses: [address])
-      end
-
-      it "returns renewals with a matching postcode" do
-        expect(scope).to include(matching_postcode_renewal)
-      end
-
-      it "does not return others" do
-        expect(scope).not_to include(in_progress_renewal)
-      end
-    end
-  end
-
   describe "#in_progress" do
     let(:scope) { WasteCarriersEngine::TransientRegistration.in_progress }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-704

This will allow the back office search to work with both Registrations and TransientRegistrations.