### PR TITLE
Secure token - Change more reg_identifier to token

### DIFF
--- a/app/views/waste_carriers_engine/company_address_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/company_address_forms/new.html.erb
@@ -9,7 +9,7 @@
     <div class="form-group">
       <label class="form-label"><%= t(".postcode_label") %></label>
       <span class="postcode"><%= @company_address_form.temp_company_postcode %></span>
-      <%= link_to(t(".postcode_change_link"), back_company_address_forms_path(@company_address_form.reg_identifier)) %>
+      <%= link_to(t(".postcode_change_link"), back_company_address_forms_path(@company_address_form.token)) %>
     </div>
 
     <%= f.fields_for :company_address do |f| %>
@@ -17,7 +17,7 @@
     <% end %>
 
     <div class="form-group">
-      <%= link_to(t(".manual_address_link"), skip_to_manual_address_company_address_forms_path(@company_address_form.reg_identifier)) %>
+      <%= link_to(t(".manual_address_link"), skip_to_manual_address_company_address_forms_path(@company_address_form.token)) %>
     </div>
 
     <div class="form-group">

--- a/app/views/waste_carriers_engine/company_address_manual_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/company_address_manual_forms/new.html.erb
@@ -17,7 +17,7 @@
       <div class="form-group">
         <label class="form-label"><%= t(".preset_postcode_label") %></label>
         <span class="postcode"><%= @company_address_manual_form.postcode %></span>
-        <%= link_to(t(".postcode_change_link"), back_company_address_manual_forms_path(@company_address_manual_form.reg_identifier)) %>
+        <%= link_to(t(".postcode_change_link"), back_company_address_manual_forms_path(@company_address_manual_form.token)) %>
       </div>
     <% end %>
 

--- a/app/views/waste_carriers_engine/company_postcode_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/company_postcode_forms/new.html.erb
@@ -31,7 +31,7 @@
 
     <% if @company_postcode_form.errors.added?(:temp_company_postcode, :no_results) %>
       <div class="form-group">
-        <%= link_to(t(".manual_address_link"), skip_to_manual_address_company_postcode_forms_path(@company_postcode_form.reg_identifier)) %>
+        <%= link_to(t(".manual_address_link"), skip_to_manual_address_company_postcode_forms_path(@company_postcode_form.token)) %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/waste_carriers_engine/contact_address_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/contact_address_forms/new.html.erb
@@ -9,7 +9,7 @@
     <div class="form-group">
       <label class="form-label"><%= t(".postcode_label") %></label>
       <span class="postcode"><%= @contact_address_form.temp_contact_postcode %></span>
-      <%= link_to(t(".postcode_change_link"), back_contact_address_forms_path(@contact_address_form.reg_identifier)) %>
+      <%= link_to(t(".postcode_change_link"), back_contact_address_forms_path(@contact_address_form.token)) %>
     </div>
 
     <%= f.fields_for :contact_address do |f| %>
@@ -17,7 +17,7 @@
     <% end %>
 
     <div class="form-group">
-      <%= link_to(t(".manual_address_link"), skip_to_manual_address_contact_address_forms_path(@contact_address_form.reg_identifier)) %>
+      <%= link_to(t(".manual_address_link"), skip_to_manual_address_contact_address_forms_path(@contact_address_form.token)) %>
     </div>
 
     <div class="form-group">

--- a/app/views/waste_carriers_engine/contact_address_manual_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/contact_address_manual_forms/new.html.erb
@@ -17,7 +17,7 @@
       <div class="form-group">
         <label class="form-label"><%= t(".preset_postcode_label") %></label>
         <span class="postcode"><%= @contact_address_manual_form.postcode %></span>
-        <%= link_to(t(".postcode_change_link"), back_contact_address_manual_forms_path(@contact_address_manual_form.reg_identifier)) %>
+        <%= link_to(t(".postcode_change_link"), back_contact_address_manual_forms_path(@contact_address_manual_form.token)) %>
       </div>
     <% end %>
 

--- a/app/views/waste_carriers_engine/contact_postcode_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/contact_postcode_forms/new.html.erb
@@ -33,7 +33,7 @@
 
     <% if @contact_postcode_form.errors.added?(:temp_contact_postcode, :no_results) %>
       <div class="form-group">
-        <%= link_to(t(".manual_address_link"), skip_to_manual_address_contact_postcode_forms_path(@contact_postcode_form.reg_identifier)) %>
+        <%= link_to(t(".manual_address_link"), skip_to_manual_address_contact_postcode_forms_path(@contact_postcode_form.token)) %>
       </div>
     <% end %>
   <% end %>


### PR DESCRIPTION
We discovered that as part of the secure token change we forgot some links in the view that are still passing around :reg_identifier rather than a :token.
This fixes them.