### PR TITLE
Refuse or revoke registration after failed conviction check

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_change_conviction_workflow_status.rb
+++ b/app/models/concerns/waste_carriers_engine/can_change_conviction_workflow_status.rb
@@ -31,7 +31,7 @@ module WasteCarriersEngine
         event :reject do
           transitions from: :checks_in_progress,
                       to: :rejected,
-                      after: :revoke_parent
+                      after: :refuse_or_revoke_parent
         end
       end
     end
@@ -44,10 +44,14 @@ module WasteCarriersEngine
       self.confirmed_by = current_user.email
     end
 
-    def revoke_parent
+    def refuse_or_revoke_parent
       return unless _parent&.metaData
 
-      _parent.metaData.revoke!
+      if _parent.pending?
+        _parent.metaData.refuse!
+      else
+        _parent.metaData.revoke!
+      end
     end
   end
 end

--- a/app/models/concerns/waste_carriers_engine/can_change_conviction_workflow_status.rb
+++ b/app/models/concerns/waste_carriers_engine/can_change_conviction_workflow_status.rb
@@ -25,22 +25,26 @@ module WasteCarriersEngine
           transitions from: %i[possible_match
                                checks_in_progress],
                       to: :approved,
-                      after: :update_confirmed_info
+                      after: %i[update_confirmed_status
+                                update_confirmed_metadata]
         end
 
         event :reject do
           transitions from: :checks_in_progress,
                       to: :rejected,
                       after: %i[refuse_or_revoke_parent
-                                update_confirmed_info]
+                                update_confirmed_metadata]
         end
       end
     end
 
     private
 
-    def update_confirmed_info(current_user)
+    def update_confirmed_status
       self.confirmed = "yes"
+    end
+
+    def update_confirmed_metadata(current_user)
       self.confirmed_at = Time.current
       self.confirmed_by = current_user.email
     end

--- a/app/models/concerns/waste_carriers_engine/can_change_conviction_workflow_status.rb
+++ b/app/models/concerns/waste_carriers_engine/can_change_conviction_workflow_status.rb
@@ -31,7 +31,8 @@ module WasteCarriersEngine
         event :reject do
           transitions from: :checks_in_progress,
                       to: :rejected,
-                      after: :refuse_or_revoke_parent
+                      after: %i[refuse_or_revoke_parent
+                                update_confirmed_info]
         end
       end
     end

--- a/spec/models/waste_carriers_engine/conviction_sign_off_spec.rb
+++ b/spec/models/waste_carriers_engine/conviction_sign_off_spec.rb
@@ -102,6 +102,10 @@ module WasteCarriersEngine
           conviction_sign_off.workflow_state = "checks_in_progress"
         end
 
+        it "does not update confirmed" do
+          expect(conviction_sign_off.confirmed).to eq("no")
+        end
+
         it "updates confirmed_at" do
           conviction_sign_off.reject(user)
           expect(conviction_sign_off.confirmed_at).to be_a(DateTime)

--- a/spec/models/waste_carriers_engine/conviction_sign_off_spec.rb
+++ b/spec/models/waste_carriers_engine/conviction_sign_off_spec.rb
@@ -100,11 +100,24 @@ module WasteCarriersEngine
       context "when the reject event happens" do
         before do
           conviction_sign_off.workflow_state = "checks_in_progress"
-          conviction_sign_off.reject
         end
 
-        it "updates the transient_registration's metaData.status" do
-          expect(transient_registration.metaData.status).to eq("REVOKED")
+        context "when the metaData status is pending" do
+          before { transient_registration.metaData.status = :PENDING }
+
+          it "updates the metaData status to refused" do
+            conviction_sign_off.reject
+            expect(transient_registration.metaData.status).to eq("REFUSED")
+          end
+        end
+
+        context "when the metaData status is not pending" do
+          before { transient_registration.metaData.status = :ACTIVE }
+
+          it "updates the metaData status to revoked" do
+            conviction_sign_off.reject
+            expect(transient_registration.metaData.status).to eq("REVOKED")
+          end
         end
       end
     end

--- a/spec/models/waste_carriers_engine/conviction_sign_off_spec.rb
+++ b/spec/models/waste_carriers_engine/conviction_sign_off_spec.rb
@@ -102,11 +102,21 @@ module WasteCarriersEngine
           conviction_sign_off.workflow_state = "checks_in_progress"
         end
 
+        it "updates confirmed_at" do
+          conviction_sign_off.reject(user)
+          expect(conviction_sign_off.confirmed_at).to be_a(DateTime)
+        end
+
+        it "updates confirmed_by" do
+          conviction_sign_off.reject(user)
+          expect(conviction_sign_off.confirmed_by).to eq(user.email)
+        end
+
         context "when the metaData status is pending" do
           before { transient_registration.metaData.status = :PENDING }
 
           it "updates the metaData status to refused" do
-            conviction_sign_off.reject
+            conviction_sign_off.reject(user)
             expect(transient_registration.metaData.status).to eq("REFUSED")
           end
         end
@@ -115,7 +125,7 @@ module WasteCarriersEngine
           before { transient_registration.metaData.status = :ACTIVE }
 
           it "updates the metaData status to revoked" do
-            conviction_sign_off.reject
+            conviction_sign_off.reject(user)
             expect(transient_registration.metaData.status).to eq("REVOKED")
           end
         end

--- a/spec/support/shared_examples/transient_registration_named_scopes.rb
+++ b/spec/support/shared_examples/transient_registration_named_scopes.rb
@@ -99,7 +99,7 @@ RSpec.shared_examples "TransientRegistration named scopes" do
 
     let(:convictions_rejected_renewal) do
       convictions_renewal.conviction_sign_offs.first.begin_checks!
-      convictions_renewal.conviction_sign_offs.first.reject!
+      convictions_renewal.conviction_sign_offs.first.reject!(build(:user))
       convictions_renewal
     end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-794

If something is not yet active, it would be refused; otherwise, it is revoked.

Plus a bonus fix!