### PR TITLE
Use Fetch instead of Require when fetching parameters

### DIFF
--- a/app/controllers/waste_carriers_engine/business_type_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/business_type_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteCarriersEngine
     private
 
     def transient_registration_attributes
-      params.require(:business_type_form).permit(:business_type, :reg_identifier)
+      params.fetch(:business_type_form, {}).permit(:business_type, :reg_identifier)
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/cards_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/cards_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteCarriersEngine
     private
 
     def transient_registration_attributes
-      params.require(:cards_form).permit(:temp_cards)
+      params.fetch(:cards_form, {}).permit(:temp_cards)
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/cbd_type_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/cbd_type_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteCarriersEngine
     private
 
     def transient_registration_attributes
-      params.require(:cbd_type_form).permit(:registration_type)
+      params.fetch(:cbd_type_form, {}).permit(:registration_type)
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/company_name_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/company_name_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteCarriersEngine
     private
 
     def transient_registration_attributes
-      params.require(:company_name_form).permit(:company_name)
+      params.fetch(:company_name_form, {}).permit(:company_name)
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/company_postcode_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/company_postcode_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteCarriersEngine
     private
 
     def transient_registration_attributes
-      params.require(:company_postcode_form).permit(:temp_company_postcode)
+      params.fetch(:company_postcode_form, {}).permit(:temp_company_postcode)
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/construction_demolition_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/construction_demolition_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteCarriersEngine
     private
 
     def transient_registration_attributes
-      params.require(:construction_demolition_form).permit(:construction_waste)
+      params.fetch(:construction_demolition_form, {}).permit(:construction_waste)
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/contact_email_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/contact_email_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteCarriersEngine
     private
 
     def transient_registration_attributes
-      params.require(:contact_email_form).permit(:contact_email, :confirmed_email)
+      params.fetch(:contact_email_form, {}).permit(:contact_email, :confirmed_email)
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/contact_name_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/contact_name_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteCarriersEngine
     private
 
     def transient_registration_attributes
-      params.require(:contact_name_form).permit(:first_name, :last_name)
+      params.fetch(:contact_name_form, {}).permit(:first_name, :last_name)
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/contact_phone_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/contact_phone_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteCarriersEngine
     private
 
     def transient_registration_attributes
-      params.require(:contact_phone_form).permit(:phone_number)
+      params.fetch(:contact_phone_form, {}).permit(:phone_number)
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/contact_postcode_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/contact_postcode_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteCarriersEngine
     private
 
     def transient_registration_attributes
-      params.require(:contact_postcode_form).permit(:temp_contact_postcode)
+      params.fetch(:contact_postcode_form, {}).permit(:temp_contact_postcode)
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/declaration_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/declaration_forms_controller.rb
@@ -16,7 +16,7 @@ module WasteCarriersEngine
     private
 
     def transient_registration_attributes
-      params.require(:declaration_form).permit(:declaration)
+      params.fetch(:declaration_form, {}).permit(:declaration)
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/declare_convictions_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/declare_convictions_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteCarriersEngine
     private
 
     def transient_registration_attributes
-      params.require(:declare_convictions_form).permit(:declared_convictions)
+      params.fetch(:declare_convictions_form, {}).permit(:declared_convictions)
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/location_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/location_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteCarriersEngine
     private
 
     def transient_registration_attributes
-      params.require(:location_form).permit(:location)
+      params.fetch(:location_form, {}).permit(:location)
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/other_businesses_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/other_businesses_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteCarriersEngine
     private
 
     def transient_registration_attributes
-      params.require(:other_businesses_form).permit(:other_businesses)
+      params.fetch(:other_businesses_form, {}).permit(:other_businesses)
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/registration_number_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/registration_number_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteCarriersEngine
     private
 
     def transient_registration_attributes
-      params.require(:registration_number_form).permit(:company_no)
+      params.fetch(:registration_number_form, {}).permit(:company_no)
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/service_provided_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/service_provided_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteCarriersEngine
     private
 
     def transient_registration_attributes
-      params.require(:service_provided_form).permit(:is_main_service)
+      params.fetch(:service_provided_form, {}).permit(:is_main_service)
     end
   end
 end

--- a/spec/support/shared_examples/post_form.rb
+++ b/spec/support/shared_examples/post_form.rb
@@ -96,9 +96,11 @@ RSpec.shared_examples "POST form" do |form, options|
 
         context "when the params are empty" do
           it "does not throw an error" do
+            # rubocop:disable Style/BlockDelimiters
             expect {
               post_with_params(form, { reg_identifier: transient_registration.reg_identifier })
             }.not_to raise_error
+            # rubocop:enable Style/BlockDelimiters
           end
         end
 

--- a/spec/support/shared_examples/post_form.rb
+++ b/spec/support/shared_examples/post_form.rb
@@ -98,7 +98,7 @@ RSpec.shared_examples "POST form" do |form, options|
           it "does not throw an error" do
             # rubocop:disable Style/BlockDelimiters
             expect {
-              post_with_params(form, { reg_identifier: transient_registration.reg_identifier })
+              post_with_params(form, reg_identifier: transient_registration.reg_identifier)
             }.not_to raise_error
             # rubocop:enable Style/BlockDelimiters
           end

--- a/spec/support/shared_examples/post_form.rb
+++ b/spec/support/shared_examples/post_form.rb
@@ -94,6 +94,14 @@ RSpec.shared_examples "POST form" do |form, options|
           end
         end
 
+        context "when the params are empty" do
+          it "does not throw an error" do
+            expect {
+              post_with_params(form, { reg_identifier: transient_registration.reg_identifier })
+            }.not_to raise_error
+          end
+        end
+
         context "when the reg_identifier is invalid" do
           before do
             valid_params[:reg_identifier] = "foo"


### PR DESCRIPTION
Given that: https://github.com/rails/strong_parameters/issues/162 is an issue for us, as we want to allow people to submit empty forms, this changes the strategy of fetching parameters from `require` to `fetch` as suggested by the official Rails documentation: https://guides.rubyonrails.org/action_controller_overview.html#more-examples