### PR TITLE
Forms refactoring - Externalise AddressFinder stubs

### DIFF
--- a/spec/forms/waste_carriers_engine/company_address_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/company_address_forms_spec.rb
@@ -4,10 +4,8 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe CompanyAddressForm, type: :model do
-    # Stub the address search so we have JSON to use
     before do
-      address_json = build(:company_address_form, :has_required_data).temp_addresses
-      allow_any_instance_of(AddressFinderService).to receive(:search_by_postcode).and_return(address_json)
+      stub_address_finder_service(uprn: "340116")
     end
 
     describe "#submit" do
@@ -16,9 +14,7 @@ module WasteCarriersEngine
         let(:valid_params) { { reg_identifier: company_address_form.reg_identifier, temp_address: company_address_form.temp_address } }
 
         it "should submit" do
-          VCR.use_cassette("company_postcode_form_valid_postcode") do
-            expect(company_address_form.submit(valid_params)).to eq(true)
-          end
+          expect(company_address_form.submit(valid_params)).to eq(true)
         end
       end
 
@@ -27,9 +23,7 @@ module WasteCarriersEngine
         let(:invalid_params) { { reg_identifier: "foo" } }
 
         it "should not submit" do
-          VCR.use_cassette("company_postcode_form_valid_postcode") do
-            expect(company_address_form.submit(invalid_params)).to eq(false)
-          end
+          expect(company_address_form.submit(invalid_params)).to eq(false)
         end
       end
     end

--- a/spec/forms/waste_carriers_engine/contact_address_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/contact_address_forms_spec.rb
@@ -4,10 +4,8 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe ContactAddressForm, type: :model do
-    # Stub the address search so we have JSON to use
     before do
-      address_json = build(:contact_address_form, :has_required_data).temp_addresses
-      allow_any_instance_of(AddressFinderService).to receive(:search_by_postcode).and_return(address_json)
+      stub_address_finder_service(uprn: "340116")
     end
 
     describe "#submit" do
@@ -16,9 +14,7 @@ module WasteCarriersEngine
         let(:valid_params) { { reg_identifier: contact_address_form.reg_identifier, temp_address: contact_address_form.temp_address } }
 
         it "should submit" do
-          VCR.use_cassette("contact_postcode_form_valid_postcode") do
-            expect(contact_address_form.submit(valid_params)).to eq(true)
-          end
+          expect(contact_address_form.submit(valid_params)).to eq(true)
         end
       end
 
@@ -27,9 +23,7 @@ module WasteCarriersEngine
         let(:invalid_params) { { reg_identifier: "foo" } }
 
         it "should not submit" do
-          VCR.use_cassette("contact_postcode_form_valid_postcode") do
-            expect(contact_address_form.submit(invalid_params)).to eq(false)
-          end
+          expect(contact_address_form.submit(invalid_params)).to eq(false)
         end
       end
     end

--- a/spec/support/address_finder_service_stub_helper.rb
+++ b/spec/support/address_finder_service_stub_helper.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module AddressFinderServiceStubHelper
+  # rubocop:disable Metrics/MethodLength
+  def stub_address_finder_service(options)
+    address_json = [{
+      "moniker" => "340116",
+      "uprn" => "340116",
+      "lines" => ["NATURAL ENGLAND", "DEANERY ROAD"],
+      "town" => "BRISTOL",
+      "postcode" => "BS1 5AH",
+      "easting" => "358205",
+      "northing" => "172708",
+      "country" => "",
+      "dependentLocality" => "",
+      "dependentThroughfare" => "",
+      "administrativeArea" => "BRISTOL",
+      "localAuthorityUpdateDate" => "",
+      "royalMailUpdateDate" => "",
+      "partial" => "NATURAL ENGLAND, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH",
+      "subBuildingName" => "",
+      "buildingName" => "HORIZON HOUSE",
+      "thoroughfareName" => "DEANERY ROAD",
+      "organisationName" => "NATURAL ENGLAND",
+      "buildingNumber" => "",
+      "postOfficeBoxNumber" => "",
+      "departmentName" => "",
+      "doubleDependentLocality" => ""
+    }.merge(options.stringify_keys)]
+
+    allow_any_instance_of(::WasteCarriersEngine::AddressFinderService)
+      .to receive(:search_by_postcode).and_return(address_json)
+  end
+  # rubocop:enable Metrics/MethodLength
+end
+
+RSpec.configure do |config|
+  config.include AddressFinderServiceStubHelper
+end


### PR DESCRIPTION
Externalise the stubs from the factory to an helper method that can be reused across files.