### PR TITLE
Update BaseForm to work with Registrations

### DIFF
--- a/app/forms/waste_carriers_engine/base_form.rb
+++ b/app/forms/waste_carriers_engine/base_form.rb
@@ -9,11 +9,19 @@ module WasteCarriersEngine
 
     attr_reader :transient_registration
 
-    delegate :token, :reg_identifier, to: :transient_registration
+    delegate :reg_identifier, to: :transient_registration
+    # Registrations don't have tokens, so don't try to delegate.
+    delegate :token, to: :transient_registration, if: lambda {
+      transient_registration&.is_a?(TransientRegistration)
+    }
 
     # If the record is new, and not yet persisted (which it is when the start
-    # page is first submitted) then we have nothing to validate hence the check
-    validates :token, presence: true, if: -> { transient_registration&.persisted? }
+    # page is first submitted) then we have nothing to validate, hence the check.
+    # Registrations also don't have tokens, so don't try to validate them.
+    validates :token, presence: true, if: lambda {
+      transient_registration&.persisted? &&
+        transient_registration&.is_a?(TransientRegistration)
+    }
     validates(
       :reg_identifier,
       "waste_carriers_engine/reg_identifier": true,

--- a/spec/forms/waste_carriers_engine/base_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/base_forms_spec.rb
@@ -37,8 +37,20 @@ module WasteCarriersEngine
           base_form.transient_registration.token = nil
         end
 
-        it "is not valid" do
-          expect(base_form).to_not be_valid
+        context "when the resource is a transient_registration" do
+          it "is not valid" do
+            expect(base_form).to_not be_valid
+          end
+        end
+
+        context "when the resource is not a transient_registration" do
+          before do
+            allow(base_form.transient_registration).to receive(:is_a?).with(TransientRegistration).and_return(false)
+          end
+
+          it "is valid" do
+            expect(base_form).to be_valid
+          end
         end
       end
     end


### PR DESCRIPTION
The back office has a few forms that inherit from BaseForm but supply a registration in place of a transient_registration. However, as registrations don't have tokens, this caused errors. This PR updates the BaseForm to only deal with tokens when the object in question is actually a TransientRegistration.

(We should arguably consider renaming `transient_registration` to `resource` or something like that, but I think that's a bigger job for another time!)