### PR TITLE
Use helpers on shared methods in rspec test suite

### DIFF
--- a/spec/support/form_request_helpers.rb
+++ b/spec/support/form_request_helpers.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module FormRequestHelpers
+  def post_form_with_params(form, params)
+    post create_path_for(form), params_for_form(form, params)
+  end
+
+  # Should call a method like location_forms_path
+  def create_path_for(form)
+    send("#{form}s_path")
+  end
+
+  # Should output a hash like { location_forms: params }
+  def params_for_form(form, params)
+    hash = {}
+    hash[form.to_sym] = params
+    hash
+  end
+end
+
+RSpec.configure do |config|
+  config.include FormRequestHelpers
+end

--- a/spec/support/shared_examples/post_form.rb
+++ b/spec/support/shared_examples/post_form.rb
@@ -31,12 +31,12 @@ RSpec.shared_examples "POST form" do |form, options|
       end
 
       it "redirects to the renewal_start_form" do
-        post_with_params(form, params)
+        post_form_with_params(form, params)
         expect(response).to redirect_to(new_renewal_start_form_path(registration[:reg_identifier]))
       end
 
       it "does not create a transient registration" do
-        post_with_params(form, params)
+        post_form_with_params(form, params)
         matching_transient_regs = WasteCarriersEngine::TransientRegistration.where(reg_identifier: registration.reg_identifier)
         expect(matching_transient_regs.length).to eq(0)
       end
@@ -61,18 +61,18 @@ RSpec.shared_examples "POST form" do |form, options|
             # Otherwise, expect the value submitted in params
             expected_value = valid_params[test_attribute] unless expected_value.present?
 
-            post_with_params(form, valid_params)
+            post_form_with_params(form, valid_params)
             expect(transient_registration.reload[test_attribute]).to eq(expected_value)
           end
 
           it "changes the workflow_state" do
             state_before_request = transient_registration[:workflow_state]
-            post_with_params(form, valid_params)
+            post_form_with_params(form, valid_params)
             expect(transient_registration.reload[:workflow_state]).to_not eq(state_before_request)
           end
 
           it "redirects to the next page" do
-            post_with_params(form, valid_params)
+            post_form_with_params(form, valid_params)
             expect(response).to have_http_status(302)
           end
         end
@@ -84,12 +84,12 @@ RSpec.shared_examples "POST form" do |form, options|
 
           it "does not update the transient registration, including workflow_state" do
             transient_reg_before_submitting = transient_registration
-            post_with_params(form, invalid_params)
+            post_form_with_params(form, invalid_params)
             expect(transient_registration.reload).to eq(transient_reg_before_submitting)
           end
 
           it "show the form again" do
-            post_with_params(form, invalid_params)
+            post_form_with_params(form, invalid_params)
             expect(response).to render_template("#{form}s/new")
           end
         end
@@ -98,7 +98,7 @@ RSpec.shared_examples "POST form" do |form, options|
           it "does not throw an error" do
             # rubocop:disable Style/BlockDelimiters
             expect {
-              post_with_params(form, reg_identifier: transient_registration.reg_identifier)
+              post_form_with_params(form, reg_identifier: transient_registration.reg_identifier)
             }.not_to raise_error
             # rubocop:enable Style/BlockDelimiters
           end
@@ -111,12 +111,12 @@ RSpec.shared_examples "POST form" do |form, options|
 
           it "does not update the transient_registration, including workflow_state" do
             transient_reg_before_submitting = transient_registration
-            post_with_params(form, valid_params)
+            post_form_with_params(form, valid_params)
             expect(transient_registration.reload).to eq(transient_reg_before_submitting)
           end
 
           it "redirects to the invalid reg_identifier error page" do
-            post_with_params(form, valid_params)
+            post_form_with_params(form, valid_params)
             expect(response).to redirect_to(page_path("invalid"))
           end
         end
@@ -126,12 +126,12 @@ RSpec.shared_examples "POST form" do |form, options|
 
           it "does not update the transient registration, including workflow_state" do
             transient_reg_before_submitting = transient_registration
-            post_with_params(form, valid_params)
+            post_form_with_params(form, valid_params)
             expect(transient_registration.reload).to eq(transient_reg_before_submitting)
           end
 
           it "redirects to the unrenewable error page" do
-            post_with_params(form, valid_params)
+            post_form_with_params(form, valid_params)
             expect(response).to redirect_to(page_path("unrenewable"))
           end
         end
@@ -154,38 +154,22 @@ RSpec.shared_examples "POST form" do |form, options|
 
         it "does not update the transient_registration, including workflow_state" do
           transient_reg_before_submitting = transient_registration
-          post_with_params(form, valid_params)
+          post_form_with_params(form, valid_params)
           expect(transient_registration.reload).to eq(transient_reg_before_submitting)
         end
 
         it "redirects to the correct form for the workflow_state" do
           workflow_state = transient_registration[:workflow_state]
