### PR TITLE
Add service to order copy cards

### DIFF
--- a/app/models/waste_carriers_engine/order.rb
+++ b/app/models/waste_carriers_engine/order.rb
@@ -25,18 +25,11 @@ module WasteCarriersEngine
     field :manualOrder, as: :manual_order,           type: String
     field :order_item_reference,                     type: String
 
+    # TODO: Move to a service
     def self.new_order(transient_registration, method, current_user)
-      order = Order.new
+      order = new_order_for(current_user)
 
       card_count = transient_registration.temp_cards
-
-      order[:order_id] = order.generate_id
-      order[:order_code] = order[:order_id]
-      order[:currency] = "GBP"
-
-      order[:date_created] = Time.current
-      order[:date_last_updated] = order[:date_created]
-      order[:updated_by_user] = current_user.email
 
       order[:order_items] = [OrderItem.new_renewal_item]
       order[:order_items] << OrderItem.new_type_change_item if transient_registration.registration_type_changed?
@@ -49,6 +42,20 @@ module WasteCarriersEngine
 
       order.add_bank_transfer_attributes if method == :bank_transfer
       order.add_worldpay_attributes if method == :worldpay
+
+      order
+    end
+
+    def self.new_order_for(user)
+      order = Order.new
+
+      order[:order_id] = order.generate_id
+      order[:order_code] = order[:order_id]
+      order[:currency] = "GBP"
+
+      order[:date_created] = Time.current
+      order[:date_last_updated] = order[:date_created]
+      order[:updated_by_user] = user.email
 
       order
     end

--- a/app/services/waste_carriers_engine/order_additional_cards_service.rb
+++ b/app/services/waste_carriers_engine/order_additional_cards_service.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class OrderAdditionalCardsService < BaseService
+    def run(cards_count:, user:, registration:, payment_method:)
+      finance_details = registration.finance_details
+      order = additional_cards_order(user, cards_count, payment_method)
+
+      finance_details[:orders] << order
+
+      finance_details.update_balance
+      finance_details.save!
+    end
+
+    private
+
+    def additional_cards_order(user, cards_count, payment_method)
+      order = Order.new_order_for(user)
+      new_item = OrderItem.new_copy_cards_item(cards_count)
+
+      order[:order_items] = [new_item]
+
+      order.generate_description
+
+      order[:total_amount] = new_item[:amount]
+
+      order.add_bank_transfer_attributes if payment_method == :bank_transfer
+      order.add_worldpay_attributes if payment_method == :worldpay
+
+      order
+    end
+  end
+end

--- a/spec/services/waste_carriers_engine/order_additional_cards_service_spec.rb
+++ b/spec/services/waste_carriers_engine/order_additional_cards_service_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe OrderAdditionalCardsService do
+    describe ".run" do
+      let(:user) { double(:user) }
+      let(:registration) { double(:registration) }
+      let(:order) { double(:order) }
+
+      before do
+        finance_details = double(:finance_details)
+        order_item = double(:order_item)
+        orders = double(:orders)
+
+        expect(registration).to receive(:finance_details).and_return(finance_details)
+        expect(Order).to receive(:new_order_for).with(user).and_return(order)
+        expect(OrderItem).to receive(:new_copy_cards_item).with(2).and_return(order_item)
+        expect(order).to receive(:generate_description)
+        expect(order).to receive(:[]=).with(:order_items, [order_item])
+        expect(order_item).to receive(:[]).with(:amount).and_return(10)
+        expect(order).to receive(:[]=).with(:total_amount, 10)
+
+        expect(finance_details).to receive(:[]).with(:orders).and_return(orders)
+        expect(orders).to receive(:<<).with(order)
+        expect(finance_details).to receive(:update_balance)
+        expect(finance_details).to receive(:save!)
+      end
+
+      context "when the payment method is bank transfer" do
+        let(:payment_method) { :bank_transfer }
+
+        it "updates the registration's finance details with a new order for the given copy cards" do
+          expect(order).to receive(:add_bank_transfer_attributes)
+
+          described_class.run(cards_count: 2, user: user, registration: registration, payment_method: payment_method)
+        end
+      end
+
+      context "when the payment method is worldpay" do
+        let(:payment_method) { :worldpay }
+
+        it "updates the registration's finance details with a new order for the given copy cards" do
+          expect(order).to receive(:add_worldpay_attributes)
+
+          described_class.run(cards_count: 2, user: user, registration: registration, payment_method: payment_method)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-767

Add a reusable service that given a registration, a user, a number of copy cards and a user, generates a copy cards only order