### PR TITLE
Fix path to correct backend

### DIFF
--- a/app/views/waste_carriers_engine/copy_cards_order_completed_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/copy_cards_order_completed_forms/new.html.erb
@@ -24,7 +24,7 @@
     </table>
   </div>
   <div class="form-group">
-    <%= link_to t(".dashboard"), Rails.application.routes.url_helpers.root_path, class: "button" %>
+    <%= link_to t(".dashboard"), "/bo", class: "button" %>
     <%= link_to t(".details_page", reg_identifier: @transient_registration.reg_identifier), Rails.application.routes.url_helpers.registration_path(@transient_registration.reg_identifier), class: "button" %>
   </div>
 </div>


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-767

Seems like the root path of the backoffice application, when deployed to the production server, is set to "/". In this case, we want to make sure we redirect to the correct backoffice backend.