### PR TITLE
Add renewable? method to all registrations

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -124,6 +124,10 @@ module WasteCarriersEngine
         conviction_sign_offs.last.rejected?
       end
 
+      def renewable?
+        false
+      end
+
       def main_people
         return [] unless key_people.present?
 

--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -33,6 +33,8 @@ module WasteCarriersEngine
       renewable_tier? && renewable_status? && renewable_date?
     end
 
+    alias renewable? can_start_renewal?
+
     private
 
     def renewable_tier?


### PR DESCRIPTION
This adds the `renewable?` method to all types of registrations, as per WEX.