### PR TITLE
Add RenewingRegistration model

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_change_conviction_workflow_status.rb
+++ b/app/models/concerns/waste_carriers_engine/can_change_conviction_workflow_status.rb
@@ -45,6 +45,8 @@ module WasteCarriersEngine
     end
 
     def revoke_parent
+      return unless _parent&.metaData
+
       _parent.metaData.revoke!
     end
   end

--- a/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
@@ -2,7 +2,7 @@
 
 module WasteCarriersEngine
   # rubocop:disable Metrics/ModuleLength
-  module CanChangeWorkflowStatus
+  module CanUseRenewingRegistrationWorkflow
     extend ActiveSupport::Concern
     include Mongoid::Document
 

--- a/app/models/waste_carriers_engine/renewing_registration.rb
+++ b/app/models/waste_carriers_engine/renewing_registration.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class RenewingRegistration < TransientRegistration
+    include CanUseRenewingRegistrationWorkflow
+
+    validate :no_renewal_in_progress?, on: :create
+    validates :reg_identifier, "waste_carriers_engine/reg_identifier": true
+
+    after_initialize :copy_data_from_registration
+
+    # Check if the user has changed the registration type, as this incurs an additional 40GBP charge
+    def registration_type_changed?
+      # Don't compare registration types if the new one hasn't been set
+      return false unless registration_type
+
+      registration.registration_type != registration_type
+    end
+
+    def registration
+      Registration.where(reg_identifier: reg_identifier).first
+    end
+
+    def fee_including_possible_type_change
+      if registration_type_changed?
+        Rails.configuration.renewal_charge + Rails.configuration.type_change_charge
+      else
+        Rails.configuration.renewal_charge
+      end
+    end
+
+    def projected_renewal_end_date
+      return unless expires_on.present?
+
+      ExpiryCheckService.new(self).expiry_date_after_renewal
+    end
+
+    def pending_payment?
+      renewal_application_submitted? && super
+    end
+
+    def company_no_changed?
+      return false unless company_no_required?
+
+      # LLP is a new business type, so users who previously were forced to select 'partnership' would not have had the
+      # opportunity to enter a company_no. Therefore we have nothing to compare against and should allow users to
+      # continue the renewal journey.
+      return false if registration.business_type == "partnership"
+
+      # It was previously possible to save a company_no with excess whitespace. This is no longer possible, but we
+      # should ignore this whitespace when comparing, otherwise a trailing space will block the user from renewing their
+      # registration.
+      old_company_no = registration.company_no.to_s.strip
+
+      # It was previously valid to have company_nos with less than 8 digits
+      # The form prepends 0s to make up the length, so we should do this for the old number to match
+      old_company_no = "0#{old_company_no}" while old_company_no.length < 8
+      old_company_no != company_no
+    end
+
+    def renewal_application_submitted?
+      not_in_progress_states = %w[renewal_received_form renewal_complete_form]
+      not_in_progress_states.include?(workflow_state)
+    end
+
+    def can_be_renewed?
+      return false unless %w[ACTIVE EXPIRED].include?(metaData.status)
+
+      # The only time an expired registration can be renewed is if the
+      # application
+      # - has a confirmed declaration i.e. user reached the copy cards page
+      # - it is within the grace window
+      return true if declaration_confirmed?
+
+      check_service = ExpiryCheckService.new(self)
+      return true if check_service.in_expiry_grace_window?
+      return false if check_service.expired?
+
+      check_service.in_renewal_window?
+    end
+
+    def ready_to_complete?
+      # Though both pending_payment? and pending_manual_conviction_check? also
+      # check that the renewal has been submitted, if it hasn't they would both
+      # return false, which would mean we would not stop the renewal from
+      # completing. Hence we have to check it separately first
+      return false unless renewal_application_submitted?
+      return false if pending_payment?
+      return false if pending_manual_conviction_check?
+
+      true
+    end
+
+    def stuck?
+      return false unless renewal_application_submitted?
+      return true if conviction_sign_offs&.first&.rejected?
+      return false if pending_payment? || pending_manual_conviction_check?
+
+      true
+    end
+
+    def pending_manual_conviction_check?
+      renewal_application_submitted? && super
+    end
+
+    private
+
+    # Check if a transient renewal already exists for this registration so we don't have
+    # multiple renewals in progress at once
+    def no_renewal_in_progress?
+      return unless RenewingRegistration.where(reg_identifier: reg_identifier).exists?
+
+      errors.add(:reg_identifier, :renewal_in_progress)
+    end
+
+    def copy_data_from_registration
+      # Don't try to get Registration data with an invalid reg_identifier
+      return unless valid? && new_record?
+
+      # Don't copy object IDs as Mongo should generate new unique ones
+      # Don't copy smart answers as we want users to use the latest version of the questions
+      attributes = registration.attributes.except("_id",
+                                                  "otherBusinesses",
+                                                  "isMainService",
+                                                  "constructionWaste",
+                                                  "onlyAMF",
+                                                  "addresses",
+                                                  "key_people",
+                                                  "financeDetails",
+                                                  "declaredConvictions",
+                                                  "conviction_search_result",
+                                                  "conviction_sign_offs",
+                                                  "declaration",
+                                                  "past_registrations",
+                                                  "copy_cards")
+
+      assign_attributes(strip_whitespace(attributes))
+      remove_invalid_attributes
+    end
+
+    def remove_invalid_attributes
+      remove_invalid_phone_numbers
+      remove_revoked_reason
+    end
+
+    def remove_invalid_phone_numbers
+      validator = DefraRuby::Validators::PhoneNumberValidator.new(attributes: :phone_number)
+      return if validator.validate_each(self, :phone_number, phone_number)
+
+      self.phone_number = nil
+    end
+
+    def remove_revoked_reason
+      metaData.revoked_reason = nil
+    end
+  end
+end

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -4,13 +4,13 @@ module WasteCarriersEngine
   # rubocop:disable Metrics/ClassLength
   class TransientRegistration
     include Mongoid::Document
