### PR TITLE
Stop validating worldpay source param

### DIFF
--- a/app/services/waste_carriers_engine/worldpay_validator_service.rb
+++ b/app/services/waste_carriers_engine/worldpay_validator_service.rb
@@ -56,8 +56,7 @@ module WasteCarriersEngine
       valid_mac? &&
         valid_order_key_format? &&
         valid_payment_amount? &&
-        valid_currency? &&
-        valid_source?
+        valid_currency?
     end
 
     # For the most up-to-date guidance about validating the MAC, see:
@@ -98,13 +97,6 @@ module WasteCarriersEngine
       return true if @currency == @order.currency
 
       Rails.logger.error "Invalid WorldPay response: #{@currency} is not valid currency"
-      false
-    end
-
-    def valid_source?
-      return true if @source == "WP"
-
-      Rails.logger.error "Invalid WorldPay response: #{@source} is not valid source"
       false
     end
 

--- a/spec/services/waste_carriers_engine/worldpay_validator_service_spec.rb
+++ b/spec/services/waste_carriers_engine/worldpay_validator_service_spec.rb
@@ -112,16 +112,6 @@ module WasteCarriersEngine
           expect(worldpay_validator_service.valid_success?).to eq(false)
         end
       end
-
-      context "when the source is invalid" do
-        before do
-          params[:source] = "foo"
-        end
-
-        it "returns false" do
-          expect(worldpay_validator_service.valid_success?).to eq(false)
-        end
-      end
     end
 
     describe "valid_failure?" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-729

We are soon to switch to Worldpay's new hosted pages service and have been conducting a series of testing.

We found there is a difference between the worldpay test and production environments when it comes to the new hosted pages. In the test environment the `source` param is no longer returned, but it is in production.

We've spoken with worldpay and it is not seen as something that needs to be verified as having been returned to ensure the worldpay response is valid. In fact our older frontend project does not check for the `source` param.

On this basis, and so we can move forward with moving to the new Worldpay hosted pages, this change remove the source param validation.