### PR TITLE
Add pending_manual_conviction_check? method to registration

### DIFF
--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -26,12 +26,10 @@ module WasteCarriersEngine
     validates :tier,
               inclusion: { in: %w[UPPER LOWER] }
 
+    alias pending_manual_conviction_check? conviction_check_required?
+
     def can_start_renewal?
       renewable_tier? && renewable_status? && renewable_date?
-    end
-
-    def pending_manual_conviction_check?
-      conviction_check_required?
     end
 
     private

--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -30,6 +30,10 @@ module WasteCarriersEngine
       renewable_tier? && renewable_status? && renewable_date?
     end
 
+    def pending_manual_conviction_check?
+      conviction_check_required?
+    end
+
     private
 
     def renewable_tier?

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -16,15 +16,16 @@ FactoryBot.define do
 
       metaData { build(:metaData, :has_required_data) }
 
-      addresses do
-        [build(:address, :has_required_data, :contact, :from_os_places),
-         build(:address, :has_required_data, :registered, :from_os_places)]
-      end
+      has_addresses
 
       key_people do
         [build(:key_person, :has_required_data, :main),
          build(:key_person, :has_required_data, :relevant)]
       end
+    end
+
+    trait :has_addresses do
+      addresses { [build(:address, :has_required_data, :registered, :from_os_places), build(:address, :has_required_data, :contact, :from_os_places)] }
     end
 
     trait :has_required_overseas_data do

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -570,5 +570,10 @@ module WasteCarriersEngine
       it_should_behave_like "Can check registration status",
                             factory: :registration
     end
+
+    describe "registration attributes" do
+      it_should_behave_like "Can have registration attributes",
+                            factory: :registration
+    end
   end
 end

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -566,26 +566,6 @@ module WasteCarriersEngine
       end
     end
 
-    describe "#pending_manual_conviction_check?" do
-      let(:registration) { build(:registration) }
-
-      context "when the registration requires a conviction check" do
-        before { allow(registration).to receive(:conviction_check_required?).and_return(true) }
-
-        it "returns true" do
-          expect(registration.pending_manual_conviction_check?).to eq(true)
-        end
-      end
-
-      context "when the registration does not require a conviction check" do
-        before { allow(registration).to receive(:conviction_check_required?).and_return(false) }
-
-        it "returns false" do
-          expect(registration.pending_manual_conviction_check?).to eq(false)
-        end
-      end
-    end
-
     describe "status" do
       it_should_behave_like "Can check registration status",
                             factory: :registration

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -566,6 +566,26 @@ module WasteCarriersEngine
       end
     end
 
+    describe "#pending_manual_conviction_check?" do
+      let(:registration) { build(:registration) }
+
+      context "when the registration requires a conviction check" do
+        before { allow(registration).to receive(:conviction_check_required?).and_return(true) }
+
+        it "returns true" do
+          expect(registration.pending_manual_conviction_check?).to eq(true)
+        end
+      end
+
+      context "when the registration does not require a conviction check" do
+        before { allow(registration).to receive(:conviction_check_required?).and_return(false) }
+
+        it "returns false" do
+          expect(registration.pending_manual_conviction_check?).to eq(false)
+        end
+      end
+    end
+
     describe "status" do
       it_should_behave_like "Can check registration status",
                             factory: :registration

--- a/spec/models/waste_carriers_engine/transient_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/transient_registration_spec.rb
@@ -50,7 +50,8 @@ module WasteCarriersEngine
     end
 
     describe "registration attributes" do
-      it_should_behave_like "Can have registration attributes"
+      it_should_behave_like "Can have registration attributes",
+                            factory: :transient_registration
     end
 
     describe "#initialize" do

--- a/spec/support/shared_examples/can_have_registration_attributes.rb
+++ b/spec/support/shared_examples/can_have_registration_attributes.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples "Can have registration attributes" do
+RSpec.shared_examples "Can have registration attributes" do |factory:|
   include_examples(
     "Can reference single document in collection",
-    proc { create(:transient_registration, :has_required_data, :has_addresses) },
+    proc { create(factory, :has_required_data, :has_addresses) },
     :contact_address,
     proc { subject.addresses.find_by(address_type: "POSTAL") },
     WasteCarriersEngine::Address.new,
     :addresses
   )
 
-  describe "#charity?" do
-    let(:transient_registration) { build(:transient_registration) }
+  let(:resource) { build(factory) }
 
