### PR TITLE
Set up OrganisationMatchService for org-level conviction checks

### DIFF
--- a/app/services/waste_carriers_engine/convictions_check/base_match_service.rb
+++ b/app/services/waste_carriers_engine/convictions_check/base_match_service.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  module ConvictionsCheck
+    class BaseMatchService < BaseService
+      def run(*args)
+        assign_search_params(*args)
+        check_for_matches_and_return_data
+      end
+
+      private
+
+      def assign_search_params(_args)
+        raise NotImplementedError
+      end
+
+      def check_for_matches_and_return_data
+        if matching_entities.any?
+          positive_match(matching_entities.first)
+        else
+          negative_match
+        end
+      rescue ArgumentError
+        error_match
+      end
+
+      def matching_entities
+        raise NotImplementedError
+      end
+
+      def positive_match(entity)
+        data = basic_match_data
+
+        data[:match_result] = "YES"
+        data[:matching_system] = entity.system_flag
+        data[:reference] = entity.incident_number
+        data[:matched_name] = entity.name
+
+        data
+      end
+
+      def negative_match
+        data = basic_match_data
+
+        data[:match_result] = "NO"
+
+        data
+      end
+
+      def error_match
+        data = basic_match_data
+
+        data[:match_result] = "UNKNOWN"
+        data[:matching_system] = "ERROR"
+
+        data
+      end
+
+      def basic_match_data
+        {
+          searched_at: Time.current,
+          confirmed: "no",
+          confirmed_at: nil,
+          confirmed_by: nil
+        }
+      end
+    end
+  end
+end

--- a/app/services/waste_carriers_engine/convictions_check/organisation_match_service.rb
+++ b/app/services/waste_carriers_engine/convictions_check/organisation_match_service.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rest-client"
+
+module WasteCarriersEngine
+  module ConvictionsCheck
+    class OrganisationMatchService < BaseService
+      def run(name:, company_no:)
+        @name = name
+        @company_no = company_no
+
+        begin
+          if matching_entities.any?
+            positive_match(matching_entities.first)
+          else
+            negative_match
+          end
+        rescue ArgumentError
+          error_match
+        end
+      end
+
+      private
+
+      def matching_entities
+        @_matching_entities ||= Entity.matching_organisations(name: @name,
+                                                              company_no: @company_no)
+      end
+
+      def positive_match(entity)
+        data = basic_match_data
+
+        data[:match_result] = "YES"
+        data[:matching_system] = entity.system_flag
+        data[:reference] = entity.incident_number
+        data[:matched_name] = entity.name
+
+        data
+      end
+
+      def negative_match
+        data = basic_match_data
+
+        data[:match_result] = "NO"
+
+        data
+      end
+
+      def error_match
+        data = basic_match_data
+
+        data[:match_result] = "UNKNOWN"
+        data[:matching_system] = "ERROR"
+
+        data
+      end
+
+      def basic_match_data
+        {
+          searched_at: Time.current,
+          confirmed: "no",
+          confirmed_at: nil,
+          confirmed_by: nil
+        }
+      end
+    end
+  end
+end

--- a/app/services/waste_carriers_engine/convictions_check/organisation_match_service.rb
+++ b/app/services/waste_carriers_engine/convictions_check/organisation_match_service.rb
@@ -2,64 +2,17 @@
 
 module WasteCarriersEngine
   module ConvictionsCheck
-    class OrganisationMatchService < BaseService
-      def run(name:, company_no:)
+    class OrganisationMatchService < BaseMatchService
+      private
+
+      def assign_search_params(name:, company_no:)
         @name = name
         @company_no = company_no
-
-        begin
-          if matching_entities.any?
-            positive_match(matching_entities.first)
-          else
-            negative_match
-          end
-        rescue ArgumentError
-          error_match
-        end
       end
-
-      private
 
       def matching_entities
         @_matching_entities ||= Entity.matching_organisations(name: @name,
                                                               company_no: @company_no)
-      end
-
-      def positive_match(entity)
-        data = basic_match_data
-
-        data[:match_result] = "YES"
-        data[:matching_system] = entity.system_flag
-        data[:reference] = entity.incident_number
-        data[:matched_name] = entity.name
-
-        data
-      end
-
-      def negative_match
-        data = basic_match_data
-
-        data[:match_result] = "NO"
-
-        data
-      end
-
-      def error_match
-        data = basic_match_data
-
-        data[:match_result] = "UNKNOWN"
-        data[:matching_system] = "ERROR"
-
-        data
-      end
-
-      def basic_match_data
-        {
-          searched_at: Time.current,
-          confirmed: "no",
-          confirmed_at: nil,
-          confirmed_by: nil
-        }
       end
     end
   end

--- a/app/services/waste_carriers_engine/convictions_check/organisation_match_service.rb
+++ b/app/services/waste_carriers_engine/convictions_check/organisation_match_service.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "rest-client"
-
 module WasteCarriersEngine
   module ConvictionsCheck
     class OrganisationMatchService < BaseService

