### PR TITLE
Move setting up of ASSISTED_DIGITAL flag in AASM machine

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_change_workflow_status.rb
+++ b/app/models/concerns/waste_carriers_engine/can_change_workflow_status.rb
@@ -262,14 +262,23 @@ module WasteCarriersEngine
           transitions from: :worldpay_form,
                       to: :renewal_received_form,
                       if: :pending_worldpay_payment_or_convictions_check?,
-                      success: :send_renewal_received_email
+                      success: :send_renewal_received_email,
+                      # TODO: This don't get triggered if in the `success`
+                      # callback block, hence we went for `after`
+                      after: :set_metadata_route
 
           transitions from: :worldpay_form,
-                      to: :renewal_complete_form
+                      to: :renewal_complete_form,
+                      # TODO: This don't get triggered if in the `success`
+                      # callback block, hence we went for `after`
+                      after: :set_metadata_route
 
           transitions from: :bank_transfer_form,
                       to: :renewal_received_form,
-                      success: :send_renewal_received_email
+                      success: :send_renewal_received_email,
+                      # TODO: This don't get triggered if in the `success`
+                      # callback block, hence we went for `after`
+                      after: :set_metadata_route
         end
 
         event :back do

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -153,6 +153,12 @@ module WasteCarriersEngine
       true
     end
 
+    def set_metadata_route
+      metaData.route = Rails.configuration.metadata_route
+
+      save
+    end
+
     private
 
     def copy_data_from_registration

--- a/app/services/waste_carriers_engine/renewal_completion_service.rb
+++ b/app/services/waste_carriers_engine/renewal_completion_service.rb
@@ -54,7 +54,7 @@ module WasteCarriersEngine
     end
 
     def update_meta_data
-      @registration.metaData.route = Rails.configuration.metadata_route
+      @registration.metaData.route = @transient_registration.metaData.route
       @registration.metaData.renew
       @registration.metaData.date_registered = Time.now
       @registration.metaData.date_activated = @registration.metaData.date_registered

--- a/spec/models/waste_carriers_engine/transient_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/transient_registration_spec.rb
@@ -12,6 +12,47 @@ module WasteCarriersEngine
           expect(transient_registration).to have_state(:renewal_start_form)
         end
       end
+
+      context "when transitioning from bank_transfer_form to renewal_received_form succesfully" do
+        it "set the transient registration metadata route" do
+          expect(transient_registration).to receive(:set_metadata_route).once
+
+          transient_registration.update_attributes(workflow_state: :bank_transfer_form)
+          transient_registration.next
+        end
+      end
+
+      context "when transitioning from worldpay_form to renewal_complete_form succesfully" do
+        it "set the transient registration metadata route" do
+          expect(transient_registration).to receive(:set_metadata_route).once
+          expect(transient_registration).to receive(:pending_worldpay_payment_or_convictions_check?).and_return(false)
+
+          transient_registration.update_attributes(workflow_state: :worldpay_form)
+          transient_registration.next
+        end
+      end
+
+      context "when transitioning from worldpay_form to renewal_received_form succesfully" do
+        it "set the transient registration metadata route" do
+          expect(transient_registration).to receive(:set_metadata_route).once
+          expect(transient_registration).to receive(:pending_worldpay_payment_or_convictions_check?).and_return(true)
+
+          transient_registration.update_attributes(workflow_state: :worldpay_form)
+          transient_registration.next
+        end
+      end
+    end
+
+    describe "#set_metadata_route" do
+      it "updates the transient registration's metadata route" do
+        metadata_route = double(:metadata_route)
+
+        expect(Rails.configuration).to receive(:metadata_route).and_return(metadata_route)
+        expect(transient_registration.metaData).to receive(:route=).with(metadata_route)
+        expect(transient_registration).to receive(:save)
+
+        transient_registration.set_metadata_route
+      end
     end
 
     describe "reg_identifier" do

--- a/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
@@ -76,6 +76,16 @@ module WasteCarriersEngine
               expect(response).to redirect_to(new_renewal_complete_form_path(reg_id))
             end
 
+            it "updates the transient registration metadata attributes from application configuration" do
+              allow(Rails.configuration).to receive(:metadata_route).and_return("ASSISTED_DIGITAL")
+
+              expect(transient_registration.reload.metaData.route).to be_nil
+
+              get success_worldpay_forms_path(reg_id), params
+
+              expect(transient_registration.reload.metaData.route).to eq("ASSISTED_DIGITAL")
+            end
+
             context "when it has been flagged for conviction checks" do
               before do
                 transient_registration.conviction_sign_offs = [build(:conviction_sign_off)]
@@ -84,6 +94,16 @@ module WasteCarriersEngine
               it "redirects to renewal_received_form" do
                 get success_worldpay_forms_path(reg_id), params
                 expect(response).to redirect_to(new_renewal_received_form_path(reg_id))
+              end
+
+              it "updates the transient registration metadata attributes from application configuration" do
+                allow(Rails.configuration).to receive(:metadata_route).and_return("ASSISTED_DIGITAL")
+
+                expect(transient_registration.reload.metaData.route).to be_nil
+
+                get success_worldpay_forms_path(reg_id), params
+
+                expect(transient_registration.reload.metaData.route).to eq("ASSISTED_DIGITAL")
               end
 
               context "when the mailer fails" do

--- a/spec/services/waste_carriers_engine/renewal_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/renewal_completion_service_spec.rb
@@ -63,6 +63,14 @@ module WasteCarriersEngine
           expect(registration.reload.finance_details.payments).to include(new_payment)
         end
 
+        it "copies the registration's route from the transient_registration to the registration" do
+          transient_registration.metaData.route = "ASSISTED_DIGITAL_FROM_TRANSIENT_REGISTRATION"
+
+          renewal_completion_service.complete_renewal
+
+          expect(registration.reload.metaData.route).to eq("ASSISTED_DIGITAL_FROM_TRANSIENT_REGISTRATION")
+        end
+
         it "keeps existing orders" do
           old_order = registration.finance_details.orders.first
           renewal_completion_service.complete_renewal
@@ -145,17 +153,6 @@ module WasteCarriersEngine
           last_name = transient_registration.last_name
           renewal_completion_service.complete_renewal
           expect(registration.reload.contact_address.last_name).to eq(last_name)
-        end
-
-        context "when the metadata_route is set" do
-          before do
-            allow(Rails.configuration).to receive(:metadata_route).and_return("ASSISTED_DIGITAL")
-          end
-
-          it "updates the registration's route to the correct value" do
-            renewal_completion_service.complete_renewal
-            expect(registration.reload.metaData.route).to eq("ASSISTED_DIGITAL")
-          end
         end
 
         it "deletes the transient registration" do


### PR DESCRIPTION
Solve: https://eaflood.atlassian.net/browse/RUBY-718

We used the `RenewalCompletionService` to setup the metaData route of the transient_registration to the correct application-level configuration of `ASSISTED_DIGITAL` vs `DIGITAL`.
This was causing some registration to be incorrectly flagged as `ASSISTED_DIGITAL`, because the same service is run in the back-office application when a conviction check or payment check have been completed.
In order to make sure that we only flag the registration at the end of the forms workflow, we have moved the setting from the Service to the workflow AASM state machine.