### PR TITLE
Fix errors in pluralisation and remove dots

### DIFF
--- a/app/models/waste_carriers_engine/order_item.rb
+++ b/app/models/waste_carriers_engine/order_item.rb
@@ -43,7 +43,13 @@ module WasteCarriersEngine
       order_item = OrderItem.base_order_item
 
       order_item[:amount] = cards * Rails.configuration.card_charge
-      order_item[:description] = "#{cards} registration cards"
+
+      if cards == 1
+        order_item[:description] = "#{cards} registration cards"
+      else
+        order_item[:description] = "1 registration card"
+      end
+
       order_item[:type] = TYPES[:copy_cards]
 
       order_item

--- a/app/models/waste_carriers_engine/order_item.rb
+++ b/app/models/waste_carriers_engine/order_item.rb
@@ -44,11 +44,8 @@ module WasteCarriersEngine
 
       order_item[:amount] = cards * Rails.configuration.card_charge
 
-      if cards == 1
-        order_item[:description] = "#{cards} registration cards"
-      else
-        order_item[:description] = "1 registration card"
-      end
+      order_item[:description] = "#{cards} registration cards"
+      order_item[:description] = "1 registration card" if cards == 1
 
       order_item[:type] = TYPES[:copy_cards]
 

--- a/config/locales/mailers/order_copy_cards_mailer.en.yml
+++ b/config/locales/mailers/order_copy_cards_mailer.en.yml
@@ -4,26 +4,26 @@ en:
       send_order_completed_email:
         subject: "We’re printing your waste carriers registration cards"
         dear: "Dear %{full_name}"
-        heading: "We’re printing your waste carriers registration cards. They should arrive within 10 working days."
+        heading: "We’re printing your waste carriers registration cards. They should arrive within 10 working days"
         receipt:
           heading: "Receipt"
           order: "Order: %{description}"
           ordered_on: "Ordered on: %{formatted_time}"
-          reference: "Carrier registration number: %{reg_identifier}."
-          paid: "Paid: £%{total_paid} by debit or credit card."
+          reference: "Carrier registration number: %{reg_identifier}"
+          paid: "Paid: £%{total_paid} by debit or credit card"
         contact_us:
           heading: "If you need to contact us"
           address:
             line_1: "Environment Agency"
             line_2: "Telephone 03708 506 506, Monday to Friday (8am to 6pm)"
-            email: "enquiries@environment-agency.gov.uk"
+            email: "nccc-carrierbroker@environment-agency.gov.uk"
         footer: "This is an automated email, please do not reply."
       send_awaiting_payment_email:
         subject: "You need to pay for your waste carriers registration card order"
         dear: "Dear %{full_name}"
         heading: "You need to pay for your waste carriers registration card order"
-        paragraph_1: "You ordered %{description} on %{formatted_date} for carrier registration number %{reg_identifier}."
-        paragraph_2: "We cannot print the cards until we receive confirmation that you have paid."
+        paragraph_1: "You ordered %{description} on %{formatted_date} for carrier registration number %{reg_identifier}"
+        paragraph_2: "We cannot print the cards until we receive confirmation that you have paid"
         pay_by_bank_transfer:
           heading: "1. Pay by bank transfer (Bacs) with these details"
           payment_due: "Payment due"
@@ -54,5 +54,5 @@ en:
           address:
             line_1: "Environment Agency"
             line_2: "Telephone 03708 506 506, Monday to Friday (8am to 6pm)"
-            email: "enquiries@environment-agency.gov.uk"
+            email: "nccc-carrierbroker@environment-agency.gov.uk"
         footer: "This is an automated email, please do not reply."

--- a/spec/models/waste_carriers_engine/order_item_spec.rb
+++ b/spec/models/waste_carriers_engine/order_item_spec.rb
@@ -67,7 +67,6 @@ module WasteCarriersEngine
           expect(order_item.description).to eq("1 registration card")
         end
       end
-
     end
   end
 end

--- a/spec/models/waste_carriers_engine/order_item_spec.rb
+++ b/spec/models/waste_carriers_engine/order_item_spec.rb
@@ -45,7 +45,8 @@ module WasteCarriersEngine
     end
 
     describe "new_copy_cards_item" do
-      let(:order_item) { described_class.new_copy_cards_item(3) }
+      let(:cards) { 3 }
+      let(:order_item) { described_class.new_copy_cards_item(cards) }
 
       it "should have a type of 'COPY_CARDS'" do
         expect(order_item.type).to eq(described_class::TYPES[:copy_cards])
@@ -58,6 +59,15 @@ module WasteCarriersEngine
       it "should set the correct description" do
         expect(order_item.description).to eq("3 registration cards")
       end
+
+      context "when the number of cards is 1" do
+        let(:cards) { 1 }
+
+        it "should set the correct description" do
+          expect(order_item.description).to eq("1 registration card")
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-814

QA have found out some inconsistencies with the use of dots and pluralization of order descriptions. This PR includes fixes for both. Instructions will be give to deal with legacy data during testing.
There is also a fix about the email address used in the wireframe, which didn't match what is currently sent out to the user.