### PR TITLE
Change back path for start of copy cards journey

### DIFF
--- a/app/views/waste_carriers_engine/copy_cards_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/copy_cards_forms/new.html.erb
@@ -1,4 +1,4 @@
-<%= render("waste_carriers_engine/shared/back", back_path: Rails.application.routes.url_helpers.root_path) %>
+<%= render("waste_carriers_engine/shared/back", back_path: Rails.application.routes.url_helpers.registration_path(@transient_registration.reg_identifier)) %>
 
 <div class="text">
   <%= form_for(@copy_cards_form) do |f| %>


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-767

This fixes a bug on the back path of the journey, which was redirecting to the root path rather than the registration's detail page