### PR TITLE
Set up RegistrationCompletionService

### DIFF
--- a/app/services/waste_carriers_engine/registration_completion_service.rb
+++ b/app/services/waste_carriers_engine/registration_completion_service.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class RegistrationCompletionService < BaseService
+    def run(registration:)
+      registration.metaData.date_activated = Time.current
+      registration.metaData.activate!
+    end
+  end
+end

--- a/app/services/waste_carriers_engine/registration_completion_service.rb
+++ b/app/services/waste_carriers_engine/registration_completion_service.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 module WasteCarriersEngine
+  class UnpaidBalanceError < StandardError; end
+  class PendingConvictionsError < StandardError; end
+
   class RegistrationCompletionService < BaseService
     def run(registration:)
       @registration = registration
@@ -20,27 +23,15 @@ module WasteCarriersEngine
     end
 
     def balance_is_paid?
-      if @registration.unpaid_balance?
-        raise_unpaid_balance_error
-      else
-        true
-      end
+      raise UnpaidBalanceError if @registration.unpaid_balance?
+
+      true
     end
 
     def no_pending_conviction_check?
-      if @registration.pending_manual_conviction_check?
-        raise_convictions_check_error
-      else
-        true
-      end
-    end
+      raise PendingConvictionsError if @registration.pending_manual_conviction_check?
 
-    def raise_unpaid_balance_error
-      raise "Registration #{@registration.reg_identifier} cannot be activated due to unpaid balance"
-    end
-
-    def raise_convictions_check_error
-      raise "Registration #{@registration.reg_identifier} cannot be activated due to pending convictions check"
+      true
     end
   end
 end

--- a/app/services/waste_carriers_engine/registration_completion_service.rb
+++ b/app/services/waste_carriers_engine/registration_completion_service.rb
@@ -16,13 +16,31 @@ module WasteCarriersEngine
     end
 
     def can_be_completed?
-      raise_unpaid_balance_error if @registration.unpaid_balance?
+      balance_is_paid? && no_pending_conviction_check?
+    end
 
-      true
+    def balance_is_paid?
+      if @registration.unpaid_balance?
+        raise_unpaid_balance_error
+      else
+        true
+      end
+    end
+
+    def no_pending_conviction_check?
+      if @registration.pending_manual_conviction_check?
+        raise_convictions_check_error
+      else
+        true
+      end
     end
 
     def raise_unpaid_balance_error
       raise "Registration #{@registration.reg_identifier} cannot be activated due to unpaid balance"
+    end
+
+    def raise_convictions_check_error
+      raise "Registration #{@registration.reg_identifier} cannot be activated due to pending convictions check"
     end
   end
 end

--- a/app/services/waste_carriers_engine/registration_completion_service.rb
+++ b/app/services/waste_carriers_engine/registration_completion_service.rb
@@ -3,8 +3,26 @@
 module WasteCarriersEngine
   class RegistrationCompletionService < BaseService
     def run(registration:)
-      registration.metaData.date_activated = Time.current
-      registration.metaData.activate!
+      @registration = registration
+
+      activate_registration if can_be_completed?
+    end
+
+    private
+
+    def activate_registration
+      @registration.metaData.date_activated = Time.current
+      @registration.metaData.activate!
+    end
+
+    def can_be_completed?
+      raise_unpaid_balance_error if @registration.unpaid_balance?
+
+      true
+    end
+
+    def raise_unpaid_balance_error
+      raise "Registration #{@registration.reg_identifier} cannot be activated due to unpaid balance"
     end
   end
 end

--- a/spec/services/waste_carriers_engine/registration_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/registration_completion_service_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe RegistrationCompletionService do
+    let(:registration) { create(:registration, :has_required_data, :is_pending) }
+
+    let(:service) { RegistrationCompletionService.run(registration: registration) }
+
+    let(:current_time) { Time.new(2020, 1, 1) }
+
+    describe "run" do
+      before { allow(Time).to receive(:current).and_return(current_time) }
+
+      it "updates the date_activated" do
+        registration.metaData.update_attributes(date_activated: nil)
+
+        expect { service }.to change { registration.metaData.reload.date_activated }.to(current_time)
+      end
+
+      it "activates the registration" do
+        expect { service }.to change { registration.active? }.from(false).to(true)
+      end
+    end
+  end
+end

