### PR TITLE
Remove alias to `revoked` and add specific method

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -110,6 +110,12 @@ module WasteCarriersEngine
         %w[limitedCompany limitedLiabilityPartnership].include?(business_type)
       end
 
+      def rejected_conviction_checks?
+        return false unless conviction_sign_offs&.any?
+
+        conviction_sign_offs.last.rejected?
+      end
+
       def main_people
         return [] unless key_people.present?
 

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -35,7 +35,11 @@ module WasteCarriersEngine
     scope :convictions_approved, -> { submitted.where("conviction_sign_offs.0.workflow_state": "approved") }
     scope :convictions_rejected, -> { submitted.where("conviction_sign_offs.0.workflow_state": "rejected") }
 
-    alias rejected? revoked?
+    def has_rejected_conviction_checks?
+      return false unless conviction_sign_offs&.any?
+
+      conviction_sign_offs.last.rejected?
+    end
 
     def total_to_pay
       charges = [Rails.configuration.renewal_charge]

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -35,7 +35,7 @@ module WasteCarriersEngine
     scope :convictions_approved, -> { submitted.where("conviction_sign_offs.0.workflow_state": "approved") }
     scope :convictions_rejected, -> { submitted.where("conviction_sign_offs.0.workflow_state": "rejected") }
 
-    def has_rejected_conviction_checks?
+    def rejected_conviction_checks?
       return false unless conviction_sign_offs&.any?
 
       conviction_sign_offs.last.rejected?

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -35,12 +35,6 @@ module WasteCarriersEngine
     scope :convictions_approved, -> { submitted.where("conviction_sign_offs.0.workflow_state": "approved") }
     scope :convictions_rejected, -> { submitted.where("conviction_sign_offs.0.workflow_state": "rejected") }
 
-    def rejected_conviction_checks?
-      return false unless conviction_sign_offs&.any?
-
-      conviction_sign_offs.last.rejected?
-    end
-
     def total_to_pay
       charges = [Rails.configuration.renewal_charge]
       charges << Rails.configuration.type_change_charge if registration_type_changed?

--- a/spec/models/waste_carriers_engine/transient_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/transient_registration_spec.rb
@@ -51,7 +51,7 @@ module WasteCarriersEngine
         let(:conviction_sign_off) { double(:conviction_sign_off, rejected?: rejected) }
         let(:conviction_sign_offs) { [double, conviction_sign_off] }
 
-        context "when thee last conviction sign off status is rejected" do
+        context "when the last conviction sign off status is rejected" do
           let(:rejected) { true }
 
           it "returns true" do

--- a/spec/models/waste_carriers_engine/transient_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/transient_registration_spec.rb
@@ -34,26 +34,37 @@ module WasteCarriersEngine
                             factory: :transient_registration
     end
 
-    describe "#rejected?" do
-      let(:metadata) { double(:metadata, REVOKED?: revoked) }
-
+    describe "#has_rejected_conviction_checks?" do
       before do
-        expect(transient_registration).to receive(:metaData).and_return(metadata)
+        allow(transient_registration).to receive(:conviction_sign_offs).and_return(conviction_sign_offs)
       end
 
-      context "when the metadata is in a REVOKED status" do
-        let(:revoked) { true }
+      context "when there are no conviction sign offs" do
+        let(:conviction_sign_offs) { nil }
 
-        it "returns true" do
-          expect(transient_registration).to be_rejected
+        it "return false" do
+          expect(transient_registration.has_rejected_conviction_checks?).to be_falsey
         end
       end
 
-      context "when the metadata is not in a REVOKED status" do
-        let(:revoked) { false }
+      context "when there are conviction sign offs" do
+        let(:conviction_sign_off) { double(:conviction_sign_off, rejected?: rejected) }
+        let(:conviction_sign_offs) { [double, conviction_sign_off] }
 
-        it "returns false" do
-          expect(transient_registration).to_not be_rejected
+        context "when thee last conviction sign off status is rejected" do
+          let(:rejected) { true }
+
+          it "returns true" do
+            expect(transient_registration.has_rejected_conviction_checks?).to be_truthy
+          end
+        end
+
+        context "when the last conviction sign off status is not rejected" do
+          let(:rejected) { false }
+
+          it "returns false" do
+            expect(transient_registration.has_rejected_conviction_checks?).to be_falsey
+          end
         end
       end
     end

--- a/spec/models/waste_carriers_engine/transient_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/transient_registration_spec.rb
@@ -34,7 +34,7 @@ module WasteCarriersEngine
                             factory: :transient_registration
     end
 
-    describe "#has_rejected_conviction_checks?" do
+    describe "#rejected_conviction_checks?" do
       before do
         allow(transient_registration).to receive(:conviction_sign_offs).and_return(conviction_sign_offs)
       end
@@ -43,7 +43,7 @@ module WasteCarriersEngine
         let(:conviction_sign_offs) { nil }
 
         it "return false" do
-          expect(transient_registration.has_rejected_conviction_checks?).to be_falsey
+          expect(transient_registration.rejected_conviction_checks?).to be_falsey
         end
       end
 
@@ -55,7 +55,7 @@ module WasteCarriersEngine
           let(:rejected) { true }
 
           it "returns true" do
-            expect(transient_registration.has_rejected_conviction_checks?).to be_truthy
+            expect(transient_registration.rejected_conviction_checks?).to be_truthy
           end
         end
 
@@ -63,7 +63,7 @@ module WasteCarriersEngine
           let(:rejected) { false }
 
           it "returns false" do
-            expect(transient_registration.has_rejected_conviction_checks?).to be_falsey
+            expect(transient_registration.rejected_conviction_checks?).to be_falsey
           end
         end
       end


### PR DESCRIPTION
On the back-office details page, we use to show a warning message when conviction checks have been rejected.
In order to do so, we check that the status of the registration is `REVOKED`. This is not quite exact though, as we have specific ConvictionSignOff objects that deal with a rejection or approval.
In this PR I remove the alias method as that is not needed and instead create a more specific method in the transient registration which target the correct object status.