### PR TITLE
Improve metadata status checks

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_change_registration_status.rb
+++ b/app/models/concerns/waste_carriers_engine/can_change_registration_status.rb
@@ -22,6 +22,7 @@ module WasteCarriersEngine
         state :REVOKED
         state :REFUSED
         state :EXPIRED
+        state :INACTIVE
 
         # Transitions
         after_all_transitions :log_status_change

--- a/app/models/concerns/waste_carriers_engine/can_check_registration_status.rb
+++ b/app/models/concerns/waste_carriers_engine/can_check_registration_status.rb
@@ -13,6 +13,10 @@ module WasteCarriersEngine
         metaData.EXPIRED?
       end
 
+      def inactive?
+        metaData.INACTIVE?
+      end
+
       def pending?
         metaData.PENDING?
       end

--- a/app/models/concerns/waste_carriers_engine/can_check_registration_status.rb
+++ b/app/models/concerns/waste_carriers_engine/can_check_registration_status.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  module CanCheckRegistrationStatus
+    extend ActiveSupport::Concern
+
+    included do
+      def active?
+        metaData.ACTIVE?
+      end
+
+      def expired?
+        metaData.EXPIRED?
+      end
+
+      def pending?
+        metaData.PENDING?
+      end
+
+      def refused?
+        metaData.REFUSED?
+      end
+
+      def revoked?
+        metaData.REVOKED?
+      end
+    end
+  end
+end

--- a/app/models/concerns/waste_carriers_engine/can_check_registration_status.rb
+++ b/app/models/concerns/waste_carriers_engine/can_check_registration_status.rb
@@ -5,6 +5,10 @@ module WasteCarriersEngine
     extend ActiveSupport::Concern
 
     included do
+      def status
+        metaData.status.downcase.to_sym
+      end
+
       def active?
         metaData.ACTIVE?
       end

--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -3,6 +3,7 @@
 module WasteCarriersEngine
   class Registration
     include Mongoid::Document
+    include CanCheckRegistrationStatus
     include CanHaveRegistrationAttributes
     include CanGenerateRegIdentifier
 

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -6,6 +6,7 @@ module WasteCarriersEngine
     include Mongoid::Document
     include CanChangeWorkflowStatus
     include CanCheckBusinessTypeChanges
+    include CanCheckRegistrationStatus
     include CanHaveRegistrationAttributes
     include CanStripWhitespace
 

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -497,5 +497,10 @@ module WasteCarriersEngine
                             record_class: WasteCarriersEngine::Registration,
                             factory: :registration
     end
+
+    describe "status" do
+      it_should_behave_like "Can check registration status",
+                            factory: :registration
+    end
   end
 end

--- a/spec/models/waste_carriers_engine/transient_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/transient_registration_spec.rb
@@ -44,6 +44,11 @@ module WasteCarriersEngine
       it_should_behave_like "TransientRegistration named scopes"
     end
 
+    describe "status" do
+      it_should_behave_like "Can check registration status",
+                            factory: :transient_registration
+    end
+
     describe "registration attributes" do
       it_should_behave_like "Can have registration attributes"
     end

--- a/spec/support/shared_examples/can_check_registration_status.rb
+++ b/spec/support/shared_examples/can_check_registration_status.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "Can check registration status" do |factory:|
+  let(:resource) { build(factory, :has_required_data) }
+
+  describe "#active?" do
+    context "when the metadata status is active" do
+      before { resource.metaData.status = "ACTIVE" }
+
+      it "returns true" do
+        expect(resource).to be_active
+      end
+    end
+
+    context "when the metadata status is not active" do
+      before { resource.metaData.status = "PENDING" }
+
+      it "returns false" do
+        expect(resource).to_not be_active
+      end
+    end
+  end
+
+  describe "#expired?" do
+    context "when the metadata status is expired" do
+      before { resource.metaData.status = "EXPIRED" }
+
+      it "returns true" do
+        expect(resource).to be_expired
+      end
+    end
+
+    context "when the metadata status is not expired" do
+      before { resource.metaData.status = "ACTIVE" }
+
+      it "returns false" do
+        expect(resource).to_not be_expired
+      end
+    end
+  end
+
+  describe "#pending?" do
+    context "when the metadata status is pending" do
+      before { resource.metaData.status = "PENDING" }
+
+      it "returns true" do
+        expect(resource).to be_pending
+      end
+    end
+
+    context "when the metadata status is not pending" do
+      before { resource.metaData.status = "ACTIVE" }
+
+      it "returns false" do
+        expect(resource).to_not be_pending
+      end
+    end
+  end
+
+  describe "#refused?" do
+    context "when the metadata status is refused" do
+      before { resource.metaData.status = "REFUSED" }
+
+      it "returns true" do
+        expect(resource).to be_refused
+      end
+    end
+
+    context "when the metadata status is not refused" do
+      before { resource.metaData.status = "ACTIVE" }
+
+      it "returns false" do
+        expect(resource).to_not be_refused
+      end
+    end
+  end
+
+  describe "#revoked?" do
+    context "when the metadata status is revoked" do
+      before { resource.metaData.status = "REVOKED" }
+
+      it "returns true" do
+        expect(resource).to be_revoked
+      end
+    end
+
+    context "when the metadata status is not revoked" do
+      before { resource.metaData.status = "ACTIVE" }
+
+      it "returns false" do
+        expect(resource).to_not be_revoked
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/can_check_registration_status.rb
+++ b/spec/support/shared_examples/can_check_registration_status.rb
@@ -39,6 +39,24 @@ RSpec.shared_examples "Can check registration status" do |factory:|
     end
   end
 
+  describe "#inactive?" do
+    context "when the metadata status is inactive" do
+      before { resource.metaData.status = "INACTIVE" }
+
+      it "returns true" do
+        expect(resource).to be_inactive
+      end
+    end
+
+    context "when the metadata status is not inactive" do
+      before { resource.metaData.status = "ACTIVE" }
+
+      it "returns false" do
+        expect(resource).to_not be_inactive
+      end
+    end
+  end
+
   describe "#pending?" do
     context "when the metadata status is pending" do
       before { resource.metaData.status = "PENDING" }

--- a/spec/support/shared_examples/can_check_registration_status.rb
+++ b/spec/support/shared_examples/can_check_registration_status.rb
@@ -3,6 +3,14 @@
 RSpec.shared_examples "Can check registration status" do |factory:|
   let(:resource) { build(factory, :has_required_data) }
 
+  describe "#status" do
+    before { resource.metaData.status = "ACTIVE" }
+
+    it "outputs a lowercase symbol of the metadata status" do
+      expect(resource.status).to eq(:active)
+    end
+  end
+
   describe "#active?" do
     context "when the metadata status is active" do
       before { resource.metaData.status = "ACTIVE" }


### PR DESCRIPTION
This PR cleans up our status checks on registrations and transient_registrations so we can call something like `registration.active?` instead of `registration.metaData.ACTIVE?` or `registration.metaData.status == "ACTIVE"`.

It also lets us call `registration.status` to get the status in a nicer format - eg `:active`.

Finally, it adds the `INACTIVE` status which we hadn't previously accounted for.

This was suggested in reviews of DEFRA/waste-carriers-back-office#387