### PR TITLE
Use correct balance when displaying bank transfer info

### DIFF
--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -27,6 +27,7 @@ module WasteCarriersEngine
     scope :pending_payment, -> { submitted.where(:"financeDetails.balance".gt => 0) }
     scope :pending_approval, -> { submitted.where("conviction_sign_offs.0.confirmed": "no") }
 
+    # TODO: Move to renewal registration
     def total_to_pay
       charges = [Rails.configuration.renewal_charge]
       charges << Rails.configuration.type_change_charge if registration_type_changed?

--- a/app/views/waste_carriers_engine/copy_cards_bank_transfer_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/copy_cards_bank_transfer_forms/new.html.erb
@@ -33,7 +33,7 @@
           </tr>
           <tr>
             <td><%= t(".uk_payment_table.total_cost.label") %></td>
-            <td>£<%= display_pence_as_pounds(@copy_cards_bank_transfer_form.total_to_pay) %></td>
+            <td>£<%= display_pence_as_pounds(@transient_registration.finance_details.balance) %></td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-767

The method I was using to show the user the correct amount to pay, is actually specific to renewals only.
I have added a TODO to the method so that we can move it in the specific object, and use the finance_details balance in this view.