### PR TITLE
Add scope to deal with conviction_sign_offs from frontend

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_filter_conviction_status.rb
+++ b/app/models/concerns/waste_carriers_engine/can_filter_conviction_status.rb
@@ -17,6 +17,14 @@ module WasteCarriersEngine
       scope :convictions_rejected, lambda {
         where("conviction_sign_offs.0.workflow_state": "rejected")
       }
+      # This is to catch historical conviction_sign_offs which were only created and modified by waste-carriers-frontend
+      # and have no workflow_state as a result. We want ones which have not been confirmed and are in a pending state.
+      scope :convictions_new_without_status, lambda {
+        where(:"conviction_sign_offs.0".exists => true,
+              :"conviction_sign_offs.0.workflow_state".exists => false,
+              :"conviction_sign_offs.0.confirmed".ne => "yes",
+              "metaData.status": "PENDING")
+      }
     end
   end
 end

--- a/spec/support/shared_examples/can_filter_conviction_status.rb
+++ b/spec/support/shared_examples/can_filter_conviction_status.rb
@@ -45,6 +45,44 @@ RSpec.shared_examples "Can filter conviction status" do
     record
   end
 
+  let(:no_status_pending) do
+    record = described_class.new(
+      conviction_sign_offs: [
+        WasteCarriersEngine::ConvictionSignOff.new
+      ],
+      metaData: { status: "PENDING" }
+    )
+    # Skip the validation so we don't have to include addresses, etc
+    record.save(validate: false)
+    record.conviction_sign_offs.first.unset(:workflow_state)
+    record
+  end
+
+  let(:no_status_active) do
+    record = described_class.new(
+      conviction_sign_offs: [
+        WasteCarriersEngine::ConvictionSignOff.new
+      ],
+      metaData: { status: "ACTIVE" }
+    )
+    # Skip the validation so we don't have to include addresses, etc
+    record.save(validate: false)
+    record.conviction_sign_offs.first.unset(:workflow_state)
+    record
+  end
+
+  let(:no_status_approved) do
+    record = described_class.new(
+      conviction_sign_offs: [
+        WasteCarriersEngine::ConvictionSignOff.new(confirmed: "yes")
+      ]
+    )
+    # Skip the validation so we don't have to include addresses, etc
+    record.save(validate: false)
+    record.conviction_sign_offs.first.unset(:workflow_state)
+    record
+  end
+
   describe "convictions_possible_match" do
     let(:scope) { described_class.convictions_possible_match }
 
@@ -86,6 +124,20 @@ RSpec.shared_examples "Can filter conviction status" do
       expect(scope).to_not include(checks_in_progress)
       expect(scope).to_not include(approved)
       expect(scope).to include(rejected)
+    end
+  end
+
+  describe "convictions_new_without_status" do
+    let(:scope) { described_class.convictions_new_without_status }
+
+    it "only returns results with the correct status" do
+      expect(scope).to_not include(possible_match)
+      expect(scope).to_not include(checks_in_progress)
+      expect(scope).to_not include(approved)
+      expect(scope).to_not include(rejected)
+      expect(scope).to include(no_status_pending)
+      expect(scope).to_not include(no_status_active)
+      expect(scope).to_not include(no_status_approved)
     end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-791

Any conviction_sign_offs that are created in the waste-carriers-frontend don't get a workflow_state when they are created. So we need an extra scope to deal with them. This will allow us to list them on the dashboard in the back office.