### PR TITLE
Check for matching company_no before name in convictions

### DIFF
--- a/app/models/waste_carriers_engine/convictions_check/entity.rb
+++ b/app/models/waste_carriers_engine/convictions_check/entity.rb
@@ -56,11 +56,10 @@ module WasteCarriersEngine
       def self.matching_organisations(name:, company_no: nil)
         raise ArgumentError if name.blank?
 
-        results = matching_organisation_name(name)
+        results = []
+        results += matching_company_number(company_no) if company_no.present?
+        results += matching_organisation_name(name)
 
-        return results unless company_no.present?
-
-        results += matching_company_number(company_no)
         results.uniq
       end
 

--- a/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
+++ b/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
@@ -292,6 +292,16 @@ module WasteCarriersEngine
           expect { described_class.matching_organisations(company_no: term) }.to raise_error { ArgumentError }
         end
 
+        context "when there is a matching company_no and a matching name" do
+          it "returns the company_no match first" do
+            company_no_match = described_class.create(company_number: term)
+            name_match = described_class.create(name: term)
+
+            expect(results.first).to eq(company_no_match)
+            expect(results.last).to eq(name_match)
+          end
+        end
+
         context "when the name is blank" do
           let(:term) { nil }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-741

This is something I spotted when looking at our docs here: https://github.com/DEFRA/ruby-services-team/blob/master/services/wcr/entity_matching.md

Previously we returned matches for the name first, but the company_no is more likely to be accurate.