--- a/spec/services/waste_carriers_engine/registration_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/registration_completion_service_spec.rb
@@ -32,9 +32,7 @@ module WasteCarriersEngine
         before { allow(registration).to receive(:unpaid_balance?).and_return(true) }
 
         it "raises an error" do
-          message = "Registration #{registration.reg_identifier} cannot be activated due to unpaid balance"
-
-          expect { service }.to raise_error(RuntimeError, message)
+          expect { service }.to raise_error(UnpaidBalanceError)
         end
       end
 
@@ -42,9 +40,7 @@ module WasteCarriersEngine
         before { allow(registration).to receive(:pending_manual_conviction_check?).and_return(true) }
 
         it "raises an error" do
-          message = "Registration #{registration.reg_identifier} cannot be activated due to pending convictions check"
-
-          expect { service }.to raise_error(RuntimeError, message)
+          expect { service }.to raise_error(PendingConvictionsError)
         end
       end
     end

--- a/spec/services/waste_carriers_engine/registration_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/registration_completion_service_spec.rb
@@ -13,8 +13,9 @@ module WasteCarriersEngine
     describe "run" do
       before { allow(Time).to receive(:current).and_return(current_time) }
 
-      context "when there is no unpaid balance" do
+      context "when there is no unpaid balance or pending convictions check" do
         before { allow(registration).to receive(:unpaid_balance?).and_return(false) }
+        before { allow(registration).to receive(:pending_manual_conviction_check?).and_return(false) }
 
         it "updates the date_activated" do
           registration.metaData.update_attributes(date_activated: nil)
@@ -32,6 +33,16 @@ module WasteCarriersEngine
 
         it "raises an error" do
           message = "Registration #{registration.reg_identifier} cannot be activated due to unpaid balance"
+
+          expect { service }.to raise_error(RuntimeError, message)
+        end
+      end
+
+      context "when the registration has a pending convictions check" do
+        before { allow(registration).to receive(:pending_manual_conviction_check?).and_return(true) }
+
+        it "raises an error" do
+          message = "Registration #{registration.reg_identifier} cannot be activated due to pending convictions check"
 
           expect { service }.to raise_error(RuntimeError, message)
         end

--- a/spec/services/waste_carriers_engine/registration_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/registration_completion_service_spec.rb
@@ -13,14 +13,28 @@ module WasteCarriersEngine
     describe "run" do
       before { allow(Time).to receive(:current).and_return(current_time) }
 
-      it "updates the date_activated" do
-        registration.metaData.update_attributes(date_activated: nil)
+      context "when there is no unpaid balance" do
+        before { allow(registration).to receive(:unpaid_balance?).and_return(false) }
 
-        expect { service }.to change { registration.metaData.reload.date_activated }.to(current_time)
+        it "updates the date_activated" do
+          registration.metaData.update_attributes(date_activated: nil)
+
+          expect { service }.to change { registration.metaData.reload.date_activated }.to(current_time)
+        end
+
+        it "activates the registration" do
+          expect { service }.to change { registration.active? }.from(false).to(true)
+        end
       end
 
-      it "activates the registration" do
-        expect { service }.to change { registration.active? }.from(false).to(true)
+      context "when the balance is unpaid" do
+        before { allow(registration).to receive(:unpaid_balance?).and_return(true) }
+
+        it "raises an error" do
+          message = "Registration #{registration.reg_identifier} cannot be activated due to unpaid balance"
+
+          expect { service }.to raise_error(RuntimeError, message)
+        end
       end
     end
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-793

When conviction checks for new registrations are moved into the back office, this is the first time we'll need to 'complete' a new registration in the new codebase. So this PR creates a RegistrationCompletionService to handle that.

When the new registration journey starts to use transient_registrations, this will probably need some modifying to deal with those instead of the registration model.