### PR TITLE
Fx bug on renewal start journey redirect

### DIFF
--- a/app/controllers/waste_carriers_engine/renewal_start_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/renewal_start_forms_controller.rb
@@ -13,7 +13,9 @@ module WasteCarriersEngine
     private
 
     def find_or_initialize_transient_registration(token)
+      # TODO: Downtime at deploy when releasing token?
       @transient_registration = RenewingRegistration.where(token: token).first ||
+                                RenewingRegistration.where(reg_identifier: token).first ||
                                 RenewingRegistration.new(reg_identifier: token)
     end
   end

--- a/app/forms/waste_carriers_engine/renewal_start_form.rb
+++ b/app/forms/waste_carriers_engine/renewal_start_form.rb
@@ -15,6 +15,7 @@ module WasteCarriersEngine
     def find_or_initialize_transient_registration(token)
       # TODO: Downtime at deploy when releasing token?
       @transient_registration = RenewingRegistration.where(token: token).first ||
+                                RenewingRegistration.where(reg_identifier: token).first ||
                                 RenewingRegistration.new(reg_identifier: token)
     end
   end

--- a/app/forms/waste_carriers_engine/renewal_start_form.rb
+++ b/app/forms/waste_carriers_engine/renewal_start_form.rb
@@ -11,12 +11,5 @@ module WasteCarriersEngine
 
       super(attributes)
     end
-
-    def find_or_initialize_transient_registration(token)
-      # TODO: Downtime at deploy when releasing token?
-      @transient_registration = RenewingRegistration.where(token: token).first ||
-                                RenewingRegistration.where(reg_identifier: token).first ||
-                                RenewingRegistration.new(reg_identifier: token)
-    end
   end
 end

--- a/spec/requests/waste_carriers_engine/renewal_start_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/renewal_start_forms_spec.rb
@@ -69,8 +69,17 @@ module WasteCarriersEngine
                          workflow_state: "location_form")
                 end
 
+                context "when the token is a reg_identifier" do
+                  it "redirects to the form for the current state" do
+                    get new_renewal_start_form_path(transient_registration.registration.reg_identifier)
+
+                    expect(response).to redirect_to(new_location_form_path(transient_registration[:token]))
+                  end
+                end
+
                 it "redirects to the form for the current state" do
                   get new_renewal_start_form_path(transient_registration[:token])
+
                   expect(response).to redirect_to(new_location_form_path(transient_registration[:token]))
                 end
               end


### PR DESCRIPTION
Since now the start page of the journey can be hit with either a token or a reg_identifier, we have to guarantee that the behaviour is going to be the same in each case.