--- a/app/services/waste_carriers_engine/convictions_check/person_match_service.rb
+++ b/app/services/waste_carriers_engine/convictions_check/person_match_service.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "rest-client"
-
 module WasteCarriersEngine
   module ConvictionsCheck
     class PersonMatchService < BaseService

--- a/app/services/waste_carriers_engine/convictions_check/person_match_service.rb
+++ b/app/services/waste_carriers_engine/convictions_check/person_match_service.rb
@@ -2,66 +2,19 @@
 
 module WasteCarriersEngine
   module ConvictionsCheck
-    class PersonMatchService < BaseService
-      def run(first_name:, last_name:, date_of_birth:)
+    class PersonMatchService < BaseMatchService
+      private
+
+      def assign_search_params(first_name:, last_name:, date_of_birth:)
         @first_name = first_name
         @last_name = last_name
         @date_of_birth = date_of_birth
-
-        begin
-          if matching_entities.any?
-            positive_match(matching_entities.first)
-          else
-            negative_match
-          end
-        rescue ArgumentError
-          error_match
-        end
       end
-
-      private
 
       def matching_entities
         @_matching_entities ||= Entity.matching_people(first_name: @first_name,
                                                        last_name: @last_name,
                                                        date_of_birth: @date_of_birth)
-      end
-
-      def positive_match(entity)
-        data = basic_match_data
-
-        data[:match_result] = "YES"
-        data[:matching_system] = entity.system_flag
-        data[:reference] = entity.incident_number
-        data[:matched_name] = entity.name
-
-        data
-      end
-
-      def negative_match
-        data = basic_match_data
-
-        data[:match_result] = "NO"
-
-        data
-      end
-
-      def error_match
-        data = basic_match_data
-
-        data[:match_result] = "UNKNOWN"
-        data[:matching_system] = "ERROR"
-
-        data
-      end
-
-      def basic_match_data
-        {
-          searched_at: Time.current,
-          confirmed: "no",
-          confirmed_at: nil,
-          confirmed_by: nil
-        }
       end
     end
   end

--- a/spec/services/waste_carriers_engine/convictions_check/organisation_match_service_spec.rb
+++ b/spec/services/waste_carriers_engine/convictions_check/organisation_match_service_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  module ConvictionsCheck
+    RSpec.describe OrganisationMatchService do
+      describe "run" do
+        let(:time) { Time.new(2019, 1, 1) }
+        before { allow(Time).to receive(:current).and_return(time) }
+
+        let(:name) { "foo" }
+        let(:company_no) { "bar" }
+
+        let(:entity_a) do
+          double(:entity,
+                 system_flag: "foo",
+                 incident_number: "bar",
+                 name: "baz")
+        end
+        let(:entity_b) do
+          double(:entity,
+                 system_flag: "qux",
+                 incident_number: "quux",
+                 name: "quuz")
+        end
+
+        let(:subject) do
+          described_class.run(name: name,
+                              company_no: company_no)
+        end
+
+        it "does not explode" do
+          expect { subject }.to_not raise_error
+        end
+
+        it "checks for matching entities" do
+          expect(Entity).to receive(:matching_organisations).with(name: name,
+                                                                  company_no: company_no)
+                                                            .and_return([entity_a])
+
+          subject
+        end
+
+        context "when there are matches" do
+          before { allow(Entity).to receive(:matching_organisations).and_return([entity_a, entity_b]) }
+
+          it "returns a hash of data for the first entity" do
+            data = {
+              searched_at: time,
+              confirmed: "no",
+              confirmed_at: nil,
+              confirmed_by: nil,
+              match_result: "YES",
+              matching_system: entity_a.system_flag,
+              reference: entity_a.incident_number,
+              matched_name: entity_a.name
+            }
+
+            expect(subject).to eq(data)
+          end
+        end
+
+        context "when there are no matches" do
+          before { allow(Entity).to receive(:matching_organisations).and_return([]) }
+
+          it "returns a hash of data" do
+            data = {
+              searched_at: time,
+              confirmed: "no",
+              confirmed_at: nil,
+              confirmed_by: nil,
+              match_result: "NO"
+            }
+
+            expect(subject).to eq(data)
+          end
+        end
+
+        context "when there is an error" do
+          before { allow(Entity).to receive(:matching_organisations).and_raise(ArgumentError) }
+
+          it "returns a hash of data" do
+            data = {
+              searched_at: time,
+              confirmed: "no",
+              confirmed_at: nil,
+              confirmed_by: nil,
+              match_result: "UNKNOWN",
+              matching_system: "ERROR"
+            }
+
+            expect(subject).to eq(data)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/waste_carriers_engine/convictions_check/organisation_match_service_spec.rb
+++ b/spec/services/waste_carriers_engine/convictions_check/organisation_match_service_spec.rb
@@ -25,7 +25,7 @@ module WasteCarriersEngine
                  name: "quuz")
         end
 
-        let(:subject) do
+        subject do
           described_class.run(name: name,
                               company_no: company_no)
         end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-741

This service will be used to check for matches on the registering business or organisation.

---

Depends on https://github.com/DEFRA/waste-carriers-engine/pull/554