### PR TITLE
Add lower and upper tier check methods to Registrations

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -103,6 +103,14 @@ module WasteCarriersEngine
         business_type == "overseas"
       end
 
+      def upper_tier?
+        tier == "UPPER"
+      end
+
+      def lower_tier?
+        tier == "LOWER"
+      end
+
       # Some business types should not have a company_no
       def company_no_required?
         return false if overseas?

--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -33,14 +33,6 @@ module WasteCarriersEngine
       renewable_tier? && renewable_status? && renewable_date?
     end
 
-    def upper_tier?
-      tier == "UPPER"
-    end
-
-    def lower_tier?
-      tier == "LOWER"
-    end
-
     private
 
     def renewable_tier?

--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -33,10 +33,18 @@ module WasteCarriersEngine
       renewable_tier? && renewable_status? && renewable_date?
     end
 
+    def upper_tier?
+      tier == "UPPER"
+    end
+
+    def lower_tier?
+      tier == "LOWER"
+    end
+
     private
 
     def renewable_tier?
-      tier == "UPPER"
+      upper_tier?
     end
 
     def renewable_status?

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -79,6 +79,46 @@ module WasteCarriersEngine
       end
     end
 
+    describe "#lower_tier?" do
+      subject(:registration) { build(:registration, :has_required_data, tier: tier) }
+
+      context "when a registration's tier is set to 'LOWER'" do
+        let(:tier) { "LOWER" }
+
+        it "returns true" do
+          expect(registration.lower_tier?).to be_truthy
+        end
+      end
+
+      context "when a registration's tier is not set to 'LOWER'" do
+        let(:tier) { "FOO" }
+
+        it "returns false" do
+          expect(registration.lower_tier?).to be_falsey
+        end
+      end
+    end
+
+    describe "#upper_tier?" do
+      subject(:registration) { build(:registration, :has_required_data, tier: tier) }
+
+      context "when a registration's tier is set to 'UPPER'" do
+        let(:tier) { "UPPER" }
+
+        it "returns true" do
+          expect(registration.upper_tier?).to be_truthy
+        end
+      end
+
+      context "when a registration's tier is not set to 'UPPER'" do
+        let(:tier) { "FOO" }
+
+        it "returns false" do
+          expect(registration.upper_tier?).to be_falsey
+        end
+      end
+    end
+
     describe "#address" do
       context "when a registration has one address" do
         let(:address) { build(:address, :has_required_data) }

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -79,46 +79,6 @@ module WasteCarriersEngine
       end
     end
 
-    describe "#lower_tier?" do
-      subject(:registration) { build(:registration, :has_required_data, tier: tier) }
-
-      context "when a registration's tier is set to 'LOWER'" do
-        let(:tier) { "LOWER" }
-
-        it "returns true" do
-          expect(registration.lower_tier?).to be_truthy
-        end
-      end
-
-      context "when a registration's tier is not set to 'LOWER'" do
-        let(:tier) { "FOO" }
-
-        it "returns false" do
-          expect(registration.lower_tier?).to be_falsey
-        end
-      end
-    end
-
-    describe "#upper_tier?" do
-      subject(:registration) { build(:registration, :has_required_data, tier: tier) }
-
-      context "when a registration's tier is set to 'UPPER'" do
-        let(:tier) { "UPPER" }
-
-        it "returns true" do
-          expect(registration.upper_tier?).to be_truthy
-        end
-      end
-
-      context "when a registration's tier is not set to 'UPPER'" do
-        let(:tier) { "FOO" }
-
-        it "returns false" do
-          expect(registration.upper_tier?).to be_falsey
-        end
-      end
-    end
-
     describe "#address" do
       context "when a registration has one address" do
         let(:address) { build(:address, :has_required_data) }

--- a/spec/support/shared_examples/can_have_registration_attributes.rb
+++ b/spec/support/shared_examples/can_have_registration_attributes.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "Can have registration attributes" do |factory:|
+  let(:resource) { build(factory) }
+
   include_examples(
     "Can reference single document in collection",
     proc { create(factory, :has_required_data, :has_addresses) },
@@ -9,8 +11,6 @@ RSpec.shared_examples "Can have registration attributes" do |factory:|
     WasteCarriersEngine::Address.new,
     :addresses
   )
-
-  let(:resource) { build(factory) }
 
   describe "#charity?" do
     test_values = {
@@ -24,6 +24,46 @@ RSpec.shared_examples "Can have registration attributes" do |factory:|
           resource.business_type = business_type.to_s
           expect(resource.charity?).to eq(result)
         end
+      end
+    end
+  end
+
+  describe "#lower_tier?" do
+    let(:resource) { build(factory, tier: tier) }
+
+    context "when a registration's tier is set to 'LOWER'" do
+      let(:tier) { "LOWER" }
+
+      it "returns true" do
+        expect(resource.lower_tier?).to be_truthy
+      end
+    end
+
+    context "when a registration's tier is not set to 'LOWER'" do
+      let(:tier) { "FOO" }
+
+      it "returns false" do
+        expect(resource.lower_tier?).to be_falsey
+      end
+    end
+  end
+
+  describe "#upper_tier?" do
+    let(:resource) { build(factory, tier: tier) }
+
+    context "when a registration's tier is set to 'UPPER'" do
+      let(:tier) { "UPPER" }
+
+      it "returns true" do
+        expect(resource.upper_tier?).to be_truthy
+      end
+    end
+
+    context "when a registration's tier is not set to 'UPPER'" do
+      let(:tier) { "FOO" }
+
+      it "returns false" do
+        expect(resource.upper_tier?).to be_falsey
       end
     end
   end


### PR DESCRIPTION
I am not aware of other code implementing those, and currently I have the need to distinguish between a `Lower` and `Upper` tier registration, hence I am adding this in.