### PR TITLE
Create model for conviction entities

### DIFF
--- a/app/models/waste_carriers_engine/convictions_check/entity.rb
+++ b/app/models/waste_carriers_engine/convictions_check/entity.rb
@@ -19,9 +19,11 @@ module WasteCarriersEngine
       field :incidentNumber, as: :incident_number, type: String
 
       scope :matching_organisation_name, lambda { |term|
-        term = ::Regexp.escape(term) if term.present?
+        escaped_term = ::Regexp.escape(term) if term.present?
+        # If the name ends with a full stop, treat that as optional in the regex
+        term_with_optional_trailing_full_stop = escaped_term.gsub(/\.$/, ".?") if escaped_term.present?
 
-        where(name: /#{term}/i)
+        where(name: /#{term_with_optional_trailing_full_stop}/i)
       }
 
       scope :matching_person_name, lambda { |first_name:, last_name:|

--- a/app/models/waste_carriers_engine/convictions_check/entity.rb
+++ b/app/models/waste_carriers_engine/convictions_check/entity.rb
@@ -35,9 +35,8 @@ module WasteCarriersEngine
         results.uniq
       end
 
-      def self.matching_people(term)
-        results = matching_name(term)
-        results += matching_date_of_birth(term) if term.is_a?(Date)
+      def self.matching_people(name:, date_of_birth:)
+        results = matching_name(name) + matching_date_of_birth(date_of_birth)
         results.uniq
       end
     end

--- a/app/models/waste_carriers_engine/convictions_check/entity.rb
+++ b/app/models/waste_carriers_engine/convictions_check/entity.rb
@@ -17,6 +17,18 @@ module WasteCarriersEngine
       field :systemFlag, as: :system_flag,         type: String
       # The incident number or reference code
       field :incidentNumber, as: :incident_number, type: String
+
+      scope :matching_name, lambda { |term|
+        where(name: term)
+      }
+
+      scope :matching_date_of_birth, lambda { |term|
+        where(date_of_birth: term)
+      }
+
+      scope :matching_company_number, lambda { |term|
+        where(company_number: term)
+      }
     end
   end
 end

--- a/app/models/waste_carriers_engine/convictions_check/entity.rb
+++ b/app/models/waste_carriers_engine/convictions_check/entity.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  module ConvictionsCheck
+    class Entity
+      include Mongoid::Document
+
+      store_in collection: "entities"
+
+      # The full name, either of an organisation or an individual
+      field :name,                                 type: String
+      # Only used for individuals - may not be known or available
+      field :dateOfBirth, as: :date_of_birth,      type: Date
+      # Only used for organisations, if applicable
+      field :companyNumber, as: :company_number,   type: String
+      # The system where the match is from
+      field :systemFlag, as: :system_flag,         type: String
+      # The incident number or reference code
+      field :incidentNumber, as: :incident_number, type: String
+    end
+  end
+end

--- a/app/models/waste_carriers_engine/convictions_check/entity.rb
+++ b/app/models/waste_carriers_engine/convictions_check/entity.rb
@@ -34,6 +34,12 @@ module WasteCarriersEngine
         results = matching_name(term) + matching_company_number(term)
         results.uniq
       end
+
+      def self.matching_people(term)
+        results = matching_name(term)
+        results += matching_date_of_birth(term) if term.is_a?(Date)
+        results.uniq
+      end
     end
   end
 end

--- a/app/models/waste_carriers_engine/convictions_check/entity.rb
+++ b/app/models/waste_carriers_engine/convictions_check/entity.rb
@@ -37,8 +37,10 @@ module WasteCarriersEngine
 
       scope :matching_company_number, lambda { |term|
         escaped_term = ::Regexp.escape(term) if term.present?
+        # If the company_no starts with a 0, treat that 0 as optional in the regex
+        term_with_optional_starting_zero = escaped_term.gsub(/^0/, "0?") if escaped_term.present?
 
-        where(company_number: /#{escaped_term}/i)
+        where(company_number: /#{term_with_optional_starting_zero}/i)
       }
 
       scope :matching_people, lambda { |first_name:, last_name:, date_of_birth:|

--- a/app/models/waste_carriers_engine/convictions_check/entity.rb
+++ b/app/models/waste_carriers_engine/convictions_check/entity.rb
@@ -18,10 +18,17 @@ module WasteCarriersEngine
       # The incident number or reference code
       field :incidentNumber, as: :incident_number, type: String
 
-      scope :matching_name, lambda { |term|
-        escaped_term = ::Regexp.escape(term) if term.present?
+      scope :matching_organisation_name, lambda { |term|
+        term = ::Regexp.escape(term) if term.present?
 
-        where(name: /#{escaped_term}/i)
+        where(name: /#{term}/i)
+      }
+
+      scope :matching_person_name, lambda { |first_name:, last_name:|
+        escaped_first_name = ::Regexp.escape(first_name) if first_name.present?
+        escaped_last_name = ::Regexp.escape(last_name) if last_name.present?
+
+        where(name: /#{escaped_first_name}/i).and(name: /#{escaped_last_name}/i)
       }
 
       scope :matching_date_of_birth, lambda { |term|
@@ -35,12 +42,13 @@ module WasteCarriersEngine
       }
 
       def self.matching_organisations(name:, company_no: nil)
-        results = matching_name(name) + matching_company_number(company_no)
+        results = matching_organisation_name(name) + matching_company_number(company_no)
         results.uniq
       end
 
-      def self.matching_people(name:, date_of_birth:)
-        results = matching_name(name) + matching_date_of_birth(date_of_birth)
+      def self.matching_people(first_name:, last_name:, date_of_birth:)
+        results = matching_person_name(first_name: first_name, last_name: last_name) +
+                  matching_date_of_birth(date_of_birth)
         results.uniq
       end
     end

--- a/app/models/waste_carriers_engine/convictions_check/entity.rb
+++ b/app/models/waste_carriers_engine/convictions_check/entity.rb
@@ -29,6 +29,11 @@ module WasteCarriersEngine
       scope :matching_company_number, lambda { |term|
         where(company_number: term)
       }
+
+      def self.matching_organisations(term)
+        results = matching_name(term) + matching_company_number(term)
+        results.uniq
+      end
     end
   end
 end

--- a/app/models/waste_carriers_engine/convictions_check/entity.rb
+++ b/app/models/waste_carriers_engine/convictions_check/entity.rb
@@ -30,8 +30,8 @@ module WasteCarriersEngine
         where(company_number: term)
       }
 
-      def self.matching_organisations(term)
-        results = matching_name(term) + matching_company_number(term)
+      def self.matching_organisations(name:, company_no: nil)
+        results = matching_name(name) + matching_company_number(company_no)
         results.uniq
       end
 

--- a/app/models/waste_carriers_engine/convictions_check/entity.rb
+++ b/app/models/waste_carriers_engine/convictions_check/entity.rb
@@ -19,7 +19,9 @@ module WasteCarriersEngine
       field :incidentNumber, as: :incident_number, type: String
 
       scope :matching_name, lambda { |term|
-        where(name: term)
+        escaped_term = ::Regexp.escape(term) if term.present?
+
+        where(name: /#{escaped_term}/i)
       }
 
       scope :matching_date_of_birth, lambda { |term|
@@ -27,7 +29,9 @@ module WasteCarriersEngine
       }
 
       scope :matching_company_number, lambda { |term|
-        where(company_number: term)
+        escaped_term = ::Regexp.escape(term) if term.present?
+
+        where(company_number: /#{escaped_term}/i)
       }
 
       def self.matching_organisations(name:, company_no: nil)

--- a/app/models/waste_carriers_engine/convictions_check/entity.rb
+++ b/app/models/waste_carriers_engine/convictions_check/entity.rb
@@ -40,7 +40,7 @@ module WasteCarriersEngine
         # If the company_no starts with a 0, treat that 0 as optional in the regex
         term_with_optional_starting_zero = escaped_term.gsub(/^0/, "0?") if escaped_term.present?
 
-        where(company_number: /#{term_with_optional_starting_zero}/i)
+        where(company_number: /^#{term_with_optional_starting_zero}$/i)
       }
 
       scope :matching_people, lambda { |first_name:, last_name:, date_of_birth:|

--- a/app/models/waste_carriers_engine/convictions_check/entity.rb
+++ b/app/models/waste_carriers_engine/convictions_check/entity.rb
@@ -41,14 +41,12 @@ module WasteCarriersEngine
         where(company_number: /#{escaped_term}/i)
       }
 
+      scope :matching_people, lambda { |first_name:, last_name:, date_of_birth:|
+        matching_person_name(first_name: first_name, last_name: last_name).matching_date_of_birth(date_of_birth)
+      }
+
       def self.matching_organisations(name:, company_no: nil)
         results = matching_organisation_name(name) + matching_company_number(company_no)
-        results.uniq
-      end
-
-      def self.matching_people(first_name:, last_name:, date_of_birth:)
-        results = matching_person_name(first_name: first_name, last_name: last_name) +
-                  matching_date_of_birth(date_of_birth)
         results.uniq
       end
     end

--- a/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
+++ b/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
@@ -63,20 +63,22 @@ module WasteCarriersEngine
         let(:term) { "foo" }
         let(:non_matching_term) { "bar" }
 
+        let(:results) { described_class.matching_organisations(name: term, company_no: term) }
+
         it "returns records with matching names" do
           matching_record = described_class.create(name: term)
           non_matching_record = described_class.create(name: non_matching_term)
 
-          expect(described_class.matching_organisations(term)).to include(matching_record)
-          expect(described_class.matching_organisations(term)).to_not include(non_matching_record)
+          expect(results).to include(matching_record)
+          expect(results).to_not include(non_matching_record)
         end
 
         it "returns records with matching company_numbers" do
           matching_record = described_class.create(company_number: term)
           non_matching_record = described_class.create(company_number: non_matching_term)
 
-          expect(described_class.matching_organisations(term)).to include(matching_record)
-          expect(described_class.matching_organisations(term)).to_not include(non_matching_record)
+          expect(results).to include(matching_record)
+          expect(results).to_not include(non_matching_record)
         end
 
         it "does not return records with matching date_of_births" do
@@ -86,8 +88,16 @@ module WasteCarriersEngine
           matching_record = described_class.create(date_of_birth: term)
           non_matching_record = described_class.create(date_of_birth: non_matching_term)
 
-          expect(described_class.matching_organisations(term)).to_not include(matching_record)
-          expect(described_class.matching_organisations(term)).to_not include(non_matching_record)
+          expect(results).to_not include(matching_record)
+          expect(results).to_not include(non_matching_record)
+        end
+
+        it "allows company_no to be missing" do
+          expect { described_class.matching_organisations(name: term) }.to_not raise_error
+        end
+
+        it "does not allow name to be missing" do
+          expect { described_class.matching_organisations(company_no: term) }.to raise_error { ArgumentError }
         end
       end
 

--- a/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
+++ b/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
@@ -58,6 +58,38 @@ module WasteCarriersEngine
           end
         end
       end
+
+      describe "#matching_organisations" do
+        let(:term) { "foo" }
+        let(:non_matching_term) { "bar" }
+
+        it "returns records with matching names" do
+          matching_record = described_class.create(name: term)
+          non_matching_record = described_class.create(name: non_matching_term)
+
+          expect(described_class.matching_organisations(term)).to include(matching_record)
+          expect(described_class.matching_organisations(term)).to_not include(non_matching_record)
+        end
+
+        it "returns records with matching company_numbers" do
+          matching_record = described_class.create(company_number: term)
+          non_matching_record = described_class.create(company_number: non_matching_term)
+
+          expect(described_class.matching_organisations(term)).to include(matching_record)
+          expect(described_class.matching_organisations(term)).to_not include(non_matching_record)
+        end
+
+        it "does not return records with matching date_of_births" do
+          term = Date.today
+          non_matching_term = Date.yesterday
+
+          matching_record = described_class.create(date_of_birth: term)
+          non_matching_record = described_class.create(date_of_birth: non_matching_term)
+
+          expect(described_class.matching_organisations(term)).to_not include(matching_record)
+          expect(described_class.matching_organisations(term)).to_not include(non_matching_record)
+        end
+      end
     end
   end
 end

--- a/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
+++ b/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
@@ -75,6 +75,14 @@ module WasteCarriersEngine
               expect { scope }.to_not raise_error
             end
           end
+
+          context "when the search term is blank" do
+            let(:term) { nil }
+
+            it "raises an error" do
+              expect { scope }.to raise_error(ArgumentError)
+            end
+          end
         end
 
         describe "#matching_person_name" do
@@ -113,6 +121,15 @@ module WasteCarriersEngine
               expect { scope }.to_not raise_error
             end
           end
+
+          context "when the search terms are blank" do
+            let(:matching_first_name) { nil }
+            let(:matching_last_name) { nil }
+
+            it "raises an error" do
+              expect { scope }.to raise_error(ArgumentError)
+            end
+          end
         end
 
         describe "#matching_date_of_birth" do
@@ -127,6 +144,22 @@ module WasteCarriersEngine
 
             expect(scope).to include(matching_record)
             expect(scope).to_not include(non_matching_record)
+          end
+
+          context "when the search term is blank" do
+            let(:term) { nil }
+
+            it "raises an error" do
+              expect { scope }.to raise_error(ArgumentError)
+            end
+          end
+
+          context "when the search term is not a date" do
+            let(:term) { "foo" }
+
+            it "raises an error" do
+              expect { scope }.to raise_error(ArgumentError)
+            end
           end
         end
 
@@ -170,6 +203,14 @@ module WasteCarriersEngine
               expect { scope }.to_not raise_error
             end
           end
+
+          context "when the search term is blank" do
+            let(:term) { nil }
+
+            it "raises an error" do
+              expect { scope }.to raise_error(ArgumentError)
+            end
+          end
         end
 
         describe "#matching_people" do
@@ -190,6 +231,22 @@ module WasteCarriersEngine
             expect(scope).to_not include(name_match_only_record)
             expect(scope).to_not include(dob_match_only_record)
             expect(scope).to_not include(non_matching_record)
+          end
+
+          context "when the name is blank" do
+            let(:term) { nil }
+
+            it "raises an error" do
+              expect { scope }.to raise_error(ArgumentError)
+            end
+          end
+
+          context "when the date_of_birth is blank" do
+            let(:date_term) { nil }
+
+            it "raises an error" do
+              expect { scope }.to raise_error(ArgumentError)
+            end
           end
         end
       end
@@ -233,6 +290,14 @@ module WasteCarriersEngine
 
         it "does not allow name to be missing" do
           expect { described_class.matching_organisations(company_no: term) }.to raise_error { ArgumentError }
+        end
+
+        context "when the name is blank" do
+          let(:term) { nil }
+
+          it "raises an error" do
+            expect { results }.to raise_error(ArgumentError)
+          end
         end
       end
     end

--- a/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
+++ b/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  module ConvictionsCheck
+    RSpec.describe Entity, type: :model do
+      describe "public interface" do
+        properties = %i[name date_of_birth company_number system_flag incident_number]
+
+        properties.each do |property|
+          it "responds to property" do
+            expect(subject).to respond_to(property)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
+++ b/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
@@ -40,6 +40,20 @@ module WasteCarriersEngine
             expect(scope).to include(upcased_record)
           end
 
+          context "when the search term ends with a ." do
+            let(:term) { "foo." }
+
+            it "treats the . as an optional match" do
+              record_with_trailing_full_stop = described_class.create(name: "foo.")
+              record_without_trailing_full_stop = described_class.create(name: "foo")
+              record_with_full_stop_somewhere_else = described_class.create(name: "f.oo")
+
+              expect(scope).to include(record_with_trailing_full_stop)
+              expect(scope).to include(record_without_trailing_full_stop)
+              expect(scope).to_not include(record_with_full_stop_somewhere_else)
+            end
+          end
+
           context "when the search term has special characters" do
             let(:matching_first_name) { "*" }
 

--- a/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
+++ b/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
@@ -139,13 +139,13 @@ module WasteCarriersEngine
             let(:term) { "01234567" }
 
             it "treats the zero as an optional match" do
-              term_with_leading_zero = described_class.create(company_number: "01234567")
-              term_without_leading_zero = described_class.create(company_number: "1234567")
-              term_with_zero_somewhere_else = described_class.create(company_number: "10234567")
+              record_with_leading_zero = described_class.create(company_number: "01234567")
+              record_without_leading_zero = described_class.create(company_number: "1234567")
+              record_with_zero_somewhere_else = described_class.create(company_number: "10234567")
 
-              expect(scope).to include(term_with_leading_zero)
-              expect(scope).to include(term_without_leading_zero)
-              expect(scope).to_not include(term_with_zero_somewhere_else)
+              expect(scope).to include(record_with_leading_zero)
+              expect(scope).to include(record_without_leading_zero)
+              expect(scope).to_not include(record_with_zero_somewhere_else)
             end
           end
 

--- a/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
+++ b/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
@@ -29,6 +29,20 @@ module WasteCarriersEngine
             expect(scope).to include(matching_record)
             expect(scope).to_not include(non_matching_record)
           end
+
+          it "is not case sensitive" do
+            upcased_record = described_class.create(name: term.upcase)
+
+            expect(scope).to include(upcased_record)
+          end
+
+          context "when the search term has special characters" do
+            let(:term) { "*" }
+
+            it "does not break the scope" do
+              expect { scope }.to_not raise_error
+            end
+          end
         end
 
         describe "#matching_date_of_birth" do
@@ -55,6 +69,20 @@ module WasteCarriersEngine
 
             expect(scope).to include(matching_record)
             expect(scope).to_not include(non_matching_record)
+          end
+
+          it "is not case sensitive" do
+            upcased_record = described_class.create(company_number: term.upcase)
+
+            expect(scope).to include(upcased_record)
+          end
+
+          context "when the search term has special characters" do
+            let(:term) { "*" }
+
+            it "does not break the scope" do
+              expect { scope }.to_not raise_error
+            end
           end
         end
       end

--- a/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
+++ b/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
@@ -14,6 +14,50 @@ module WasteCarriersEngine
           end
         end
       end
+
+      describe "scopes" do
+        let(:term) { "foo" }
+        let(:non_matching_term) { "bar" }
+
+        describe "#matching_name" do
+          let(:scope) { described_class.matching_name(term) }
+
+          it "returns records with matching names" do
+            matching_record = described_class.create(name: term)
+            non_matching_record = described_class.create(name: non_matching_term)
+
+            expect(scope).to include(matching_record)
+            expect(scope).to_not include(non_matching_record)
+          end
+        end
+
+        describe "#matching_date_of_birth" do
+          let(:scope) { described_class.matching_date_of_birth(term) }
+
+          let(:term) { Date.today }
+          let(:non_matching_term) { Date.yesterday }
+
+          it "returns records with matching date_of_births" do
+            matching_record = described_class.create(date_of_birth: term)
+            non_matching_record = described_class.create(date_of_birth: non_matching_term)
+
+            expect(scope).to include(matching_record)
+            expect(scope).to_not include(non_matching_record)
+          end
+        end
+
+        describe "#matching_company_number" do
+          let(:scope) { described_class.matching_company_number(term) }
+
+          it "returns records with matching company_numbers" do
+            matching_record = described_class.create(company_number: term)
+            non_matching_record = described_class.create(company_number: non_matching_term)
+
+            expect(scope).to include(matching_record)
+            expect(scope).to_not include(non_matching_record)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
+++ b/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
@@ -26,9 +26,11 @@ module WasteCarriersEngine
 
           it "returns records with matching names" do
             matching_record = described_class.create(name: term)
+            partially_matching_record = described_class.create(name: "#{term} waste")
             non_matching_record = described_class.create(name: non_matching_term)
 
             expect(scope).to include(matching_record)
+            expect(scope).to include(partially_matching_record)
             expect(scope).to_not include(non_matching_record)
           end
 

--- a/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
+++ b/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
@@ -103,11 +103,13 @@ module WasteCarriersEngine
         describe "#matching_company_number" do
           let(:scope) { described_class.matching_company_number(term) }
 
-          it "returns records with matching company_numbers" do
+          it "returns records with exactly matching company_numbers" do
             matching_record = described_class.create(company_number: term)
+            partially_matching_record = described_class.create(company_number: "#{term}A")
             non_matching_record = described_class.create(company_number: non_matching_term)
 
             expect(scope).to include(matching_record)
+            expect(scope).to_not include(partially_matching_record)
             expect(scope).to_not include(non_matching_record)
           end
 

--- a/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
+++ b/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
@@ -104,32 +104,41 @@ module WasteCarriersEngine
       describe "#matching_people" do
         let(:term) { "foo" }
         let(:non_matching_term) { "bar" }
+        let(:date_term) { Date.today }
+        let(:non_matching_date_term) { Date.yesterday }
+
+        let(:results) { described_class.matching_people(name: term, date_of_birth: date_term) }
 
         it "returns records with matching names" do
           matching_record = described_class.create(name: term)
           non_matching_record = described_class.create(name: non_matching_term)
 
-          expect(described_class.matching_people(term)).to include(matching_record)
-          expect(described_class.matching_people(term)).to_not include(non_matching_record)
+          expect(results).to include(matching_record)
+          expect(results).to_not include(non_matching_record)
         end
 
         it "returns records with matching date_of_births" do
-          term = Date.today
-          non_matching_term = Date.yesterday
+          matching_record = described_class.create(date_of_birth: date_term)
+          non_matching_record = described_class.create(date_of_birth: non_matching_date_term)
 
-          matching_record = described_class.create(date_of_birth: term)
-          non_matching_record = described_class.create(date_of_birth: non_matching_term)
-
-          expect(described_class.matching_people(term)).to include(matching_record)
-          expect(described_class.matching_people(term)).to_not include(non_matching_record)
+          expect(results).to include(matching_record)
+          expect(results).to_not include(non_matching_record)
         end
 
         it "does not return records with matching company_numbers" do
           matching_record = described_class.create(company_number: term)
           non_matching_record = described_class.create(company_number: non_matching_term)
 
-          expect(described_class.matching_people(term)).to_not include(matching_record)
-          expect(described_class.matching_people(term)).to_not include(non_matching_record)
+          expect(results).to_not include(matching_record)
+          expect(results).to_not include(non_matching_record)
+        end
+
+        it "does not allow name to be missing" do
+          expect { described_class.matching_people(date_of_birth: term) }.to raise_error { ArgumentError }
+        end
+
+        it "does not allow date_of_birth to be missing" do
+          expect { described_class.matching_people(name: term) }.to raise_error { ArgumentError }
         end
       end
     end

--- a/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
+++ b/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
@@ -125,6 +125,27 @@ module WasteCarriersEngine
             end
           end
         end
+
+        describe "#matching_people" do
+          let(:term) { "foo" }
+          let(:non_matching_term) { "bar" }
+          let(:date_term) { Date.today }
+          let(:non_matching_date_term) { Date.yesterday }
+
+          let(:scope) { described_class.matching_people(first_name: term, last_name: term, date_of_birth: date_term) }
+
+          it "only returns records where both the name and date_of_birth match" do
+            matching_record = described_class.create(name: "#{term} #{term}", date_of_birth: date_term)
+            name_match_only_record = described_class.create(name: "#{term} #{term}", date_of_birth: non_matching_date_term)
+            dob_match_only_record = described_class.create(name: non_matching_term, date_of_birth: date_term)
+            non_matching_record = described_class.create(name: non_matching_term, date_of_birth: non_matching_date_term)
+
+            expect(scope).to include(matching_record)
+            expect(scope).to_not include(name_match_only_record)
+            expect(scope).to_not include(dob_match_only_record)
+            expect(scope).to_not include(non_matching_record)
+          end
+        end
       end
 
       describe "#matching_organisations" do
@@ -166,51 +187,6 @@ module WasteCarriersEngine
 
         it "does not allow name to be missing" do
           expect { described_class.matching_organisations(company_no: term) }.to raise_error { ArgumentError }
-        end
-      end
-
-      describe "#matching_people" do
-        let(:term) { "foo" }
-        let(:non_matching_term) { "bar" }
-        let(:date_term) { Date.today }
-        let(:non_matching_date_term) { Date.yesterday }
-
-        let(:results) { described_class.matching_people(first_name: term, last_name: term, date_of_birth: date_term) }
-
-        it "returns records with matching names" do
-          matching_record = described_class.create(name: "#{term} #{term}")
-          non_matching_record = described_class.create(name: non_matching_term)
-
-          expect(results).to include(matching_record)
-          expect(results).to_not include(non_matching_record)
-        end
-
-        it "returns records with matching date_of_births" do
-          matching_record = described_class.create(date_of_birth: date_term)
-          non_matching_record = described_class.create(date_of_birth: non_matching_date_term)
-
-          expect(results).to include(matching_record)
-          expect(results).to_not include(non_matching_record)
-        end
-
-        it "does not return records with matching company_numbers" do
-          matching_record = described_class.create(company_number: term)
-          non_matching_record = described_class.create(company_number: non_matching_term)
-
-          expect(results).to_not include(matching_record)
-          expect(results).to_not include(non_matching_record)
-        end
-
-        it "does not allow first_name to be missing" do
-          expect { described_class.matching_people(last_name: term, date_of_birth: term) }.to raise_error { ArgumentError }
-        end
-
-        it "does not allow last_name to be missing" do
-          expect { described_class.matching_people(first_name: term, date_of_birth: term) }.to raise_error { ArgumentError }
-        end
-
-        it "does not allow date_of_birth to be missing" do
-          expect { described_class.matching_people(first_name: term, last_name: term) }.to raise_error { ArgumentError }
         end
       end
     end

--- a/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
+++ b/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
@@ -117,6 +117,20 @@ module WasteCarriersEngine
             expect(scope).to include(upcased_record)
           end
 
+          context "when the search term starts with a 0" do
+            let(:term) { "01234567" }
+
+            it "treats the zero as an optional match" do
+              term_with_leading_zero = described_class.create(company_number: "01234567")
+              term_without_leading_zero = described_class.create(company_number: "1234567")
+              term_with_zero_somewhere_else = described_class.create(company_number: "10234567")
+
+              expect(scope).to include(term_with_leading_zero)
+              expect(scope).to include(term_without_leading_zero)
+              expect(scope).to_not include(term_with_zero_somewhere_else)
+            end
+          end
+
           context "when the search term has special characters" do
             let(:term) { "*" }
 

--- a/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
+++ b/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
@@ -54,6 +54,20 @@ module WasteCarriersEngine
             end
           end
 
+          context "when the search term contains ignorable words" do
+            let(:term) { "foo ltd" }
+
+            it "does not require them to match" do
+              record_with_exact_name = described_class.create(name: "foo ltd")
+              record_without_common_word = described_class.create(name: "foo")
+              record_with_different_common_word = described_class.create(name: "foo limited")
+
+              expect(scope).to include(record_with_exact_name)
+              expect(scope).to include(record_without_common_word)
+              expect(scope).to include(record_with_different_common_word)
+            end
+          end
+
           context "when the search term has special characters" do
             let(:matching_first_name) { "*" }
 

--- a/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
+++ b/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
@@ -90,6 +90,38 @@ module WasteCarriersEngine
           expect(described_class.matching_organisations(term)).to_not include(non_matching_record)
         end
       end
+
+      describe "#matching_people" do
+        let(:term) { "foo" }
+        let(:non_matching_term) { "bar" }
+
+        it "returns records with matching names" do
+          matching_record = described_class.create(name: term)
+          non_matching_record = described_class.create(name: non_matching_term)
+
+          expect(described_class.matching_people(term)).to include(matching_record)
+          expect(described_class.matching_people(term)).to_not include(non_matching_record)
+        end
+
+        it "returns records with matching date_of_births" do
+          term = Date.today
+          non_matching_term = Date.yesterday
+
+          matching_record = described_class.create(date_of_birth: term)
+          non_matching_record = described_class.create(date_of_birth: non_matching_term)
+
+          expect(described_class.matching_people(term)).to include(matching_record)
+          expect(described_class.matching_people(term)).to_not include(non_matching_record)
+        end
+
+        it "does not return records with matching company_numbers" do
+          matching_record = described_class.create(company_number: term)
+          non_matching_record = described_class.create(company_number: non_matching_term)
+
+          expect(described_class.matching_people(term)).to_not include(matching_record)
+          expect(described_class.matching_people(term)).to_not include(non_matching_record)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-741

This is the first step of implementing conviction checking entirely in the engine instead of making calls to waste-carriers-service.

This PR sets up an Entity model to match the data we store in the database.