### PR TITLE
Deal with special characters in search scope

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -83,10 +83,12 @@ module WasteCarriersEngine
       field :total_fee,                                        type: String
 
       scope :search_term, lambda { |term|
-        any_of({ reg_identifier: /\A#{term}\z/i },
-               { company_name: /#{term}/i },
-               { last_name: /#{term}/i },
-               "addresses.postcode": /#{term}/i)
+        escaped_term = Regexp.escape(term) if term.present?
+
+        any_of({ reg_identifier: /\A#{escaped_term}\z/i },
+               { company_name: /#{escaped_term}/i },
+               { last_name: /#{escaped_term}/i },
+               "addresses.postcode": /#{escaped_term}/i)
       }
 
       def charity?

--- a/spec/support/shared_examples/search_scope.rb
+++ b/spec/support/shared_examples/search_scope.rb
@@ -70,5 +70,13 @@ RSpec.shared_examples "Search scopes" do |record_class:, factory:|
         expect(scope).not_to include(non_matching_record)
       end
     end
+
+    context "when the search term has special characters" do
+      let(:term) { "*" }
+
+      it "does not break the search" do
+        expect { scope }.to_not raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-696

This fixes a bug spotted in QA. Our existing search scope did not escape characters that were used in constructing regexes (eg `*`) which resulted in broken searches when the scope attempted to construct its own new regex.

This fix escapes the search term before using it in the regex, which should fix that problem.