### PR TITLE
Change complete workflow to specific copy cards complete status

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_use_order_copy_cards_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_order_copy_cards_workflow.rb
@@ -18,7 +18,7 @@ module WasteCarriersEngine
         state :copy_cards_payment_form
         state :worldpay_form
         state :copy_cards_bank_transfer_form
-        state :completed
+        state :copy_cards_order_completed_form
 
         # Transitions
         event :next do
@@ -35,11 +35,11 @@ module WasteCarriersEngine
 
           # TODO: after: :complete_order
           transitions from: :copy_cards_bank_transfer_form,
-                      to: :completed
+                      to: :copy_cards_order_completed_form
 
           # TODO: after: :complete_order
           transitions from: :worldpay_form,
-                      to: :completed
+                      to: :copy_cards_order_completed_form
         end
 
         event :back do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,11 @@ WasteCarriersEngine::Engine.routes.draw do
                     as: "back",
                     on: :collection
               end
+
+    resources :copy_cards_order_completed_forms,
+              only: %i[new create],
+              path: "order-copy-cards-complete",
+              path_names: { new: "" }
     # End of order copy cards flow
 
     resources :renewal_start_forms,

--- a/spec/models/waste_carriers_engine/order_copy_cards_registration_workflow_state/copy_cards_bank_transfer_form_spec.rb
+++ b/spec/models/waste_carriers_engine/order_copy_cards_registration_workflow_state/copy_cards_bank_transfer_form_spec.rb
@@ -7,12 +7,12 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":copy_cards_bank_transfer_form state transitions" do
         context "on next" do
-          it "can transition from a :copy_cards_bank_transfer_form state to a :completed" do
+          it "can transition from a :copy_cards_bank_transfer_form state to a :copy_cards_order_completed_form" do
             order_copy_cards_registration.workflow_state = :copy_cards_bank_transfer_form
 
             order_copy_cards_registration.next
 
-            expect(order_copy_cards_registration.workflow_state).to eq("completed")
+            expect(order_copy_cards_registration.workflow_state).to eq("copy_cards_order_completed_form")
           end
         end
 

--- a/spec/models/waste_carriers_engine/order_copy_cards_registration_workflow_state/wordpay_form_spec.rb
+++ b/spec/models/waste_carriers_engine/order_copy_cards_registration_workflow_state/wordpay_form_spec.rb
@@ -7,12 +7,12 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":worldpay_form state transitions" do
         context "on next" do
-          it "can transition from a :worldpay_form state to a :completed" do
+          it "can transition from a :worldpay_form state to a :copy_cards_order_completed_form" do
             order_copy_cards_registration.workflow_state = :worldpay_form
 
             order_copy_cards_registration.next
 
-            expect(order_copy_cards_registration.workflow_state).to eq("completed")
+            expect(order_copy_cards_registration.workflow_state).to eq("copy_cards_order_completed_form")
           end
         end
 


### PR DESCRIPTION
This renames the complete status to have a more flow-specific name. 