### PR TITLE
Add cache and use find_by to registration method

### DIFF
--- a/app/models/waste_carriers_engine/renewing_registration.rb
+++ b/app/models/waste_carriers_engine/renewing_registration.rb
@@ -18,7 +18,7 @@ module WasteCarriersEngine
     end
 
     def registration
-      Registration.where(reg_identifier: reg_identifier).first
+      @_registration ||= Registration.find_by(reg_identifier: reg_identifier)
     end
 
     def fee_including_possible_type_change

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_registration_number_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_registration_number_form_spec.rb
@@ -28,7 +28,7 @@ module WasteCarriersEngine
           context "when the business used to be a partnership and is now an LLP" do
             before do
               transient_registration.business_type = "limitedLiabilityPartnership"
-              Registration.where(reg_identifier: transient_registration.reg_identifier).first.update_attributes(business_type: "partnership")
+              transient_registration.registration.update_attributes(business_type: "partnership")
             end
 
             it "changes to :company_name_form after the 'next' event" do


### PR DESCRIPTION
We do actually have a `#registration` method on RenewingRegistrations :)

I have applied some instance-level cache to it and moved to use `find_by` over `#where..#first`