### PR TITLE
Add email for completed copy cards order

### DIFF
--- a/app/mailers/waste_carriers_engine/order_copy_cards_mailer.rb
+++ b/app/mailers/waste_carriers_engine/order_copy_cards_mailer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class OrderCopyCardsMailer < BaseMailer
+    def send_order_completed_email(registration, order)
+      @presenter = OrderCopyCardsMailerPresenter.new(registration, order)
+
+      mail(to: @presenter.contact_email,
+           from: from_email,
+           subject: I18n.t(".waste_carriers_engine.order_copy_cards_mailer.send_order_completed_email.subject"))
+    end
+
+    # def send_awaiting_payment_email(registration, order)
+    #   TODO:
+    #   @presenter = OrderCopyCardsMailerPresenter.new(registration, order)
+
+    #   mail(to: @presenter.contact_email,
+    #        from: from_email,
+    #        subject: I18n.t(".waste_carriers_engine.order_copy_cards_mailer.send_awaiting_payment_email.subject"))
+    # end
+  end
+end

--- a/app/presenters/waste_carriers_engine/order_copy_cards_mailer_presenter.rb
+++ b/app/presenters/waste_carriers_engine/order_copy_cards_mailer_presenter.rb
@@ -2,7 +2,7 @@
 
 module WasteCarriersEngine
   class OrderCopyCardsMailerPresenter < BasePresenter
-    def initialize(registration, copy_cards_order, view_context=nil)
+    def initialize(registration, copy_cards_order, view_context = nil)
       @copy_cards_order = copy_cards_order
 
       super(registration, view_context)
@@ -13,11 +13,11 @@ module WasteCarriersEngine
     end
 
     def order_description
-      @_cards_count ||= copy_cards_order.order_items.first.description
+      @_order_description ||= copy_cards_order.order_items.first.description
     end
 
     def ordered_on_formatted_string
-      @_ordered_on ||= copy_cards_order.date_created.to_datetime.to_formatted_s(:day_month_year)
+      @_ordered_on_formatted_string ||= copy_cards_order.date_created.to_datetime.to_formatted_s(:day_month_year)
     end
 
     def total_paid

--- a/app/presenters/waste_carriers_engine/order_copy_cards_mailer_presenter.rb
+++ b/app/presenters/waste_carriers_engine/order_copy_cards_mailer_presenter.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class OrderCopyCardsMailerPresenter < BasePresenter
+    def initialize(registration, copy_cards_order, view_context=nil)
+      @copy_cards_order = copy_cards_order
+
+      super(registration, view_context)
+    end
+
+    def contact_name
+      @_contact_name ||= "#{first_name} #{last_name}"
+    end
+
+    def order_description
+      @_cards_count ||= copy_cards_order.order_items.first.description
+    end
+
+    def ordered_on_formatted_string
+      @_ordered_on ||= copy_cards_order.date_created.to_datetime.to_formatted_s(:day_month_year)
+    end
+
+    def total_paid
+      @_total_paid ||= copy_cards_order.total_amount
+    end
+
+    private
+
+    attr_reader :copy_cards_order
+  end
+end

--- a/app/services/waste_carriers_engine/order_copy_cards_completion_service.rb
+++ b/app/services/waste_carriers_engine/order_copy_cards_completion_service.rb
@@ -35,10 +35,18 @@ module WasteCarriersEngine
     end
 
     def send_confirmation_email
-      # TODO
-      # RenewalMailer.send_renewal_complete_email(registration).deliver_now
-      # rescue StandardError => e
-      #   Airbrake.notify(e, registration_no: registration.reg_identifier) if defined?(Airbrake)
+      if @transient_registration.unpaid_balance?
+        # TODO:
+        # OrderCopyCardsMailer.send_awaiting_payment_email(registration, copy_cards_order).deliver_now
+      else
+        OrderCopyCardsMailer.send_order_completed_email(registration, copy_cards_order).deliver_now
+      end
+    rescue StandardError => e
+      Airbrake.notify(e, registration_no: registration.reg_identifier) if defined?(Airbrake)
+    end
+
+    def copy_cards_order
+      @_copy_cards_order ||= transient_registration.finance_details.orders.last
     end
   end
 end

--- a/app/services/waste_carriers_engine/order_copy_cards_completion_service.rb
+++ b/app/services/waste_carriers_engine/order_copy_cards_completion_service.rb
@@ -36,8 +36,7 @@ module WasteCarriersEngine
 
     def send_confirmation_email
       if @transient_registration.unpaid_balance?
-        # TODO:
-        # OrderCopyCardsMailer.send_awaiting_payment_email(registration, copy_cards_order).deliver_now
+        # TODO: OrderCopyCardsMailer.send_awaiting_payment_email(registration, copy_cards_order).deliver_now
       else
         OrderCopyCardsMailer.send_order_completed_email(registration, copy_cards_order).deliver_now
       end

