### PR TITLE
Add shared convictions scopes for regs and transient_regs

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_filter_conviction_status.rb
+++ b/app/models/concerns/waste_carriers_engine/can_filter_conviction_status.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  module CanFilterConvictionStatus
+    extend ActiveSupport::Concern
+
+    included do
+      scope :convictions_possible_match, lambda {
+        where("conviction_sign_offs.0.workflow_state": "possible_match")
+      }
+      scope :convictions_checks_in_progress, lambda {
+        where("conviction_sign_offs.0.workflow_state": "checks_in_progress")
+      }
+      scope :convictions_approved, lambda {
+        where("conviction_sign_offs.0.workflow_state": "approved")
+      }
+      scope :convictions_rejected, lambda {
+        where("conviction_sign_offs.0.workflow_state": "rejected")
+      }
+    end
+  end
+end

--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -4,6 +4,7 @@ module WasteCarriersEngine
   class Registration
     include Mongoid::Document
     include CanCheckRegistrationStatus
+    include CanFilterConvictionStatus
     include CanHaveRegistrationAttributes
     include CanGenerateRegIdentifier
 

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -5,6 +5,7 @@ module WasteCarriersEngine
     include Mongoid::Document
     include CanCheckBusinessTypeChanges
     include CanCheckRegistrationStatus
+    include CanFilterConvictionStatus
     include CanHaveRegistrationAttributes
     include CanStripWhitespace
 
@@ -27,13 +28,6 @@ module WasteCarriersEngine
     scope :submitted, -> { where(:workflow_state.in => %w[renewal_complete_form renewal_received_form]) }
     scope :pending_payment, -> { submitted.where(:"financeDetails.balance".gt => 0) }
     scope :pending_approval, -> { submitted.where("conviction_sign_offs.0.confirmed": "no") }
-
-    scope :convictions_possible_match, -> { submitted.where("conviction_sign_offs.0.workflow_state": "possible_match") }
-    scope :convictions_checks_in_progress, lambda {
-      submitted.where("conviction_sign_offs.0.workflow_state": "checks_in_progress")
-    }
-    scope :convictions_approved, -> { submitted.where("conviction_sign_offs.0.workflow_state": "approved") }
-    scope :convictions_rejected, -> { submitted.where("conviction_sign_offs.0.workflow_state": "rejected") }
 
     def total_to_pay
       charges = [Rails.configuration.renewal_charge]

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -575,5 +575,9 @@ module WasteCarriersEngine
       it_should_behave_like "Can have registration attributes",
                             factory: :registration
     end
+
+    describe "conviction scopes" do
+      it_should_behave_like "Can filter conviction status"
+    end
   end
 end

--- a/spec/models/waste_carriers_engine/transient_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/transient_registration_spec.rb
@@ -34,6 +34,10 @@ module WasteCarriersEngine
                             factory: :transient_registration
     end
 
+    describe "conviction scopes" do
+      it_should_behave_like "Can filter conviction status"
+    end
+
     describe "#rejected_conviction_checks?" do
       before do
         allow(transient_registration).to receive(:conviction_sign_offs).and_return(conviction_sign_offs)

--- a/spec/support/shared_examples/can_filter_conviction_status.rb
+++ b/spec/support/shared_examples/can_filter_conviction_status.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "Can filter conviction status" do
+  let(:possible_match) do
+    record = described_class.new(
+      conviction_sign_offs: [
+        WasteCarriersEngine::ConvictionSignOff.new(workflow_state: :possible_match)
+      ]
+    )
+    # Skip the validation so we don't have to include addresses, etc
+    record.save(validate: false)
+    record
+  end
+
+  let(:checks_in_progress) do
+    record = described_class.new(
+      conviction_sign_offs: [
+        WasteCarriersEngine::ConvictionSignOff.new(workflow_state: :checks_in_progress)
+      ]
+    )
+    # Skip the validation so we don't have to include addresses, etc
+    record.save(validate: false)
+    record
+  end
+
+  let(:approved) do
+    record = described_class.new(
+      conviction_sign_offs: [
+        WasteCarriersEngine::ConvictionSignOff.new(workflow_state: :approved)
+      ]
+    )
+    # Skip the validation so we don't have to include addresses, etc
+    record.save(validate: false)
+    record
+  end
+
+  let(:rejected) do
+    record = described_class.new(
+      conviction_sign_offs: [
+        WasteCarriersEngine::ConvictionSignOff.new(workflow_state: :rejected)
+      ]
+    )
+    # Skip the validation so we don't have to include addresses, etc
+    record.save(validate: false)
+    record
+  end
+
+  describe "convictions_possible_match" do
+    let(:scope) { described_class.convictions_possible_match }
+
+    it "only returns results with the correct status" do
+      expect(scope).to include(possible_match)
+      expect(scope).to_not include(checks_in_progress)
+      expect(scope).to_not include(approved)
+      expect(scope).to_not include(rejected)
+    end
+  end
+
+  describe "convictions_checks_in_progress" do
+    let(:scope) { described_class.convictions_checks_in_progress }
+
+    it "only returns results with the correct status" do
+      expect(scope).to_not include(possible_match)
+      expect(scope).to include(checks_in_progress)
+      expect(scope).to_not include(approved)
+      expect(scope).to_not include(rejected)
+    end
+  end
+
+  describe "convictions_approved" do
+    let(:scope) { described_class.convictions_approved }
+
+    it "only returns results with the correct status" do
+      expect(scope).to_not include(possible_match)
+      expect(scope).to_not include(checks_in_progress)
+      expect(scope).to include(approved)
+      expect(scope).to_not include(rejected)
+    end
+  end
+
+  describe "convictions_rejected" do
+    let(:scope) { described_class.convictions_rejected }
+
+    it "only returns results with the correct status" do
+      expect(scope).to_not include(possible_match)
+      expect(scope).to_not include(checks_in_progress)
+      expect(scope).to_not include(approved)
+      expect(scope).to include(rejected)
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-791

These are for use on the convictions dashboard.

There was a previous version which only applied to transient registrations, but that also included a `submitted` scope. I think we should just apply this separately where we use it (which is only on the current version of the convictions dashboard, as far as I can tell).