-          post_with_params(form, valid_params)
+          post_form_with_params(form, valid_params)
           expect(response).to redirect_to(new_path_for(workflow_state, transient_registration))
         end
       end
     end
   end
 
-  def post_with_params(form, params)
-    post create_path_for(form), params_for_form(form, params)
-  end
-
-  # Should call a method like location_forms_path
-  def create_path_for(form)
-    send("#{form}s_path")
-  end
-
   # Should call a method like new_location_form_path("CBDU1234")
   def new_path_for(form, transient_registration)
     reg_id = transient_registration[:reg_identifier] if transient_registration.present?
     send("new_#{form}_path", reg_id)
-  end
-
-  # Should output a hash like { location_forms: params }
-  def params_for_form(form, params)
-    hash = {}
-    hash[form.to_sym] = params
-    hash
   end
 end

--- a/spec/support/shared_examples/request_post_no_params_form.rb
+++ b/spec/support/shared_examples/request_post_no_params_form.rb
@@ -26,12 +26,12 @@ RSpec.shared_examples "POST without params form" do |form|
       end
 
       it "redirects to the renewal_start_form" do
-        post_with_params(form, params)
+        post_form_with_params(form, params)
         expect(response).to redirect_to(new_renewal_start_form_path(registration[:reg_identifier]))
       end
 
       it "does not create a transient registration" do
-        post_with_params(form, params)
+        post_form_with_params(form, params)
         matching_transient_regs = WasteCarriersEngine::TransientRegistration.where(reg_identifier: registration.reg_identifier)
         expect(matching_transient_regs.length).to eq(0)
       end
@@ -59,12 +59,12 @@ RSpec.shared_examples "POST without params form" do |form|
         context "when the params are valid" do
           it "changes the workflow_state" do
             state_before_request = transient_registration[:workflow_state]
-            post_with_params(form, params)
+            post_form_with_params(form, params)
             expect(transient_registration.reload[:workflow_state]).to_not eq(state_before_request)
           end
 
           it "redirects to the next page" do
-            post_with_params(form, params)
+            post_form_with_params(form, params)
             expect(response).to have_http_status(302)
           end
         end
@@ -76,12 +76,12 @@ RSpec.shared_examples "POST without params form" do |form|
 
           it "does not update the transient_registration, including workflow_state" do
             transient_reg_before_submitting = transient_registration
-            post_with_params(form, params)
+            post_form_with_params(form, params)
             expect(transient_registration.reload).to eq(transient_reg_before_submitting)
           end
 
           it "redirects to the invalid reg_identifier error page" do
-            post_with_params(form, params)
+            post_form_with_params(form, params)
             expect(response).to redirect_to(page_path("invalid"))
           end
         end
@@ -91,12 +91,12 @@ RSpec.shared_examples "POST without params form" do |form|
 
           it "does not update the transient registration, including workflow_state" do
             transient_reg_before_submitting = transient_registration
-            post_with_params(form, params)
+            post_form_with_params(form, params)
             expect(transient_registration.reload).to eq(transient_reg_before_submitting)
           end
 
           it "redirects to the unrenewable error page" do
-            post_with_params(form, params)
+            post_form_with_params(form, params)
             expect(response).to redirect_to(page_path("unrenewable"))
           end
         end
@@ -119,38 +119,16 @@ RSpec.shared_examples "POST without params form" do |form|
 
         it "does not update the transient_registration, including workflow_state" do
           transient_reg_before_submitting = transient_registration
-          post_with_params(form, params)
+          post_form_with_params(form, params)
           expect(transient_registration.reload).to eq(transient_reg_before_submitting)
         end
 
         it "redirects to the correct form for the workflow_state" do
           workflow_state = transient_registration[:workflow_state]
-          post_with_params(form, params)
+          post_form_with_params(form, params)
           expect(response).to redirect_to(new_path_for(workflow_state, transient_registration))
         end
       end
     end
-  end
-
-  def post_with_params(form, params)
-    post create_path_for(form), params_for_form(form, params)
-  end
-
-  # Should call a method like location_forms_path
-  def create_path_for(form)
-    send("#{form}s_path")
-  end
-
-  # Should call a method like new_location_form_path("CBDU1234")
-  def new_path_for(form, transient_registration)
-    reg_id = transient_registration[:reg_identifier] if transient_registration.present?
-    send("new_#{form}_path", reg_id)
-  end
-
-  # Should output a hash like { location_forms: params }
-  def params_for_form(form, params)
-    hash = {}
-    hash[form.to_sym] = params
-    hash
   end
 end


### PR DESCRIPTION
Little refactoring to externalise the logic of `post_with_params` in a shared helper