### PR TITLE
Remove order copy cards shared form and create concern

### DIFF
--- a/app/controllers/concerns/waste_carriers_engine/order_copy_cards_permission_checks.rb
+++ b/app/controllers/concerns/waste_carriers_engine/order_copy_cards_permission_checks.rb
@@ -1,18 +1,14 @@
 # frozen_string_literal: true
 
 module WasteCarriersEngine
-  class BaseOrderCopyCardsFormsController < FormsController
-    def find_or_initialize_transient_registration(reg_identifier)
-      @transient_registration = OrderCopyCardsRegistration.where(reg_identifier: reg_identifier).first ||
-                                OrderCopyCardsRegistration.new(reg_identifier: reg_identifier)
-    end
+  module OrderCopyCardsPermissionChecks
+    extend ActiveSupport::Concern
 
     def setup_checks_pass?
       transient_registration_is_valid? && user_has_permission? && registation_is_active? && state_is_correct?
     end
 
     # Guards
-
     def user_has_permission?
       return true if can? :order_copy_cards, @transient_registration.registration
 

--- a/app/controllers/waste_carriers_engine/copy_cards_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/copy_cards_forms_controller.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 module WasteCarriersEngine
-  class CopyCardsFormsController < BaseOrderCopyCardsFormsController
+  class CopyCardsFormsController < FormsController
+    include OrderCopyCardsPermissionChecks
+
     def new
       super(CopyCardsForm, "copy_cards_form")
     end
@@ -14,6 +16,11 @@ module WasteCarriersEngine
 
     def transient_registration_attributes
       params.fetch(:copy_cards_form).permit(:temp_cards)
+    end
+
+    def find_or_initialize_transient_registration(reg_identifier)
+      @transient_registration = OrderCopyCardsRegistration.where(reg_identifier: reg_identifier).first ||
+                                OrderCopyCardsRegistration.new(reg_identifier: reg_identifier)
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/copy_cards_payment_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/copy_cards_payment_forms_controller.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 module WasteCarriersEngine
-  class CopyCardsPaymentFormsController < BaseOrderCopyCardsFormsController
+  class CopyCardsPaymentFormsController < FormsController
+    include OrderCopyCardsPermissionChecks
+
     def new
       super(CopyCardsPaymentForm, "copy_cards_payment_form")
     end

--- a/app/controllers/waste_carriers_engine/forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/forms_controller.rb
@@ -35,7 +35,7 @@ module WasteCarriersEngine
     end
 
     def find_or_initialize_transient_registration(reg_identifier)
-      @transient_registration = RenewingRegistration.where(reg_identifier: reg_identifier).first ||
+      @transient_registration = TransientRegistration.where(reg_identifier: reg_identifier).first ||
                                 RenewingRegistration.new(reg_identifier: reg_identifier)
     end
 

--- a/config/locales/models/order_copy_cards_registrations/en.yml
+++ b/config/locales/models/order_copy_cards_registrations/en.yml
@@ -1,0 +1,11 @@
+en:
+  activemodel:
+    errors:
+      models:
+        waste_carriers_engine:
+          order_copy_cards_registration:
+            attributes:
+              reg_identifier:
+                invalid_format: "The registration ID is not in a valid format"
+                no_registration: "There is no registration matching this ID"
+                renewal_in_progress: "This renewal is already in progress"

--- a/spec/factories/order_copy_cards_registration.rb
+++ b/spec/factories/order_copy_cards_registration.rb
@@ -2,5 +2,6 @@
 
 FactoryBot.define do
   factory :order_copy_cards_registration, class: WasteCarriersEngine::OrderCopyCardsRegistration do
+    initialize_with { new(reg_identifier: create(:registration, :has_required_data, :is_active).reg_identifier) }
   end
 end

--- a/spec/requests/waste_carriers_engine/copy_cards_payment_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/copy_cards_payment_forms_spec.rb
@@ -122,16 +122,15 @@ module WasteCarriersEngine
         end
 
         context "when a matching registration exists" do
-          let(:registration) { create(:registration, :has_required_data, :is_active) }
+          let(:transient_registration) { create(:order_copy_cards_registration) }
 
           before do
-            order_copy_cards_registration = OrderCopyCardsRegistration.new(reg_identifier: registration.reg_identifier)
-            order_copy_cards_registration.workflow_state = "copy_cards_payment_form"
-            order_copy_cards_registration.save
+            transient_registration.workflow_state = "copy_cards_payment_form"
+            transient_registration.save
           end
 
           context "when valid params are submitted" do
-            let(:valid_params) { { reg_identifier: registration.reg_identifier, temp_payment_method: temp_payment_method } }
+            let(:valid_params) { { reg_identifier: transient_registration.reg_identifier, temp_payment_method: temp_payment_method } }
 
             context "when the temp payment method is `card`" do
               let(:temp_payment_method) { "card" }
@@ -139,7 +138,7 @@ module WasteCarriersEngine
               it "updates the transient registration with correct data, returns a 302 response and redirects to the worldpay form" do
                 post copy_cards_payment_forms_path, copy_cards_payment_form: valid_params
 
-                transient_registration = OrderCopyCardsRegistration.find_by(reg_identifier: registration.reg_identifier)
+                transient_registration.reload
 
                 expect(transient_registration.temp_payment_method).to eq("card")
                 expect(response).to have_http_status(302)
@@ -153,7 +152,7 @@ module WasteCarriersEngine
               it "updates the transient registration with correct data, returns a 302 response and redirects to the bank transfer form" do
                 post copy_cards_payment_forms_path, copy_cards_payment_form: valid_params
 
-                transient_registration = OrderCopyCardsRegistration.find_by(reg_identifier: registration.reg_identifier)
+                transient_registration.reload
 
                 expect(transient_registration.temp_payment_method).to eq("bank_transfer")
                 expect(response).to have_http_status(302)
@@ -163,7 +162,7 @@ module WasteCarriersEngine
           end
 
           context "when invalid params are submitted" do
-            let(:invalid_params) { { reg_identifier: registration.reg_identifier, temp_payment_method: "foo" } }
+            let(:invalid_params) { { reg_identifier: transient_registration.reg_identifier, temp_payment_method: "foo" } }
 
             it "returns a 200 response and render the new copy cards form" do
               post copy_cards_payment_forms_path, copy_cards_payment_form: invalid_params


### PR DESCRIPTION
In order to be able to reuse other forms in the order copy cards flow, such as the worldpay forms, this changes the strategy used to deal with the initialization of transient registrations in the base form and create a concern to deal with permission custom rules of the order copy cards form.
This will bring it more in line with what we have done in wex to share screens between the various transient objects (Edit, New, Renew).
However, this introduce a foundamental issue in the fact that transient registrations are not uniquely identifiable by reg_identifier any more. This means that this version of the code cannot be deployed until we have completed the refactoring which is going to replace reg_identifiers with unique tokens in routes and URL, as per WEX.