### PR TITLE
Fix bug in assigning empty hash

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_reference_single_document_in_collection.rb
+++ b/app/models/concerns/waste_carriers_engine/can_reference_single_document_in_collection.rb
@@ -35,7 +35,7 @@ module WasteCarriersEngine
         # Remove current object, if present, from the collection
         new_collection -= [public_send(attribute_name)]
 
-        if new_object
+        if new_object.present?
           # Assign the params that define this relation to the new object
           find_by.each do |key, value|
             new_object[key] = value

--- a/spec/support/shared_examples/can_reference_single_document_in_collection.rb
+++ b/spec/support/shared_examples/can_reference_single_document_in_collection.rb
@@ -50,5 +50,11 @@ RSpec.shared_examples "Can reference single document in collection" do |subject_
         .to change { subject.public_send(collection).size }
         .by(-1)
     end
+
+    it "can remove the attribute from the collection if assigning empty hash" do
+      expect { subject.public_send("#{attribute}=", {}) }
+        .to change { subject.public_send(collection).size }
+        .by(-1)
+    end
   end
 end


### PR DESCRIPTION
When assigning an empty hash we want the object to be removed from the collection