### PR TITLE
Change validation message to represent real maximum

### DIFF
--- a/config/locales/forms/copy_cards_forms/en.yml
+++ b/config/locales/forms/copy_cards_forms/en.yml
@@ -16,5 +16,5 @@ en:
           attributes:
             temp_cards:
               not_a_number: "You must enter a number between 1 and 999"
-              greater_than_or_equal_to: "You must enter a number between 1 and 99"
+              greater_than_or_equal_to: "You must enter a number between 1 and 999"
               not_an_integer: "You must enter a number between 1 and 999"

--- a/config/locales/forms/copy_cards_forms/en.yml
+++ b/config/locales/forms/copy_cards_forms/en.yml
@@ -15,6 +15,6 @@ en:
         waste_carriers_engine/copy_cards_form:
           attributes:
             temp_cards:
-              not_a_number: "You must enter a number between 1 and 99"
+              not_a_number: "You must enter a number between 1 and 999"
               greater_than_or_equal_to: "You must enter a number between 1 and 99"
-              not_an_integer: "You must enter a number between 1 and 99"
+              not_an_integer: "You must enter a number between 1 and 999"


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-767

This fixes the validation message we display to the user to contain the correct maximum number of cards they can order.