### PR TITLE
Assign correct type to object

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_reference_single_document_in_collection.rb
+++ b/app/models/concerns/waste_carriers_engine/can_reference_single_document_in_collection.rb
@@ -37,7 +37,7 @@ module WasteCarriersEngine
 
         # Assign the params that define this relation to the new object
         find_by.each do |key, value|
-          new_object.public_send("#{key}=", value)
+          new_object[key] = value
         end
 
         # Add new object to the collection

--- a/app/models/concerns/waste_carriers_engine/can_reference_single_document_in_collection.rb
+++ b/app/models/concerns/waste_carriers_engine/can_reference_single_document_in_collection.rb
@@ -35,13 +35,15 @@ module WasteCarriersEngine
         # Remove current object, if present, from the collection
         new_collection -= [public_send(attribute_name)]
 
-        # Assign the params that define this relation to the new object
-        find_by.each do |key, value|
-          new_object[key] = value
-        end
+        if new_object
+          # Assign the params that define this relation to the new object
+          find_by.each do |key, value|
+            new_object[key] = value
+          end
 
-        # Add new object to the collection
-        new_collection << new_object
+          # Add new object to the collection
+          new_collection << new_object
+        end
 
         # Assign the new collection
         public_send("#{collection}=", new_collection)

--- a/app/models/concerns/waste_carriers_engine/can_reference_single_document_in_collection.rb
+++ b/app/models/concerns/waste_carriers_engine/can_reference_single_document_in_collection.rb
@@ -17,7 +17,7 @@ module WasteCarriersEngine
         end
 
         define_method("#{attribute_name}=") do |new_object|
-          assign_attribute(attribute_name, collection, new_object)
+          assign_attribute(attribute_name, collection, new_object, find_by)
         end
       end
     end
@@ -28,12 +28,22 @@ module WasteCarriersEngine
           fetch_attribute(collection, find_by)
       end
 
-      def assign_attribute(attribute_name, collection, new_object)
+      def assign_attribute(attribute_name, collection, new_object, find_by)
+        # Feth the existing collection
         new_collection = public_send(collection) || []
 
+        # Remove current object, if present, from the collection
         new_collection -= [public_send(attribute_name)]
+
+        # Assign the params that define this relation to the new object
+        find_by.each do |key, value|
+          new_object.public_send("#{key}=", value)
+        end
+
+        # Add new object to the collection
         new_collection << new_object
 
+        # Assign the new collection
         public_send("#{collection}=", new_collection)
       end
 

--- a/spec/support/shared_examples/can_reference_single_document_in_collection.rb
+++ b/spec/support/shared_examples/can_reference_single_document_in_collection.rb
@@ -6,7 +6,7 @@ RSpec.shared_examples "Can reference single document in collection" do |subject_
   context "when mass assignment happens" do
     context "when the object to save is not persisted and the number of transactions would be more than one" do
       it "can save a document to MongoDb without throwing an error" do
-        subject.send("#{attribute}=", new_object_for_collection)
+        subject.public_send("#{attribute}=", new_object_for_collection)
         subject.assign_attributes(attribute => new_object_for_collection.clone)
 
         expect { subject.save! }.to_not raise_error
@@ -26,23 +26,29 @@ RSpec.shared_examples "Can reference single document in collection" do |subject_
 
   describe "##{attribute}" do
     it "returns the correct object from the collection" do
-      expect(subject.send(attribute)).to eq(instance_eval(&object_from_collection))
+      expect(subject.public_send(attribute)).to eq(instance_eval(&object_from_collection))
     end
   end
 
   describe "##{attribute}=" do
     it "updates the object's collection with the new object" do
-      expect(subject.send(collection)).to_not include(new_object_for_collection)
+      expect(subject.public_send(collection)).to_not include(new_object_for_collection)
 
-      subject.send("#{attribute}=", new_object_for_collection)
+      subject.public_send("#{attribute}=", new_object_for_collection)
 
-      expect(subject.send(collection)).to include(new_object_for_collection)
+      expect(subject.public_send(collection)).to include(new_object_for_collection)
     end
 
     it "apply correct attributes to new objects so that they can be found back in the collection" do
-      subject.send("#{attribute}=", new_object_for_collection)
+      subject.public_send("#{attribute}=", new_object_for_collection)
 
-      expect(subject.send(attribute)).to eq(new_object_for_collection)
+      expect(subject.public_send(attribute)).to eq(new_object_for_collection)
+    end
+
+    it "can remove the attribute from the collection if assigning nil" do
+      expect { subject.public_send("#{attribute}=", nil) }
+        .to change { subject.public_send(collection).size }
+        .by(-1)
     end
   end
 end

--- a/spec/support/shared_examples/can_reference_single_document_in_collection.rb
+++ b/spec/support/shared_examples/can_reference_single_document_in_collection.rb
@@ -32,14 +32,17 @@ RSpec.shared_examples "Can reference single document in collection" do |subject_
 
   describe "##{attribute}=" do
     it "updates the object's collection with the new object" do
-      size = subject.send(collection).size
-
       expect(subject.send(collection)).to_not include(new_object_for_collection)
 
       subject.send("#{attribute}=", new_object_for_collection)
 
       expect(subject.send(collection)).to include(new_object_for_collection)
-      expect(subject.send(collection).size).to eq(size)
+    end
+
+    it "apply correct attributes to new objects so that they can be found back in the collection" do
+      subject.send("#{attribute}=", new_object_for_collection)
+
+      expect(subject.send(attribute)).to eq(new_object_for_collection)
     end
   end
 end


### PR DESCRIPTION
When assigning an object through a relation defined via CanReferenceSingleDocumentInCollection, we want to make sure that the object is saved and can be retrieved with the same relation defined methods using the filters that define the relation.
Test case added for documentation.