-    include CanChangeWorkflowStatus
     include CanCheckBusinessTypeChanges
     include CanCheckRegistrationStatus
     include CanHaveRegistrationAttributes
     include CanStripWhitespace
 
-    store_in collection: "transient_registrations"
+    # TODO: Swap me with the base registration workflow for new registrations
+    include CanUseRenewingRegistrationWorkflow
 
     validates :reg_identifier, "waste_carriers_engine/reg_identifier": true
     validate :no_renewal_in_progress?, on: :create

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -12,6 +12,8 @@ module WasteCarriersEngine
     # TODO: Swap me with the base registration workflow for new registrations
     include CanUseRenewingRegistrationWorkflow
 
+    store_in collection: "transient_registrations"
+
     validates :reg_identifier, "waste_carriers_engine/reg_identifier": true
     validate :no_renewal_in_progress?, on: :create
 

--- a/app/services/waste_carriers_engine/renewal_completion_service.rb
+++ b/app/services/waste_carriers_engine/renewal_completion_service.rb
@@ -85,6 +85,7 @@ module WasteCarriersEngine
                                                                      "temp_os_places_error",
                                                                      "temp_payment_method",
                                                                      "temp_tier_check",
+                                                                     "_type",
                                                                      "workflow_state")
 
       remove_unused_attributes(registration_attributes, renewal_attributes)

