### PR TITLE
Persist setting of expiries_on when activating

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_change_registration_status.rb
+++ b/app/models/concerns/waste_carriers_engine/can_change_registration_status.rb
@@ -57,7 +57,7 @@ module WasteCarriersEngine
 
       # Transition effects
       def set_expiry_date
-        registration.expires_on = Rails.configuration.expires_after.years.from_now
+        registration.update_attributes(expires_on: Rails.configuration.expires_after.years.from_now)
       end
 
       def log_status_change

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -393,13 +393,17 @@ module WasteCarriersEngine
         end
 
         context "when a registration is activated" do
-          let(:registration) { build(:registration, :is_pending) }
+          let(:registration) { create(:registration, :has_required_data, :is_pending) }
+
+          before { allow(Rails.configuration).to receive(:expires_after).and_return(3) }
 
           it "sets expires_on 3 years in the future" do
             expect(registration.expires_on).to be_nil
-            registration.metaData.activate
+
+            registration.metaData.activate!
+
             # Use .to_i to ignore milliseconds when comparing time
-            expect(registration.expires_on.to_i).to eq(3.years.from_now.to_i)
+            expect(registration.reload.expires_on.to_i).to eq(3.years.from_now.to_i)
           end
         end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-793

Spotted that while the `activate` event sets the `expires_on` in memory, it doesn't persist it. This means that if the registration was assigned an `expires_on` when it was first submitted through the frontend, that value sticks, although the behaviour we want is for it to expire 3 years after approval.

So this fixes that.