### PR TITLE
Redirects to the correct workflow state when an order is in progress

### DIFF
--- a/app/controllers/waste_carriers_engine/copy_cards_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/copy_cards_forms_controller.rb
@@ -16,9 +16,11 @@ module WasteCarriersEngine
       params.fetch(:copy_cards_form).permit(:temp_cards)
     end
 
+    # rubocop:disable Naming/MemoizedInstanceVariableName
     def find_or_initialize_transient_registration(token)
-      @transient_registration = OrderCopyCardsRegistration.where(token: token).first ||
-                                OrderCopyCardsRegistration.new(reg_identifier: token)
+      @transient_registration ||= OrderCopyCardsRegistration.where(reg_identifier: token).first ||
+                                  OrderCopyCardsRegistration.new(reg_identifier: token)
     end
+    # rubocop:enable Naming/MemoizedInstanceVariableName
   end
 end

--- a/app/controllers/waste_carriers_engine/copy_cards_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/copy_cards_forms_controller.rb
@@ -19,6 +19,7 @@ module WasteCarriersEngine
     # rubocop:disable Naming/MemoizedInstanceVariableName
     def find_or_initialize_transient_registration(token)
       @transient_registration ||= OrderCopyCardsRegistration.where(reg_identifier: token).first ||
+                                  OrderCopyCardsRegistration.where(token: token).first ||
                                   OrderCopyCardsRegistration.new(reg_identifier: token)
     end
     # rubocop:enable Naming/MemoizedInstanceVariableName

--- a/app/forms/waste_carriers_engine/copy_cards_form.rb
+++ b/app/forms/waste_carriers_engine/copy_cards_form.rb
@@ -3,7 +3,7 @@
 module WasteCarriersEngine
   class CopyCardsForm < CardsForm
     def self.can_navigate_flexibly?
-      true
+      false
     end
 
     validates(

--- a/spec/factories/order_copy_cards_registration.rb
+++ b/spec/factories/order_copy_cards_registration.rb
@@ -8,5 +8,10 @@ FactoryBot.define do
       temp_cards { 1 }
       finance_details { build(:finance_details, :has_copy_cards_order) }
     end
+
+    trait :copy_cards_payment_form_state do
+      workflow_state { :copy_cards_payment_form }
+      temp_cards { 1 }
+    end
   end
 end

--- a/spec/requests/waste_carriers_engine/copy_cards_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/copy_cards_forms_spec.rb
@@ -50,14 +50,18 @@ module WasteCarriersEngine
             end
 
             context "when an order is in progress" do
-              # TODO: Discuss at dev meeting.
-              # When the `let`ed attribute is passed by as an attribute, it does not get initialised up until the
-              # request have been made. This means that the DB will be empty when the request executes.
-              # Using `let!` for now.
               let!(:transient_registration) { create(:order_copy_cards_registration, :copy_cards_payment_form_state) }
 
+              context "when the token is a reg_identifier" do
+                it "redirects to the correct workflow state form" do
+                  get new_copy_cards_form_path(transient_registration.registration.reg_identifier)
+
+                  expect(response).to redirect_to(new_copy_cards_payment_form_path(transient_registration.token))
+                end
+              end
+
               it "redirects to the correct workflow state form" do
-                get new_copy_cards_form_path(transient_registration.registration.reg_identifier)
+                get new_copy_cards_form_path(transient_registration.token)
 
                 expect(response).to redirect_to(new_copy_cards_payment_form_path(transient_registration.token))
               end

--- a/spec/requests/waste_carriers_engine/copy_cards_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/copy_cards_forms_spec.rb
@@ -48,6 +48,23 @@ module WasteCarriersEngine
               expect(response).to render_template("waste_carriers_engine/copy_cards_forms/new")
               expect(response.code).to eq("200")
             end
+
+            context "when an order is in progress" do
+              # TODO: Discuss at dev meeting.
+              # When the `let`ed attribute is passed by as an attribute, it does not get initialised up until the
+              # request have been made. This means that the DB will be empty when the request executes.
+              # Using `let!` for now.
+              let!(:transient_registration) { create(:order_copy_cards_registration, :copy_cards_payment_form_state) }
+
+              it "respond with a 200 status, updates the workflow state and  prepopulate data on the view" do
+                get new_copy_cards_form_path(transient_registration.registration.reg_identifier)
+
+                expect(response).to render_template("waste_carriers_engine/copy_cards_forms/new")
+                expect(response.code).to eq("200")
+                expect(transient_registration.reload.workflow_state).to eq(:copy_cards_forms)
+                expect(response.body).to include("value=\"#{transient_registration.temp_cards}\"")
+              end
+            end
           end
         end
       end

--- a/spec/requests/waste_carriers_engine/copy_cards_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/copy_cards_forms_spec.rb
@@ -56,13 +56,10 @@ module WasteCarriersEngine
               # Using `let!` for now.
               let!(:transient_registration) { create(:order_copy_cards_registration, :copy_cards_payment_form_state) }
 
-              it "respond with a 200 status, updates the workflow state and  prepopulate data on the view" do
+              it "redirects to the correct workflow state form" do
                 get new_copy_cards_form_path(transient_registration.registration.reg_identifier)
 
-                expect(response).to render_template("waste_carriers_engine/copy_cards_forms/new")
-                expect(response.code).to eq("200")
-                expect(transient_registration.reload.workflow_state).to eq(:copy_cards_forms)
-                expect(response.body).to include("value=\"#{transient_registration.temp_cards}\"")
+                expect(response).to redirect_to(new_copy_cards_payment_form_path(transient_registration.token))
               end
             end
           end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-767

This fixes a bug which was creating a new transient object every time the start page of the flow was hit with a :reg_identifier. 