### PR TITLE
Delegate registered address to transient object

### DIFF
--- a/app/models/waste_carriers_engine/order_copy_cards_registration.rb
+++ b/app/models/waste_carriers_engine/order_copy_cards_registration.rb
@@ -5,7 +5,8 @@ module WasteCarriersEngine
     include CanUseOrderCopyCardsWorkflow
 
     validates :reg_identifier, "waste_carriers_engine/reg_identifier": true
-    delegate :contact_address, to: :registration
+
+    delegate :contact_address, :registered_address, to: :registration
 
     def registration
       @_registration ||= Registration.find_by(reg_identifier: reg_identifier)


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-767

Since the worldpay form needs the registered address to be a method in the transient object, this delegates it to the registration and make it possible to use the shared worldpay service