### PR TITLE
Fix back buttons on copy cards journey pages

### DIFF
--- a/app/views/waste_carriers_engine/copy_cards_bank_transfer_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/copy_cards_bank_transfer_forms/new.html.erb
@@ -1,4 +1,4 @@
-<%= render("waste_carriers_engine/shared/back", back_path: back_copy_cards_bank_transfer_forms_path(@copy_cards_bank_transfer_form.reg_identifier)) %>
+<%= render("waste_carriers_engine/shared/back", back_path: back_copy_cards_bank_transfer_forms_path(@copy_cards_bank_transfer_form.token)) %>
 
 <div class="text">
   <%= form_for(@copy_cards_bank_transfer_form) do |f| %>

--- a/app/views/waste_carriers_engine/copy_cards_payment_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/copy_cards_payment_forms/new.html.erb
@@ -1,4 +1,4 @@
-<%= render("waste_carriers_engine/shared/back", back_path: back_copy_cards_payment_forms_path(reg_identifier: @transient_registration.reg_identifier)) %>
+<%= render("waste_carriers_engine/shared/back", back_path: back_copy_cards_payment_forms_path(token: @transient_registration.token)) %>
 
 <div class="text">
   <%= form_for(@copy_cards_payment_form) do |f| %>


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-767

Fix back buttons to send the correct token rather than a reg_identifier