### PR TITLE
Fix bug in CanReferenceSingleDocument

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_reference_single_document_in_collection.rb
+++ b/app/models/concerns/waste_carriers_engine/can_reference_single_document_in_collection.rb
@@ -28,20 +28,23 @@ module WasteCarriersEngine
           fetch_attribute(collection, find_by)
       end
 
-      # rubocop:disable Lint/UnusedMethodArgument
       def assign_attribute(attribute_name, collection, new_object)
-        send(attribute_name)&.delete
+        public_send(attribute_name)&.delete
 
-        instance_eval("#{collection} << new_object", __FILE__, __LINE__)
+        new_collection = public_send(collection)
+        new_collection += [new_object]
 
-        instance_variable_set("@#{attribute_name}", nil)
+        public_send("#{collection}=", new_collection)
       end
-      # rubocop:enable Lint/UnusedMethodArgument
 
       def fetch_attribute(collection, find_by)
-        criteria = instance_eval("#{collection}.criteria", __FILE__, __LINE__)
+        public_send(collection).each do |element|
+          find_by.each do |key, value|
+            return element if element.public_send(key) == value
+          end
+        end
 
-        criteria.where(find_by).first
+        nil
       end
     end
   end

--- a/app/models/concerns/waste_carriers_engine/can_reference_single_document_in_collection.rb
+++ b/app/models/concerns/waste_carriers_engine/can_reference_single_document_in_collection.rb
@@ -29,10 +29,10 @@ module WasteCarriersEngine
       end
 
       def assign_attribute(attribute_name, collection, new_object)
-        public_send(attribute_name)&.delete
+        new_collection = public_send(collection) || []
 
-        new_collection = public_send(collection)
-        new_collection += [new_object]
+        new_collection -= [public_send(attribute_name)]
+        new_collection << new_object
 
         public_send("#{collection}=", new_collection)
       end

--- a/spec/support/shared_examples/can_reference_single_document_in_collection.rb
+++ b/spec/support/shared_examples/can_reference_single_document_in_collection.rb
@@ -3,6 +3,15 @@
 RSpec.shared_examples "Can reference single document in collection" do |subject_lambda, attribute, object_from_collection, new_object_for_collection, collection|
   subject { instance_eval(&subject_lambda) }
 
+  context "when mass assignment happens" do
+    context "when the object to save is not persisted and the number of transactions would be more than one" do
+      it "can save a document to MongoDb without throwing an error" do
+        subject.send("#{attribute}=", new_object_for_collection)
+        expect { subject.assign_attributes(attribute => new_object_for_collection.clone, account_email: "new@test.com"); subject.save! }.to_not raise_error
+      end
+    end
+  end
+
   describe ".reference_one" do
     it "defines an attr getter for the given attribute" do
       expect(subject).to respond_to(attribute.to_s)

--- a/spec/support/shared_examples/can_reference_single_document_in_collection.rb
+++ b/spec/support/shared_examples/can_reference_single_document_in_collection.rb
@@ -7,7 +7,9 @@ RSpec.shared_examples "Can reference single document in collection" do |subject_
     context "when the object to save is not persisted and the number of transactions would be more than one" do
       it "can save a document to MongoDb without throwing an error" do
         subject.send("#{attribute}=", new_object_for_collection)
-        expect { subject.assign_attributes(attribute => new_object_for_collection.clone, account_email: "new@test.com"); subject.save! }.to_not raise_error
+        subject.assign_attributes(attribute => new_object_for_collection.clone)
+
+        expect { subject.save! }.to_not raise_error
       end
     end
   end


### PR DESCRIPTION
For some reasons, when assigning an un-persisted object to a multiple association using `<<` and then saving the parent object, creates 2 transitions to the MongoDb API.
Since we are stuck with an old version of MongoId, the call is made using a deprecated attribute and an error is thrown:
```
  Mongo::Error::OperationFailure: Unknown modifier: $pushAll (9)
```
https://stackoverflow.com/questions/48607918/mongoerror-unknown-modifier-pushall-in-node-js/48621806#48621806

Before the change we were assigning the new object by re-assigning the entire hash in the collection. This will not trigger the `pushAll` command.

A new scenario have been added for documentation and to avoid regression,