### PR TITLE
Move prepare for payment method in transient object

### DIFF
--- a/app/controllers/waste_carriers_engine/bank_transfer_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/bank_transfer_forms_controller.rb
@@ -15,7 +15,7 @@ module WasteCarriersEngine
     private
 
     def set_up_finance_details
-      FinanceDetails.new_finance_details(@transient_registration, :bank_transfer, current_user)
+      @transient_registration.prepare_for_payment(:bank_transfer, current_user)
     end
 
     def transient_registration_attributes

--- a/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
@@ -39,7 +39,7 @@ module WasteCarriersEngine
     private
 
     def prepare_for_payment
-      FinanceDetails.new_finance_details(@transient_registration, :worldpay, current_user)
+      @transient_registration.prepare_for_payment(:worldpay, current_user)
       order = @transient_registration.finance_details.orders.first
       worldpay_service = WorldpayService.new(@transient_registration, order, current_user)
       worldpay_service.prepare_for_payment

--- a/app/models/waste_carriers_engine/finance_details.rb
+++ b/app/models/waste_carriers_engine/finance_details.rb
@@ -17,7 +17,7 @@ module WasteCarriersEngine
     validates :balance,
               presence: true
 
-    def self.new_finance_details(transient_registration, method, current_user)
+    def self.new_renewal_finance_details(transient_registration, method, current_user)
       finance_details = FinanceDetails.new
       finance_details.transient_registration = transient_registration
       finance_details[:orders] = [Order.new_order(transient_registration, method, current_user)]

--- a/app/models/waste_carriers_engine/renewing_registration.rb
+++ b/app/models/waste_carriers_engine/renewing_registration.rb
@@ -39,6 +39,10 @@ module WasteCarriersEngine
       renewal_application_submitted? && super
     end
 
+    def prepare_for_payment(mode, user)
+      FinanceDetails.new_renewal_finance_details(self, mode, user)
+    end
+
     def company_no_changed?
       return false unless company_no_required?
 

--- a/spec/factories/renewing_registration.rb
+++ b/spec/factories/renewing_registration.rb
@@ -39,7 +39,7 @@ FactoryBot.define do
 
     trait :has_finance_details do
       after(:build, :create) do |renewing_registration|
-        WasteCarriersEngine::FinanceDetails.new_finance_details(renewing_registration, :worldpay, build(:user))
+        renewing_registration.prepare_for_payment(:worldpay, build(:user))
       end
     end
 

--- a/spec/models/waste_carriers_engine/finance_details_spec.rb
+++ b/spec/models/waste_carriers_engine/finance_details_spec.rb
@@ -10,11 +10,11 @@ module WasteCarriersEngine
       allow(Rails.configuration).to receive(:card_charge).and_return(1_000)
     end
 
-    let(:transient_registration) { build(:transient_registration, :has_required_data, temp_cards: 0) }
+    let(:transient_registration) { build(:renewing_registration, :has_required_data, temp_cards: 0) }
     let(:current_user) { build(:user) }
 
     describe "new_finance_details" do
-      let(:finance_details) { FinanceDetails.new_finance_details(transient_registration, :worldpay, current_user) }
+      let(:finance_details) { transient_registration.prepare_for_payment(:worldpay, current_user) }
 
       it "should include 1 order" do
         order_count = finance_details.orders.length

--- a/spec/models/waste_carriers_engine/order_item_spec.rb
+++ b/spec/models/waste_carriers_engine/order_item_spec.rb
@@ -10,7 +10,7 @@ module WasteCarriersEngine
       allow(Rails.configuration).to receive(:card_charge).and_return(1_000)
     end
 
-    let(:transient_registration) { build(:transient_registration, :has_required_data) }
+    let(:transient_registration) { build(:renewing_registration, :has_required_data) }
 
     describe "new_renewal_item" do
       let(:order_item) { described_class.new_renewal_item }

--- a/spec/models/waste_carriers_engine/order_spec.rb
+++ b/spec/models/waste_carriers_engine/order_spec.rb
@@ -155,7 +155,7 @@ module WasteCarriersEngine
     end
 
     describe "update_after_worldpay" do
-      let(:finance_details) { FinanceDetails.new_finance_details(transient_registration, :worldpay, current_user) }
+      let(:finance_details) { transient_registration.prepare_for_payment(:worldpay, current_user) }
       let(:order) { finance_details.orders.first }
 
       it "copies the worldpay status to the order" do

--- a/spec/models/waste_carriers_engine/payment_spec.rb
+++ b/spec/models/waste_carriers_engine/payment_spec.rb
@@ -4,13 +4,13 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe Payment, type: :model do
-    let(:transient_registration) { build(:transient_registration, :has_required_data) }
+    let(:transient_registration) { build(:renewing_registration, :has_required_data) }
     let(:current_user) { build(:user) }
 
     describe "new_from_worldpay" do
       before do
         Timecop.freeze(Time.new(2018, 1, 1)) do