--- a/spec/factories/renewing_registration.rb
+++ b/spec/factories/renewing_registration.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :renewing_registration, class: WasteCarriersEngine::RenewingRegistration do
+    trait :has_required_data do
+      location { "england" }
+      declared_convictions { "no" }
+      temp_cards { 1 }
+
+      has_postcode
+
+      # Create a new registration when initializing so we can copy its data
+      initialize_with { new(reg_identifier: create(:registration, :has_required_data, :expires_soon).reg_identifier) }
+    end
+
+    trait :has_addresses do
+      addresses { [build(:address, :has_required_data, :registered, :from_os_places), build(:address, :has_required_data, :contact, :from_os_places)] }
+    end
+
+    trait :has_key_people do
+      key_people do
+        [build(:key_person, :has_required_data, :unmatched_conviction_search_result, :main),
+         build(:key_person, :has_required_data, :unmatched_conviction_search_result, :relevant)]
+      end
+    end
+
+    trait :has_postcode do
+      temp_company_postcode { "BS1 5AH" }
+      temp_contact_postcode { "BS1 5AH" }
+    end
+
+    trait :declared_convictions do
+      declared_convictions { "yes" }
+    end
+
+    trait :is_submitted do
+      workflow_state { "renewal_received_form" }
+    end
+
+    trait :has_finance_details do
+      after(:build, :create) do |renewing_registration|
+        WasteCarriersEngine::FinanceDetails.new_finance_details(renewing_registration, :worldpay, build(:user))
+      end
+    end
+
+    trait :has_paid_order do
+      finance_details { build(:finance_details, :has_paid_order_and_payment) }
+    end
+
+    trait :has_conviction_search_result do
+      conviction_search_result { build(:conviction_search_result, :match_result_no) }
+    end
+
+    trait :requires_conviction_check do
+      is_submitted
+      key_people { [build(:key_person, :matched_conviction_search_result)] }
+      conviction_search_result { build(:conviction_search_result, :match_result_yes) }
+      conviction_sign_offs { [build(:conviction_sign_off)] }
+    end
+
+    trait :has_rejected_conviction_sign_off do
+      declared_convictions
+      conviction_search_result { build(:conviction_sign_off, :rejected) }
+    end
+
+    trait :has_unpaid_balance do
+      is_submitted
+      finance_details { build(:finance_details, balance: 1000) }
+    end
+
+    trait :has_paid_balance do
+      finance_details { build(:finance_details, balance: 0) }
+    end
+
+    trait :has_different_contact_email do
+      contact_email { "contact-foo@example.com" }
+    end
+
+    # Overseas registrations
+
+    trait :has_required_overseas_data do
+      location { "overseas" }
+      business_type { "overseas" }
+      declared_convictions { "no" }
+      temp_cards { 1 }
+
+      # Create a new registration when initializing so we can copy its data
+      initialize_with { new(reg_identifier: create(:registration, :has_required_overseas_data, :expires_soon).reg_identifier) }
+    end
+
+    trait :has_overseas_addresses do
+      addresses do
+        [build(:address, :has_required_data, :registered, :manual_foreign),
+         build(:address, :has_required_data, :contact, :manual_foreign)]
+      end
+    end
+
+    trait :has_matching_convictions do
+      company_name { "Test Waste Services" }
+      company_no { "12345678" }
+
+      key_people do
+        [build(:key_person, :has_matching_conviction, :main)]
+      end
+    end
+
+    trait :has_revoked_registration do
+      # Create a new registration when initializing so we can copy its data
+      initialize_with do
+        new(reg_identifier: create(:registration, :has_required_data, :is_revoked).reg_identifier)
+      end
+    end
+
+    trait :has_expired do
+      # Create a new registration when initializing so we can copy its data
+      initialize_with { new(reg_identifier: create(:registration, :has_required_data, :expired_one_month_ago).reg_identifier) }
+    end
+
+    trait :has_expired_today do
+      # Create a new registration when initializing so we can copy its data
+      initialize_with { new(reg_identifier: create(:registration, :has_required_data, :expires_today).reg_identifier) }
+    end
+
+    trait :is_ready_to_complete do
+      has_required_data
+      has_paid_order
+      is_submitted
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/renewing_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_spec.rb
@@ -1,0 +1,400 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe RenewingRegistration, type: :model do
+    subject(:renewing_registration) { build(:renewing_registration, :has_required_data) }
+
+    describe "workflow_state" do
+      context "when a RenewingRegistration is created" do
+        it "has the state :renewal_start_form" do
+          expect(renewing_registration).to have_state(:renewal_start_form)
+        end
+      end
+
+      context "when transitioning from bank_transfer_form to renewal_received_form succesfully" do
+        it "set the transient registration metadata route" do
+          expect(renewing_registration).to receive(:set_metadata_route).once
+
+          renewing_registration.update_attributes(workflow_state: :bank_transfer_form)
+          renewing_registration.next
+        end
+      end
+
+      context "when transitioning from worldpay_form to renewal_complete_form succesfully" do
+        it "set the transient registration metadata route" do
+          expect(renewing_registration).to receive(:set_metadata_route).once
+          expect(renewing_registration).to receive(:pending_worldpay_payment_or_convictions_check?).and_return(false)
+
+          renewing_registration.update_attributes(workflow_state: :worldpay_form)
+          renewing_registration.next
+        end
+      end
+
+      context "when transitioning from worldpay_form to renewal_received_form succesfully" do
+        it "set the transient registration metadata route" do
+          expect(renewing_registration).to receive(:set_metadata_route).once
+          expect(renewing_registration).to receive(:pending_worldpay_payment_or_convictions_check?).and_return(true)
+
+          renewing_registration.update_attributes(workflow_state: :worldpay_form)
+          renewing_registration.next
+        end
+      end
+    end
+
+    context "Validations" do
+      describe "reg_identifier" do
+        context "when a RenewingRegistration is created" do
+          it "is not valid if the reg_identifier is in the wrong format" do
+            renewing_registration.reg_identifier = "foo"
+            expect(renewing_registration).to_not be_valid
+          end
+
+          it "is not valid if no matching registration exists" do
+            renewing_registration.reg_identifier = "CBDU999999"
+            expect(renewing_registration).to_not be_valid
+          end
+
+          it "is not valid if the reg_identifier is already in use" do
+            existing_renewing_registration = create(:renewing_registration, :has_required_data)
+            renewing_registration.reg_identifier = existing_renewing_registration.reg_identifier
+            expect(renewing_registration).to_not be_valid
+          end
+        end
+      end
+    end
+
+    describe "#initialize" do
+      context "when the source registration has whitespace in its attributes" do
+        let(:registration) do
+          create(:registration,
+                 :has_required_data,
+                 company_name: " test ")
+        end
+
+        it "strips the whitespace from the attributes" do
+          renewing_registration = RenewingRegistration.new(reg_identifier: registration.reg_identifier)
+          expect(renewing_registration.company_name).to eq("test")
+        end
+      end
+
+      context "when the source registration has a valid phone_number" do
+        let(:registration) do
+          create(:registration,
+                 :has_required_data)
+        end
+
+        it "imports it" do
+          renewing_registration = RenewingRegistration.new(reg_identifier: registration.reg_identifier)
+          expect(renewing_registration.phone_number).to eq(registration.phone_number)
+        end
+      end
+
+      context "when the source registration has an invalid phone_number" do
+        let(:registration) do
+          create(:registration,
+                 :has_required_data,
+                 phone_number: "test")
+        end
+
+        it "does not import it" do
+          renewing_registration = RenewingRegistration.new(reg_identifier: registration.reg_identifier)
+          expect(renewing_registration.phone_number).to eq(nil)
+        end
+      end
+
+      context "when the source registration has a revoked_reason" do
+        let(:revoked_renewing_registration) { build(:renewing_registration, :has_revoked_registration) }
+
+        it "does not import it" do
+          expect(revoked_renewing_registration.metaData.revoked_reason).to eq(nil)
+        end
+      end
+    end
+
+    describe "status" do
+      it_should_behave_like "Can check registration status",
+                            factory: :renewing_registration
+    end
+
+    describe "#registration_type_changed?" do
+      context "when a RenewingRegistration is created" do
+        it "should return false" do
+          expect(renewing_registration.registration_type_changed?).to eq(false)
+        end
+
+        context "when the registration_type is updated" do
+          before(:each) do
+            renewing_registration.registration_type = "broker_dealer"
+          end
+
+          it "should return true" do
+            expect(renewing_registration.registration_type_changed?).to eq(true)
+          end
+        end
+      end
+    end
+
+    describe "#renewal_application_submitted?" do
+      context "when the workflow_state is not a completed one" do
+        it "returns false" do
+          expect(renewing_registration.renewal_application_submitted?).to eq(false)
+        end
+      end
+
+      context "when the workflow_state is renewal_received" do
+        before do
+          renewing_registration.workflow_state = "renewal_received_form"
+        end
+
+        it "returns true" do
+          expect(renewing_registration.renewal_application_submitted?).to eq(true)
+        end
+      end
+
+      context "when the workflow_state is renewal_complete" do
+        before do
+          renewing_registration.workflow_state = "renewal_complete_form"
+        end
+
+        it "returns true" do
+          expect(renewing_registration.renewal_application_submitted?).to eq(true)
+        end
+      end
+    end
+
+    describe "#can_be_renewed?" do
+      context "when a registration is neither active or expired" do
+        let(:revoked_renewing_registration) { build(:renewing_registration, :has_revoked_registration) }
+
+        it "returns false" do
+          expect(revoked_renewing_registration.can_be_renewed?).to eq(false)
+        end
+      end
+
+      context "when the declaration is confirmed" do
+        it "returns true" do
+          renewing_registration.declaration = 1
+          expect(renewing_registration.can_be_renewed?).to eq(true)
+        end
+      end
+
+      context "when a registration is active" do
+        context "when it is within the grace window" do
+          before { allow_any_instance_of(ExpiryCheckService).to receive(:in_expiry_grace_window?).and_return(true) }
+
+          it "returns true" do
+            expect(renewing_registration.can_be_renewed?).to eq(true)
+          end
+        end
+
+        context "when it is not within the grace window" do
+          before { allow_any_instance_of(ExpiryCheckService).to receive(:in_expiry_grace_window?).and_return(false) }
+
+          context "and when it is within the renewal window" do
+            before { allow_any_instance_of(ExpiryCheckService).to receive(:in_renewal_window?).and_return(true) }
+
+            it "returns true" do
+              expect(renewing_registration.can_be_renewed?).to eq(true)
+            end
+          end
+
+          context "and when it is not within the renewal window" do
+            before { allow_any_instance_of(ExpiryCheckService).to receive(:in_renewal_window?).and_return(false) }
+
+            it "returns false" do
+              expect(renewing_registration.can_be_renewed?).to eq(false)
+            end
+          end
+        end
+      end
+
+      context "when a registration is expired" do
+        let(:expired_renewing_registration) { build(:renewing_registration, :has_expired) }
+
+        context "when a registration is active" do
+          context "when it is within the grace window" do
+            before { allow_any_instance_of(ExpiryCheckService).to receive(:in_expiry_grace_window?).and_return(true) }
+
+            it "returns true" do
+              expect(renewing_registration.can_be_renewed?).to eq(true)
+            end
+          end
+
+          context "when it is not within the grace window" do
+            before { allow_any_instance_of(ExpiryCheckService).to receive(:in_expiry_grace_window?).and_return(false) }
+
+            context "and when it is within the renewal window" do
+              before { allow_any_instance_of(ExpiryCheckService).to receive(:in_renewal_window?).and_return(true) }
+
+              it "returns true" do
+                expect(renewing_registration.can_be_renewed?).to eq(true)
+              end
+            end
+
+            context "and when it is not within the renewal window" do
+              before { allow_any_instance_of(ExpiryCheckService).to receive(:in_renewal_window?).and_return(false) }
+
+              it "returns false" do
+                expect(renewing_registration.can_be_renewed?).to eq(false)
+              end
+            end
+          end
+        end
+      end
+    end
+
+    describe "#ready_to_complete?" do
+      context "when the transient registration is ready to complete" do
+        let(:renewing_registration) { build(:renewing_registration, :is_ready_to_complete) }
+        it "returns true" do
+          expect(renewing_registration.ready_to_complete?).to eq(true)
+        end
+      end
+
+      context "when the transient registration is not ready to complete" do
+        context "because it is not submitted" do
+          let(:renewing_registration) { build(:renewing_registration, workflow_state: "bank_transfer_form") }
+          it "returns false" do
+            expect(renewing_registration.ready_to_complete?).to eq(false)
+          end
+        end
+
+        context "because it has outstanding payments" do
+          it "returns false" do
+            expect(renewing_registration.ready_to_complete?).to eq(false)
+          end
+        end
+
+        context "because it has outstanding conviction checks" do
+          it "returns false" do
+            expect(renewing_registration.ready_to_complete?).to eq(false)
+          end
+        end
+      end
+    end
+
+    describe "#stuck?" do
+      context "when the registration is not submitted" do
+        let(:renewing_registration) { build(:renewing_registration) }
+
+        it "returns false" do
+          expect(renewing_registration.stuck?).to eq(false)
+        end
+      end
+
+      context "when the registration is submitted" do
+        context "and has an outstanding payment" do
+          let(:renewing_registration) { build(:renewing_registration, :has_unpaid_balance) }
+
+          it "returns false" do
+            expect(renewing_registration.stuck?).to eq(false)
+          end
+        end
+
+        context "and has an outstanding conviction check" do
+          let(:renewing_registration) { build(:renewing_registration, :is_submitted, :requires_conviction_check) }
+
+          it "returns false" do
+            expect(renewing_registration.stuck?).to eq(false)
+          end
+        end
+
+        context "and has been refused" do
+          let(:renewing_registration) { build(:renewing_registration, :is_submitted, :has_rejected_conviction_sign_off) }
+
+          it "returns true" do
+            expect(renewing_registration.stuck?).to eq(true)
+          end
+        end
+
+        context "and has no outstanding checks" do
+          let(:renewing_registration) { build(:renewing_registration, :is_submitted, :has_paid_balance) }
+
+          it "returns true" do
+            expect(renewing_registration.stuck?).to eq(true)
+          end
+        end
+      end
+    end
+
+    describe "#pending_payment?" do
+      context "when the renewal is not in a completed workflow_state" do
+        it "returns false" do
+          expect(renewing_registration.pending_payment?).to eq(false)
+        end
+      end
+
+      context "when the renewal is in a completed workflow_state" do
+        before do
+          renewing_registration.workflow_state = "renewal_received_form"
+        end
+
+        context "when there is no unpaid balance" do
+          before do
+            allow(renewing_registration).to receive(:unpaid_balance?).and_return(false)
+          end
+
+          it "returns false" do
+            expect(renewing_registration.pending_payment?).to eq(false)
+          end
+        end
+
+        context "when there is an unpaid balance" do
+          before do
+            allow(renewing_registration).to receive(:unpaid_balance?).and_return(true)
+          end
+
+          it "returns true" do
+            expect(renewing_registration.pending_payment?).to eq(true)
+          end
+        end
+      end
+    end
+
+    describe "#pending_manual_conviction_check?" do
+      context "when the renewal is not in a completed workflow_state" do
+        it "returns false" do
+          expect(renewing_registration.pending_manual_conviction_check?).to eq(false)
+        end
+      end
+
+      context "when the renewal is in a completed workflow_state" do
+        before do
+          renewing_registration.workflow_state = "renewal_received_form"
+        end
+
+        context "when conviction_check_required? is false" do
+          before do
+            allow(renewing_registration).to receive(:conviction_check_required?).and_return(false)
+          end
+
+          it "returns false" do
+            expect(renewing_registration.pending_manual_conviction_check?).to eq(false)
+          end
+        end
+
+        context "when conviction_check_required? is true" do
+          before do
+            allow(renewing_registration).to receive(:conviction_check_required?).and_return(true)
+          end
+
+          context "when the registration is not active" do
+            let(:revoked_renewing_registration) { build(:renewing_registration, :has_revoked_registration) }
+
+            it "returns false" do
+              expect(revoked_renewing_registration.pending_manual_conviction_check?).to eq(false)
+            end
+          end
+
+          context "when the registration is active" do
+            it "returns true" do
+              expect(renewing_registration.pending_manual_conviction_check?).to eq(true)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-756

In order to align the codebase with WEX we want to make TransientRegistration a STI model.
This PR includes the new model that will split renewing functionality out of TransientRegistration into RenewingRegistration model.

The class is a copy-paste of most the code in `TransientRegistration` 