### PR TITLE
Treat punctuation as optional for org name conviction checks

### DIFF
--- a/app/models/waste_carriers_engine/convictions_check/entity.rb
+++ b/app/models/waste_carriers_engine/convictions_check/entity.rb
@@ -81,15 +81,34 @@ module WasteCarriersEngine
       private_class_method def self.org_name_search_term(term)
         return if term.blank?
 
-        # Trim trailing full stops
-        term_without_trailing_full_stops = term.gsub(/\.$/, "")
+        # The steps for processing the org name must be done in this order:
 
-        # Remove the words we want to ignore
-        word_array = term_without_trailing_full_stops.downcase.split(" ")
+        # 1. Remove trailing full stops
+        without_full_stops = term.gsub(/\.$/, "")
+        # 2. Remove common org words
+        without_org_words = term_without_ignorable_org_words(without_full_stops)
+        # 3. Escape special characters for regex
+        escaped = ::Regexp.escape(without_org_words)
+        # 4. Treat punctuation as optional when matching
+        term_with_optional_punctuation(escaped)
+      end
+
+      private_class_method def self.term_without_ignorable_org_words(term)
+        word_array = term.downcase.split(" ")
         word_array.reject! { |word| IGNORABLE_ORG_NAME_WORDS.include?(word) }
-        term_without_ignorable_words = word_array.join(" ")
+        word_array.join(" ")
+      end
 
-        ::Regexp.escape(term_without_ignorable_words)
+      private_class_method def self.term_with_optional_punctuation(term)
+        # These are characters we want to treat as optional
+        punctuation_chars = %w[. , / # ! $ % ^ & * ; : { } = - _ ` ~ ( )]
+
+        chars_array = term.scan(/./)
+        chars_array.each_with_index do |char, index|
+          chars_array[index] = "#{char}?" if punctuation_chars.include?(char)
+        end
+
+        chars_array.join
       end
     end
   end

--- a/app/models/waste_carriers_engine/convictions_check/entity.rb
+++ b/app/models/waste_carriers_engine/convictions_check/entity.rb
@@ -108,11 +108,11 @@ module WasteCarriersEngine
 
       private_class_method def self.term_with_optional_punctuation(term)
         # These are characters we want to treat as optional
-        punctuation_chars = %w[. , / # ! $ % ^ & * ; : { } = - _ ` ~ ( )]
+        optional_characters = %w[. , / # ! $ % ^ & * ; : { } = - _ ` ~ ( )]
 
         chars_array = term.scan(/./)
         chars_array.each_with_index do |char, index|
-          chars_array[index] = "#{char}?" if punctuation_chars.include?(char)
+          chars_array[index] = "#{char}?" if optional_characters.include?(char)
         end
 
         chars_array.join

--- a/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
+++ b/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
@@ -40,17 +40,17 @@ module WasteCarriersEngine
             expect(scope).to include(upcased_record)
           end
 
-          context "when the search term ends with a ." do
-            let(:term) { "foo." }
+          context "when the search term contains punctuation" do
+            let(:term) { "Waste Not (Want Not)." }
 
-            it "treats the . as an optional match" do
-              record_with_trailing_full_stop = described_class.create(name: "foo.")
-              record_without_trailing_full_stop = described_class.create(name: "foo")
-              record_with_full_stop_somewhere_else = described_class.create(name: "f.oo")
+            it "treats them as optional" do
+              record_with_all_punctuation = described_class.create(name: term)
+              record_with_some_punctuation = described_class.create(name: "Waste Not (Want Not)")
+              record_with_no_punctuation = described_class.create(name: "Waste Not Want Not")
 
-              expect(scope).to include(record_with_trailing_full_stop)
-              expect(scope).to include(record_without_trailing_full_stop)
-              expect(scope).to_not include(record_with_full_stop_somewhere_else)
+              expect(scope).to include(record_with_all_punctuation)
+              expect(scope).to include(record_with_some_punctuation)
+              expect(scope).to include(record_with_no_punctuation)
             end
           end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-741

This fixes an issue spotted in QA. Punctuation should be treated as optional when matching organisation names - for example, if a user enters "Waste Not (Want Not) UK" that should still match a record called "Waste Not Want Not UK".