### PR TITLE
Add registration.can_start_renewal?

### DIFF
--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -37,7 +37,7 @@ module WasteCarriersEngine
     end
 
     def renewable_status?
-      %w[ACTIVE EXPIRED].include?(metaData.status)
+      active? || expired?
     end
 
     def renewable_date?

--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -24,5 +24,27 @@ module WasteCarriersEngine
 
     validates :tier,
               inclusion: { in: %w[UPPER LOWER] }
+
+    def can_start_renewal?
+      renewable_tier? && renewable_status? && renewable_date?
+    end
+
+    private
+
+    def renewable_tier?
+      tier == "UPPER"
+    end
+
+    def renewable_status?
+      %w[ACTIVE EXPIRED].include?(metaData.status)
+    end
+
+    def renewable_date?
+      check_service = ExpiryCheckService.new(self)
+      return true if check_service.in_expiry_grace_window?
+      return false if check_service.expired?
+
+      check_service.in_renewal_window?
+    end
   end
 end

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -497,5 +497,73 @@ module WasteCarriersEngine
                             record_class: WasteCarriersEngine::Registration,
                             factory: :registration
     end
+
+    describe "#can_start_renewal?" do
+      let(:registration) { build(:registration, :has_required_data) }
+
+      context "when the registration is lower tier" do
+        before { registration.tier = "LOWER" }
+
+        it "returns false" do
+          expect(registration.can_start_renewal?).to eq(false)
+        end
+      end
+
+      context "when the registration is upper tier" do
+        before { registration.tier = "UPPER" }
+
+        context "when the registration has been revoked or refused" do
+          before { registration.metaData.status = %w[REVOKED REFUSED].sample }
+
+          it "returns false" do
+            expect(registration.can_start_renewal?).to eq(false)
+          end
+        end
+
+        context "when the registration has not been revoked or refused" do
+          before { registration.metaData.status = "ACTIVE" }
+
+          context "when the registration is in the grace window" do
+            before { allow_any_instance_of(ExpiryCheckService).to receive(:in_expiry_grace_window?).and_return(true) }
+
+            it "returns true" do
+              expect(registration.can_start_renewal?).to eq(true)
+            end
+          end
+
+          context "when the registration is not in the grace window" do
+            before { allow_any_instance_of(ExpiryCheckService).to receive(:in_expiry_grace_window?).and_return(false) }
+
+            context "when the registration is past the expiry date" do
+              before { allow_any_instance_of(ExpiryCheckService).to receive(:expired?).and_return(true) }
+
+              it "returns false" do
+                expect(registration.can_start_renewal?).to eq(false)
+              end
+            end
+
+            context "when the registration is not past the expiry date" do
+              before { allow_any_instance_of(ExpiryCheckService).to receive(:expired?).and_return(false) }
+
+              context "when the registration is in the renewal window" do
+                before { allow_any_instance_of(ExpiryCheckService).to receive(:in_renewal_window?).and_return(true) }
+
+                it "returns true" do
+                  expect(registration.can_start_renewal?).to eq(true)
+                end
+              end
+
+              context "when the result is not in the renewal window" do
+                before { allow_any_instance_of(ExpiryCheckService).to receive(:in_renewal_window?).and_return(false) }
+
+                it "returns false" do
+                  expect(registration.can_start_renewal?).to eq(false)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This was suggested in reviews of https://github.com/DEFRA/waste-carriers-back-office/pull/385

I opted for `can_start_renewal?` instead of `renewable?` as the conditions for starting and completing a renewal are different, and this seemed like a clearer name.