### PR TITLE
Implement view for bank transfer page on order copy cards flow

### DIFF
--- a/app/views/waste_carriers_engine/copy_cards_bank_transfer_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/copy_cards_bank_transfer_forms/new.html.erb
@@ -1,0 +1,82 @@
+<%= render("waste_carriers_engine/shared/back", back_path: back_copy_cards_bank_transfer_forms_path(@copy_cards_bank_transfer_form.reg_identifier)) %>
+
+<div class="text">
+  <%= form_for(@copy_cards_bank_transfer_form) do |f| %>
+    <%= render("waste_carriers_engine/shared/errors", object: @copy_cards_bank_transfer_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <div class="panel">
+      <%= t(".subheading_panel") %>
+    </div>
+
+    <div class="form-group">
+      <table>
+        <legend>
+          <h2 class="heading-medium">
+            <%= t(".uk_payment_table.heading") %>
+          </h2>
+        </legend>
+
+        <tbody>
+          <tr>
+            <th><%= t(".uk_payment_table.sort_code.label") %></th>
+            <td><%= t(".uk_payment_table.sort_code.value") %></td>
+          </tr>
+          <tr>
+            <td><%= t(".uk_payment_table.account_number.label") %></td>
+            <td><%= t(".uk_payment_table.account_number.value") %></td>
+          </tr>
+          <tr>
+            <th><%= t(".uk_payment_table.reference_number.label") %></th>
+            <td><%= @copy_cards_bank_transfer_form.reg_identifier %></td>
+          </tr>
+          <tr>
+            <td><%= t(".uk_payment_table.total_cost.label") %></td>
+            <td>£<%= display_pence_as_pounds(@copy_cards_bank_transfer_form.total_to_pay) %></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <details>
+      <summary>
+        <%= t(".overseas_payments.heading") %>
+      </summary>
+      <div class="panel">
+        <%= t(".overseas_payments.iban") %><br/><br/>
+        <%= t(".overseas_payments.swiftbic") %><br/><br/>
+        <%= t(".overseas_payments.currency") %>
+      </div>
+    </details>
+
+    <div class="form-group">
+      <table>
+        <legend>
+          <h2 class="heading-medium">
+            <%= t(".send_confirmation.heading") %>
+          </h2>
+
+          <div class="panel">
+            <%= t(".send_confirmation.sub_heading") %>
+          </div>
+        </legend>
+
+        <tbody>
+          <tr>
+            <th><%= t(".email_us.label") %></th>
+            <td><%= t(".email_us.value") %></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p>
+      <%= t(".cards_info") %>
+    </p>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/config/locales/forms/copy_cards_bank_transfer_forms/en.yml
+++ b/config/locales/forms/copy_cards_bank_transfer_forms/en.yml
@@ -1,0 +1,32 @@
+en:
+  waste_carriers_engine:
+    copy_cards_bank_transfer_forms:
+      new:
+        next_button: Continue
+        heading: "Details for bank transfer"
+        subheading_panel: "Make sure the customer includes their CBDU number as the payment reference, or we won’t be able to match the payment."
+        uk_payment_table:
+          heading: "Bank details"
+          sort_code:
+            label: Sort code
+            value: 60-70-80
+          account_number:
+            label: Account number
+            value: "10014411"
+          reference_number:
+            label: Payment reference
+          total_cost:
+            label: Payment due
+        overseas_payments:
+          heading: "Overseas payments"
+          iban: "IBAN: GB23 NWBK 607080 10014411"
+          swiftbic: "SWIFTBIC: NWBK GB2L"
+          currency: "Currency: Sterling"
+        send_confirmation:
+          heading: "Send us confirmation"
+          sub_heading: "Remind the customer to send us notification of the payment once the bank transfer has been arranged."
+        email_us:
+          label: "Email us"
+          value: "ea_fsc_ar@sscl.gse.gov.uk"
+        cards_info: "Cards will be sent out after the payment has cleared."
+        next_button: "Complete order"


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-767

This implements the view for the bank transfer informative screen on the order copy cards flow, as per wireframe.

<img width="586" alt="Screenshot 2019-12-11 at 13 59 10" src="https://user-images.githubusercontent.com/1385397/70649904-5b1ee680-1c4e-11ea-9d38-b1b823cfc9b5.png">