-          FinanceDetails.new_finance_details(transient_registration, :worldpay, current_user)
+          transient_registration.prepare_for_payment(:worldpay, current_user)
         end
       end
 
@@ -49,7 +49,7 @@ module WasteCarriersEngine
     describe "new_from_non_worldpay" do
       before do
         Timecop.freeze(Time.new(2018, 1, 1)) do
-          FinanceDetails.new_finance_details(transient_registration, :worldpay, current_user)
+          transient_registration.prepare_for_payment(:worldpay, current_user)
         end
       end
 
@@ -127,7 +127,7 @@ module WasteCarriersEngine
 
       before do
         Timecop.freeze(Time.new(2018, 3, 4)) do
-          FinanceDetails.new_finance_details(transient_registration, :worldpay, current_user)
+          transient_registration.prepare_for_payment(:worldpay, current_user)
           payment.update_after_worldpay(paymentStatus: "AUTHORISED", mac: "foo")
         end
       end

--- a/spec/requests/waste_carriers_engine/bank_transfer_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/bank_transfer_forms_spec.rb
@@ -29,7 +29,7 @@ module WasteCarriersEngine
 
           context "when a worldpay order already exists" do
             before do
-              FinanceDetails.new_finance_details(transient_registration, :worldpay, user)
+              transient_registration.prepare_for_payment(:worldpay, user)
               transient_registration.finance_details.orders.first.world_pay_status = "CANCELLED"
             end
 

--- a/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
@@ -51,7 +51,7 @@ module WasteCarriersEngine
 
         describe "#success" do
           before do
-            FinanceDetails.new_finance_details(transient_registration, :worldpay, user)
+            transient_registration.prepare_for_payment(:worldpay, user)
           end
 
           let(:order) do
@@ -150,7 +150,7 @@ module WasteCarriersEngine
 
         describe "#pending" do
           before do
-            FinanceDetails.new_finance_details(transient_registration, :worldpay, user)
+            transient_registration.prepare_for_payment(:worldpay, user)
           end
 
           let(:order) do

--- a/spec/services/waste_carriers_engine/smart_answers_checker_service_spec.rb
+++ b/spec/services/waste_carriers_engine/smart_answers_checker_service_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe SmartAnswersCheckerService do
-    let(:transient_registration) { build(:transient_registration) }
+    let(:transient_registration) { build(:renewing_registration) }
     let(:service) { SmartAnswersCheckerService.new(transient_registration) }
 
     describe "#lower_tier?" do

--- a/spec/services/waste_carriers_engine/worldpay_service_spec.rb
+++ b/spec/services/waste_carriers_engine/worldpay_service_spec.rb
@@ -16,7 +16,7 @@ module WasteCarriersEngine
     before do
       allow(Rails.configuration).to receive(:renewal_charge).and_return(10_500)
 
-      WasteCarriersEngine::FinanceDetails.new_finance_details(transient_registration, :worldpay, current_user)
+      transient_registration.prepare_for_payment(:worldpay, current_user)
     end
 
     let(:order) { transient_registration.finance_details.orders.first }

--- a/spec/services/waste_carriers_engine/worldpay_validator_service_spec.rb
+++ b/spec/services/waste_carriers_engine/worldpay_validator_service_spec.rb
@@ -21,7 +21,7 @@ module WasteCarriersEngine
       current_user = build(:user)
       # We need to set a specific time so we know what order code to expect
       Timecop.freeze(Time.new(2018, 1, 1)) do
-        WasteCarriersEngine::FinanceDetails.new_finance_details(transient_registration, :worldpay, current_user)
+        transient_registration.prepare_for_payment(:worldpay, current_user)
       end
     end
 

--- a/spec/support/shared_examples/request_get_unsuccessful_worldpay_response.rb
+++ b/spec/support/shared_examples/request_get_unsuccessful_worldpay_response.rb
@@ -20,7 +20,7 @@ RSpec.shared_examples "GET unsuccessful Worldpay response" do |action|
       let(:reg_id) { transient_registration[:reg_identifier] }
 
       before do
-        WasteCarriersEngine::FinanceDetails.new_finance_details(transient_registration, :worldpay, user)
+        transient_registration.prepare_for_payment(:worldpay, user)
       end
 
       let(:order) do

--- a/spec/support/shared_examples/worldpay_service_valid_unsuccessful_action.rb
+++ b/spec/support/shared_examples/worldpay_service_valid_unsuccessful_action.rb
@@ -13,7 +13,7 @@ RSpec.shared_examples "WorldpayService valid unsuccessful action" do |valid_acti
   before do
     allow(Rails.configuration).to receive(:renewal_charge).and_return(10_500)
 
-    WasteCarriersEngine::FinanceDetails.new_finance_details(transient_registration, :worldpay, current_user)
+    transient_registration.prepare_for_payment(:worldpay, current_user)
   end
 
   let(:order) { transient_registration.finance_details.orders.first }


### PR DESCRIPTION
This moves the `prepare_for_payment` implementation and responsibility into the transient object. Will give us the ability to re-use the code in the Worldpay controller.