--- a/app/views/waste_carriers_engine/order_copy_cards_mailer/send_order_completed_email.html.erb
+++ b/app/views/waste_carriers_engine/order_copy_cards_mailer/send_order_completed_email.html.erb
@@ -1,0 +1,114 @@
+<!doctype html>
+<!--[if lt IE 7]>  <html class="ie ie6 lte9 lte8 lte7"> <![endif]-->
+<!--[if IE 7]>     <html class="ie ie7 lte9 lte8 lte7"> <![endif]-->
+<!--[if IE 8]>     <html class="ie ie8 lte9 lte8"> <![endif]-->
+<!--[if IE 9]>     <html class="ie ie9 lte9"> <![endif]-->
+<!--[if gt IE 9]>  <html> <![endif]-->
+<!--[if !IE]><!-->
+<html>
+<!--<![endif]-->
+
+<head>
+  <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+  <meta content="utf-8" http-equiv="encoding">
+  <!-- Use title if it's in the page YAML frontmatter -->
+  <title>Waste Carriers Service</title>
+</head>
+
+<body style="font-family: Helvetica, Arial, sans-serif; font-size: 16px; margin: 0; color: #0b0c0c">
+  <table width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+      <td width="100%" height="53px" bgcolor="#0b0c0c">
+        <table width="580" cellpadding="0" cellspacing="0" border="0" align="center">
+          <tr>
+            <td width="100%" bgcolor="#0b0c0c" valign="middle">
+              <%= email_image_tag("govuk_logotype_email.png", { alt: 'GOV.UK', border: '0' }) %>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+
+  <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF">
+    <tr>
+      <td width="100%">
+        <table width="580" cellpadding="0" cellspacing="0" border="0" align="center">
+          <tr>
+            <td width="100%" class="header" style="padding-top: 10px;" colspan="2">
+              <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF">
+                <tr>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td width="75%" style="font-family: Helvetica, Arial, sans-serif;">
+              <p style="font-weight: 400; font-size: 16px; line-height: 1; margin: 10px 0 10px 0;"><%= t(".dear", full_name: @presenter.contact_name) %></p>
+            </td>
+            <td width="25%">&nbsp;</td>
+          </tr>
+          <tr>
+            <td style="font-family: Helvetica, Arial, sans-serif; margin: 0 0 30px 0;">
+              <h1 style="font-size: 20px; margin: 10px 0px 15px 0px;">
+                <%= t(".heading") %>
+              </h1>
+            </td>
+            <td width="25%">&nbsp;</td>
+          </tr>
+          <tr>
+            <td width="75%" style="font-family: Helvetica, Arial, sans-serif;">
+              <p style="font-size: 18px; font-weight: bold; line-height: 1.315789474; margin: 0 0 15px 0;">
+                <%= t(".receipt.heading") %>
+              </p>
+
+              <p style="font-size: 16px; line-height: 1.125; margin: 0 0 15px 0;">
+                <%= t(".receipt.order", description: @presenter.order_description) %>
+              </p>
+              <p style="font-size: 16px; line-height: 1.125; margin: 0 0 15px 0;">
+                <%= t(".receipt.ordered_on", formatted_time: @presenter.ordered_on_formatted_string) %>
+              </p>
+              <p style="font-size: 16px; line-height: 1.125; margin: 0 0 15px 0;">
+                <%= t(".receipt.reference", reg_identifier: @presenter.reg_identifier) %>
+              </p>
+              <p style="font-size: 16px; line-height: 1.125; margin: 0 0 15px 0;">
+                <%= t(".receipt.paid", total_paid: display_pence_as_pounds(@presenter.total_paid)) %>
+              </p>
+            </td>
+            <td width="25%">
+              &nbsp;
+            </td>
+          </tr>
+          <tr style="margin-top:40px">
+            <td width="75%" style="font-family: Helvetica, Arial, sans-serif;">
+              <p style="font-size: 16px; font-weight: bold; line-height: 1.125; margin: 40px 0 15px 0;">
+                <%= t(".contact_us.heading") %>
+              </p>
+
+              <p style="font-size: 16px; line-height: 1.125; margin: 0 0 5px 0;">
+                <%= t(".contact_us.address.line_1") %>
+              </p>
+              <p style="font-size: 16px; line-height: 1.125; margin: 0 0 5px 0;">
+                <%= t(".contact_us.address.line_2") %>
+              </p>
+              <p style="font-size: 16px; line-height: 1.125; margin: 0 0 5px 0;">
+                <%= link_to t(".contact_us.address.email"), "mailto:#{t(".contact_us.address.email")}" %>
+              </p>
+            </td>
+            <td width="25%">
+              &nbsp;
+            </td>
+          </tr>
+          <tr style="margin-top:40px">
+            <td>
+              <p style="font-size: 16px; line-height: 1.125;">
+                <%= t(".footer") %>
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -2,3 +2,4 @@
 
 Date::DATE_FORMATS[:default] = "%e %B %Y"
 Time::DATE_FORMATS[:entity_matching] = "%d-%m-%Y"
+Time::DATE_FORMATS[:day_month_year] = "%d %B %Y"