+  describe "#charity?" do
     test_values = {
       charity: true,
       limitedCompany: false
@@ -21,8 +21,8 @@ RSpec.shared_examples "Can have registration attributes" do
     test_values.each do |business_type, result|
       context "when the 'business_type' is '#{business_type}'" do
         it "returns #{result}" do
-          transient_registration.business_type = business_type.to_s
-          expect(transient_registration.charity?).to eq(result)
+          resource.business_type = business_type.to_s
+          expect(resource.charity?).to eq(result)
         end
       end
     end
@@ -30,27 +30,25 @@ RSpec.shared_examples "Can have registration attributes" do
 
   describe "#contact_address" do
     let(:contact_address) { build(:address, :contact) }
-    let(:transient_registration) { build(:transient_registration, addresses: [contact_address]) }
+    let(:resource) { build(factory, addresses: [contact_address]) }
 
     it "returns the address of type contact" do
-      expect(transient_registration.contact_address).to eq(contact_address)
+      expect(resource.contact_address).to eq(contact_address)
     end
   end
 
   describe "#contact_address=" do
     let(:contact_address) { build(:address) }
-    let(:transient_registration) { build(:transient_registration, addresses: []) }
+    let(:resource) { build(factory, addresses: []) }
 
     it "set an address of type contact" do
-      transient_registration.contact_address = contact_address
+      resource.contact_address = contact_address
 
-      expect(transient_registration.addresses).to eq([contact_address])
+      expect(resource.addresses).to eq([contact_address])
     end
   end
 
   describe "#company_no_required?" do
-    let(:transient_registration) { build(:transient_registration) }
-
     test_values = {
       limitedCompany: true,
       limitedLiabilityPartnership: true,
@@ -60,8 +58,8 @@ RSpec.shared_examples "Can have registration attributes" do
     test_values.each do |business_type, result|
       context "when the 'business_type' is '#{business_type}'" do
         it "returns #{result}" do
-          transient_registration.business_type = business_type.to_s
-          expect(transient_registration.company_no_required?).to eq(result)
+          resource.business_type = business_type.to_s
+          expect(resource.company_no_required?).to eq(result)
         end
       end
     end
@@ -70,36 +68,36 @@ RSpec.shared_examples "Can have registration attributes" do
   describe "#conviction_check_approved?" do
     context "when there are no conviction_sign_offs" do
       before do
-        transient_registration.conviction_sign_offs = nil
+        resource.conviction_sign_offs = nil
       end
 
       it "returns false" do
-        expect(transient_registration.conviction_check_approved?).to eq(false)
+        expect(resource.conviction_check_approved?).to eq(false)
       end
     end
 
     context "when there is a conviction_sign_off" do
       before do
-        transient_registration.conviction_sign_offs = [build(:conviction_sign_off)]
+        resource.conviction_sign_offs = [build(:conviction_sign_off)]
       end
 
       context "when confirmed is no" do
         before do
-          transient_registration.conviction_sign_offs.first.confirmed = "no"
+          resource.conviction_sign_offs.first.confirmed = "no"
         end
 
         it "returns false" do
-          expect(transient_registration.conviction_check_approved?).to eq(false)
+          expect(resource.conviction_check_approved?).to eq(false)
         end
       end
 
       context "when confirmed is yes" do
         before do
-          transient_registration.conviction_sign_offs.first.confirmed = "yes"
+          resource.conviction_sign_offs.first.confirmed = "yes"
         end
 
         it "returns true" do
-          expect(transient_registration.conviction_check_approved?).to eq(true)
+          expect(resource.conviction_check_approved?).to eq(true)
         end
       end
     end

--- a/spec/support/shared_examples/can_have_registration_attributes.rb
+++ b/spec/support/shared_examples/can_have_registration_attributes.rb
@@ -144,41 +144,41 @@ RSpec.shared_examples "Can have registration attributes" do |factory:|
   describe "#unpaid_balance?" do
     context do
       before do
-        transient_registration.finance_details = nil
+        resource.finance_details = nil
       end
 
       it "returns false" do
-        expect(transient_registration.unpaid_balance?).to eq(false)
+        expect(resource.unpaid_balance?).to eq(false)
       end
     end
 
     context "when the balance is 0" do
       before do
-        transient_registration.finance_details = build(:finance_details, balance: 0)
+        resource.finance_details = build(:finance_details, balance: 0)
       end
 
       it "returns false" do
-        expect(transient_registration.unpaid_balance?).to eq(false)
+        expect(resource.unpaid_balance?).to eq(false)
       end
     end
 
     context "when the balance is negative" do
       before do
-        transient_registration.finance_details = build(:finance_details, balance: -1)
+        resource.finance_details = build(:finance_details, balance: -1)
       end
 
       it "returns false" do
-        expect(transient_registration.unpaid_balance?).to eq(false)
+        expect(resource.unpaid_balance?).to eq(false)
       end
     end
 
     context "when the balance is positive" do
       before do
-        transient_registration.finance_details = build(:finance_details, balance: 1)
+        resource.finance_details = build(:finance_details, balance: 1)
       end
 
       it "returns true" do
-        expect(transient_registration.unpaid_balance?).to eq(true)
+        expect(resource.unpaid_balance?).to eq(true)
       end
     end
   end

--- a/spec/support/shared_examples/can_have_registration_attributes.rb
+++ b/spec/support/shared_examples/can_have_registration_attributes.rb
@@ -65,6 +65,44 @@ RSpec.shared_examples "Can have registration attributes" do |factory:|
     end
   end
 
+  describe "#conviction_check_required?" do
+    context "when there are no conviction_sign_offs" do
+      before do
+        resource.conviction_sign_offs = nil
+      end
+
+      it "returns false" do
+        expect(resource.conviction_check_required?).to eq(false)
+      end
+    end
+
+    context "when there is a conviction_sign_off" do
+      before do
+        resource.conviction_sign_offs = [build(:conviction_sign_off)]
+      end
+
+      context "when confirmed is yes" do
+        before do
+          resource.conviction_sign_offs.first.confirmed = "yes"
+        end
+
+        it "returns false" do
+          expect(resource.conviction_check_required?).to eq(false)
+        end
+      end
+
+      context "when confirmed is no" do
+        before do
+          resource.conviction_sign_offs.first.confirmed = "no"
+        end
+
+        it "returns true" do
+          expect(resource.conviction_check_required?).to eq(true)
+        end
+      end
+    end
+  end
+
   describe "#conviction_check_approved?" do
     context "when there are no conviction_sign_offs" do
       before do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-704

This may seem redundant, but it means that registrations and transient_registrations have the same interface, which will simplify the checks for the back office dashboard.