### PR TITLE
Forms Refactoring -Add ability to reference single document in collection

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_reference_single_document_in_collection.rb
+++ b/app/models/concerns/waste_carriers_engine/can_reference_single_document_in_collection.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  module CanReferenceSingleDocumentInCollection
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def reference_one(attribute_name, collection:, find_by:)
+        define_method(attribute_name) do
+          retrieve_attribute(attribute_name, collection, find_by)
+        end
+
+        define_method("#{attribute_name}=") do |new_object|
+          assign_attribute(attribute_name, collection, find_by, new_object)
+        end
+      end
+    end
+
+    included do
+      def retrieve_attribute(attribute_name, collection, find_by)
+        instance_variable_get("@#{attribute_name}") ||
+          fetch_attribute(attribute_name, collection, find_by)
+      end
+
+      def assign_attribute(attribute_name, collection, find_by, new_object)
+        eval("#{attribute_name}.delete") if send(attribute_name)
+        eval("#{collection} << new_object")
+
+        instance_variable_set("@#{attribute_name}", nil)
+      end
+
+      def fetch_attribute(attribute_name, collection, find_by)
+        criteria = instance_eval("#{collection}.criteria")
+
+        criteria.where(find_by).first
+      end
+    end
+  end
+end

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -48,8 +48,11 @@ module WasteCarriersEngine
       # Don't compare registration types if the new one hasn't been set
       return false unless registration_type
 
-      original_registration_type = Registration.where(reg_identifier: reg_identifier).first.registration_type
-      original_registration_type != registration_type
+      registration.registration_type != registration_type
+    end
+
+    def registration
+      Registration.where(reg_identifier: reg_identifier).first
     end
 
     def fee_including_possible_type_change
@@ -82,7 +85,6 @@ module WasteCarriersEngine
     def company_no_changed?
       return false unless company_no_required?
 
-      registration = Registration.where(reg_identifier: reg_identifier).first
       # LLP is a new business type, so users who previously were forced to select 'partnership' would not have had the
       # opportunity to enter a company_no. Therefore we have nothing to compare against and should allow users to
       # continue the renewal journey.
@@ -161,8 +163,6 @@ module WasteCarriersEngine
     def copy_data_from_registration
       # Don't try to get Registration data with an invalid reg_identifier
       return unless valid? && new_record?
-
-      registration = Registration.where(reg_identifier: reg_identifier).first
 
       # Don't copy object IDs as Mongo should generate new unique ones
       # Don't copy smart answers as we want users to use the latest version of the questions

--- a/spec/requests/waste_carriers_engine/company_address_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/company_address_forms_spec.rb
@@ -78,7 +78,7 @@ module WasteCarriersEngine
               end
 
               it "does not modify the existing contact address" do
-                old_contact_address = transient_registration.contact_address
+                old_contact_address = transient_registration.reload.contact_address
                 post company_address_manual_forms_path, company_address_manual_form: valid_params
                 expect(transient_registration.reload.contact_address).to eq(old_contact_address)
               end

--- a/spec/support/shared_examples/can_have_registration_attributes.rb
+++ b/spec/support/shared_examples/can_have_registration_attributes.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "Can have registration attributes" do
+  include_examples "Can reference single document in collection",
+    Proc.new { create(:transient_registration, :has_required_data, :has_addresses) },
+    :contact_address,
+    Proc.new { subject.addresses.find_by(address_type: "POSTAL") },
+    WasteCarriersEngine::Address.new,
+    :addresses
+
   describe "#charity?" do
     let(:transient_registration) { build(:transient_registration) }
 
@@ -16,6 +23,26 @@ RSpec.shared_examples "Can have registration attributes" do
           expect(transient_registration.charity?).to eq(result)
         end
       end
+    end
+  end
+
+  describe "#contact_address" do
+    let(:contact_address) { build(:address, :contact) }
+    let(:transient_registration) { build(:transient_registration, addresses: [contact_address]) }
+
+    it "returns the address of type contact" do
+      expect(transient_registration.contact_address).to eq(contact_address)
+    end
+  end
+
+  describe "#contact_address=" do
+    let(:contact_address) { build(:address) }
+    let(:transient_registration) { build(:transient_registration, addresses: []) }
+
+    it "set an address of type contact" do
+      transient_registration.contact_address = contact_address
+
+      expect(transient_registration.addresses).to eq([contact_address])
     end
   end
 

--- a/spec/support/shared_examples/can_reference_single_document_in_collection.rb
+++ b/spec/support/shared_examples/can_reference_single_document_in_collection.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "Can reference single document in collection" do |subject_lambda, attribute, object_from_collection, new_object_for_collection, collection|
+  subject { instance_eval(&subject_lambda) }
+
+  describe ".reference_one" do
+    it "defines an attr getter for the given attribute" do
+      expect(subject).to respond_to("#{attribute}")
+    end
+
+    it "defines an attr setter for the given attribute" do
+      expect(subject).to respond_to("#{attribute}=")
+    end
+  end
+
+  describe "##{attribute}" do
+    it "returns the correct object from the collection" do
+      expect(subject.send(attribute)).to eq(instance_eval(&object_from_collection))
+    end
+  end
+
+  describe "##{attribute}=" do
+    it "updates the object's collection with the new object" do
+      size = subject.send(collection).size
+
+      expect(subject.send(collection)).to_not include(new_object_for_collection)
+
+      subject.send("#{attribute}=", new_object_for_collection)
+
+      expect(subject.send(collection)).to include(new_object_for_collection)
+      expect(subject.send(collection).size).to eq(size)
+    end
+  end
+end


### PR DESCRIPTION

From: https://eaflood.atlassian.net/browse/RUBY-693

In Wex, using Active Record, we were able to simplify a lot our logic around addresses forms by redefining the association to the address as `has_one` associations.
Currently, there is no way to do the same with MongId 5.2, hence this adds some metaprogramming code that will allow a mode l to define a single object that is persisted inside a location and to override it.