### PR TITLE
Remove TODO on persisted and destroy MongoId bug

### DIFF
--- a/spec/requests/waste_carriers_engine/copy_cards_order_completed_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/copy_cards_order_completed_forms_spec.rb
@@ -38,7 +38,6 @@ module WasteCarriersEngine
               order = finance_details.orders.first
               order_item = order.order_items.first
 
-              # TODO: Discuss bug with Reload and Let at next dev meeting
               expect(WasteCarriersEngine::TransientRegistration.count).to eq(0)
 
               expect(finance_details.orders.count).to eq(1)


### PR DESCRIPTION
We have gather together today and we discussed the issue.
From our discoveries, when a MongoId document is created in a process and then destroyed in aother process, the instance created in the first process changes to an unpredictable status.
The instance was responding to `#persistent?` with a `true` value rather than a `false`, as we obsered the database was actually empty. Even worst, when `reload` was called on the instance after the destroy of the object in the second process, the instance refreshed itself with a completely new set of data, including `_id`, and still respondend to `persisted?` with a `false`.

We have decided that since this is mostly an issue with the way we run request tests, we just have to keep it in mind when we work with MongoId and destroy when we write our tests and make decisions accordingly.