--- a/config/locales/mailers/order_copy_cards_mailer.yml
+++ b/config/locales/mailers/order_copy_cards_mailer.yml
@@ -1,0 +1,20 @@
+en:
+  waste_carriers_engine:
+    order_copy_cards_mailer:
+      send_order_completed_email:
+        subject: "We’re printing your waste carriers registration cards"
+        dear: "Dear %{full_name}"
+        heading: "We’re printing your waste carriers registration cards. They should arrive within 10 working days."
+        receipt:
+          heading: "Receipt"
+          order: "Order: %{description}"
+          ordered_on: "Ordered on: %{formatted_time}"
+          reference: "Carrier registration number: %{reg_identifier}."
+          paid: "Paid: £%{total_paid} by debit or credit card."
+        contact_us:
+          heading: "If you need to contact us"
+          address:
+            line_1: "Environment Agency"
+            line_2: "Telephone 03708 506 506, Monday to Friday (8am to 6pm)"
+            email: "enquiries@environment-agency.gov.uk"
+        footer: "This is an automated email, please do not reply."

--- a/spec/presenters/waste_carriers_engine/order_copy_cards_mailer_presenter_spec.rb
+++ b/spec/presenters/waste_carriers_engine/order_copy_cards_mailer_presenter_spec.rb
@@ -30,7 +30,7 @@ module WasteCarriersEngine
     end
 
     describe "#ordered_on_formatted_string" do
-      it "returns the order items count" do
+      it "returns the date the order was created as a string eg '31 October 2010'" do
         expect(order).to receive(:date_created).and_return(Time.parse("2010-10-31").to_datetime)
 
         expect(subject.ordered_on_formatted_string).to eq("31 October 2010")

--- a/spec/presenters/waste_carriers_engine/order_copy_cards_mailer_presenter_spec.rb
+++ b/spec/presenters/waste_carriers_engine/order_copy_cards_mailer_presenter_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe OrderCopyCardsMailerPresenter do
+    subject { described_class.new(registration, order) }
+    let(:registration) { double(:registration) }
+    let(:order) { double(:order) }
+
+    describe "#contact_name" do
+      it "returns a string with first and last name" do
+        expect(registration).to receive(:first_name).and_return("Bob")
+        expect(registration).to receive(:last_name).and_return("Proctor")
+
+        expect(subject.contact_name).to eq("Bob Proctor")
+      end
+    end
+
+    describe "#order_description" do
+      it "returns the order's description" do
+        order_item = double(:order_item)
+        result = double(:result)
+
+        expect(order).to receive(:order_items).and_return([order_item])
+        expect(order_item).to receive(:description).and_return(result)
+
+        expect(subject.order_description).to eq(result)
+      end
+    end
+
+    describe "#ordered_on_formatted_string" do
+      it "returns the order items count" do
+        expect(order).to receive(:date_created).and_return(Time.parse("2010-10-31").to_datetime)
+
+        expect(subject.ordered_on_formatted_string).to eq("31 October 2010")
+      end
+    end
+  end
+end

--- a/spec/services/waste_carriers_engine/order_copy_cards_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/order_copy_cards_completion_service_spec.rb
@@ -16,11 +16,17 @@ module WasteCarriersEngine
         )
       end
 
-      it "completes an order" do
+      skip "TODO: when the registration have not been paid in full" do
+        pending "completes an order and sends an awaiting payment email" do
+        end
+      end
+
+      it "completes an order and sends a confirmation email" do
         orders = double(:orders)
         payments = double(:payments)
         transient_order = double(:transient_order)
         transient_payment = double(:transient_payment)
+        mailer = double(:mailer)
 
         # Merge finance details
         allow(registration).to receive(:finance_details).and_return(finance_details)
@@ -28,8 +34,8 @@ module WasteCarriersEngine
         expect(finance_details).to receive(:update_balance)
 
         ## Merge orders
-        expect(finance_details).to receive(:orders).and_return(orders).twice
-        expect(transient_finance_details).to receive(:orders).and_return([transient_order]).twice
+        allow(finance_details).to receive(:orders).and_return(orders)
+        allow(transient_finance_details).to receive(:orders).and_return([transient_order])
         expect(orders).to receive(:<<).with(transient_order)
 
         ## Merge payments
@@ -42,6 +48,11 @@ module WasteCarriersEngine
 
         # Save registration
         expect(registration).to receive(:save!)
+
+        # Send email
+        expect(transient_registration).to receive(:unpaid_balance?).and_return(false)
+        expect(OrderCopyCardsMailer).to receive(:send_order_completed_email).and_return(mailer)
+        expect(mailer).to receive(:deliver_now)
 
         described_class.run(transient_registration)
       end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-814

This creates the email for a completed copy cards order

<img width="579" alt="Screenshot 2019-12-13 at 15 05 57" src="https://user-images.githubusercontent.com/1385397/70806844-7e67a400-1dbc-11ea-89ab-3fedde25fa29.png">
