### PR TITLE
Add pluralisation for copy cards email

### DIFF
--- a/app/mailers/waste_carriers_engine/order_copy_cards_mailer.rb
+++ b/app/mailers/waste_carriers_engine/order_copy_cards_mailer.rb
@@ -4,10 +4,10 @@ module WasteCarriersEngine
   class OrderCopyCardsMailer < BaseMailer
     def send_order_completed_email(registration, order)
       @presenter = OrderCopyCardsMailerPresenter.new(registration, order)
-      total_cards = order.order_items.first.quantity
+
       subject = I18n.t(
         ".waste_carriers_engine.order_copy_cards_mailer.send_order_completed_email.subject",
-        count: total_cards
+        count: @presenter.total_cards
       )
 
       mail(to: @presenter.contact_email,

--- a/app/mailers/waste_carriers_engine/order_copy_cards_mailer.rb
+++ b/app/mailers/waste_carriers_engine/order_copy_cards_mailer.rb
@@ -4,10 +4,11 @@ module WasteCarriersEngine
   class OrderCopyCardsMailer < BaseMailer
     def send_order_completed_email(registration, order)
       @presenter = OrderCopyCardsMailerPresenter.new(registration, order)
+      total_cards = order.order_items.first.quantity
 
       mail(to: @presenter.contact_email,
            from: from_email,
-           subject: I18n.t(".waste_carriers_engine.order_copy_cards_mailer.send_order_completed_email.subject"))
+           subject: I18n.t(".waste_carriers_engine.order_copy_cards_mailer.send_order_completed_email.subject", count: total_cards))
     end
 
     def send_awaiting_payment_email(registration, order)

--- a/app/mailers/waste_carriers_engine/order_copy_cards_mailer.rb
+++ b/app/mailers/waste_carriers_engine/order_copy_cards_mailer.rb
@@ -5,10 +5,14 @@ module WasteCarriersEngine
     def send_order_completed_email(registration, order)
       @presenter = OrderCopyCardsMailerPresenter.new(registration, order)
       total_cards = order.order_items.first.quantity
+      subject = I18n.t(
+        ".waste_carriers_engine.order_copy_cards_mailer.send_order_completed_email.subject",
+        count: total_cards
+      )
 
       mail(to: @presenter.contact_email,
            from: from_email,
-           subject: I18n.t(".waste_carriers_engine.order_copy_cards_mailer.send_order_completed_email.subject", count: total_cards))
+           subject: subject)
     end
 
     def send_awaiting_payment_email(registration, order)

--- a/app/models/waste_carriers_engine/order_item.rb
+++ b/app/models/waste_carriers_engine/order_item.rb
@@ -13,6 +13,7 @@ module WasteCarriersEngine
     )
 
     field :amount,                          type: Integer
+    field :quantity,                        type: Integer
     field :currency,                        type: String
     field :lastUpdated, as: :last_updated,  type: DateTime
     field :description,                     type: String
@@ -22,9 +23,10 @@ module WasteCarriersEngine
     def self.new_renewal_item
       order_item = OrderItem.base_order_item
 
-      order_item[:amount] = Rails.configuration.renewal_charge
-      order_item[:description] = "Renewal of registration"
-      order_item[:type] = TYPES[:renew]
+      order_item.amount = Rails.configuration.renewal_charge
+      order_item.description = "Renewal of registration"
+      order_item.type = TYPES[:renew]
+      order_item.quantity = 1
 
       order_item
     end
@@ -32,9 +34,10 @@ module WasteCarriersEngine
     def self.new_type_change_item
       order_item = OrderItem.base_order_item
 
-      order_item[:amount] = Rails.configuration.type_change_charge
-      order_item[:description] = "changing carrier type during renewal"
-      order_item[:type] = TYPES[:edit]
+      order_item.amount = Rails.configuration.type_change_charge
+      order_item.description = "changing carrier type during renewal"
+      order_item.type = TYPES[:edit]
+      order_item.quantity = 1
 
       order_item
     end
@@ -42,19 +45,20 @@ module WasteCarriersEngine
     def self.new_copy_cards_item(cards)
       order_item = OrderItem.base_order_item
 
-      order_item[:amount] = cards * Rails.configuration.card_charge
+      order_item.amount = cards * Rails.configuration.card_charge
 
-      order_item[:description] = "#{cards} registration cards"
-      order_item[:description] = "1 registration card" if cards == 1
+      order_item.description = "#{cards} registration cards"
+      order_item.description = "1 registration card" if cards == 1
+      order_item.quantity = cards
 
-      order_item[:type] = TYPES[:copy_cards]
+      order_item.type = TYPES[:copy_cards]
 
       order_item
     end
 
     def self.base_order_item
       order_item = OrderItem.new
-      order_item[:currency] = "GBP"
+      order_item.currency = "GBP"
       order_item
     end
   end

--- a/app/presenters/waste_carriers_engine/order_copy_cards_mailer_presenter.rb
+++ b/app/presenters/waste_carriers_engine/order_copy_cards_mailer_presenter.rb
@@ -13,7 +13,11 @@ module WasteCarriersEngine
     end
 
     def order_description
-      @_order_description ||= copy_cards_order.order_items.first.description
+      @_order_description ||= order_item.description
+    end
+
+    def total_cards
+      @_total_cards ||= order_item.quantity
     end
 
     def ordered_on_formatted_string
@@ -27,5 +31,9 @@ module WasteCarriersEngine
     private
 
     attr_reader :copy_cards_order
+
+    def order_item
+      @_order_item ||= copy_cards_order.order_items.first
+    end
   end
 end

--- a/app/views/waste_carriers_engine/order_copy_cards_mailer/send_order_completed_email.html.erb
+++ b/app/views/waste_carriers_engine/order_copy_cards_mailer/send_order_completed_email.html.erb
@@ -51,7 +51,7 @@
           <tr>
             <td style="font-family: Helvetica, Arial, sans-serif; margin: 0 0 30px 0;">
               <h1 style="font-size: 20px; margin: 10px 0px 15px 0px;">
-                <%= t(".heading") %>
+                <%= t(".heading", count: @presenter.total_cards) %>
               </h1>
             </td>
             <td width="25%">&nbsp;</td>

--- a/config/locales/mailers/order_copy_cards_mailer.en.yml
+++ b/config/locales/mailers/order_copy_cards_mailer.en.yml
@@ -2,9 +2,13 @@ en:
   waste_carriers_engine:
     order_copy_cards_mailer:
       send_order_completed_email:
-        subject: "We’re printing your waste carriers registration cards"
+        subject:
+          one: "We’re printing your waste carriers registration cards"
+          other: "We’re printing your waste carriers registration card"
         dear: "Dear %{full_name}"
-        heading: "We’re printing your waste carriers registration cards. They should arrive within 10 working days"
+        heading:
+          one: "We’re printing your waste carriers registration card. It should arrive within 10 working days"
+          other: "We’re printing your waste carriers registration cards. They should arrive within 10 working days"
         receipt:
           heading: "Receipt"
           order: "Order: %{description}"

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -28,6 +28,10 @@ FactoryBot.define do
       addresses { [build(:address, :has_required_data, :registered, :from_os_places), build(:address, :has_required_data, :contact, :from_os_places)] }
     end
 
+    trait :has_copy_cards_order do
+      finance_details { build(:finance_details, :has_copy_cards_order) }
+    end
+
     trait :has_required_overseas_data do
       account_email { "foo@example.com" }
       business_type { "overseas" }

--- a/spec/mailers/waste_carriers_engine/order_copy_cards_mailer_spec.rb
+++ b/spec/mailers/waste_carriers_engine/order_copy_cards_mailer_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe OrderCopyCardsMailer do
+    before do
+      allow(Rails.configuration).to receive(:email_service_email).and_return("test@example.com")
+    end
+
+    describe ".send_order_completed_email" do
+      let(:registration) { create(:registration, :has_required_data, :has_copy_cards_order) }
+      let(:order) { registration.finance_details.orders.last }
+
+      let(:mail) { OrderCopyCardsMailer.send_order_completed_email(registration, order) }
+
+      it "send an email using the correct information" do
+        expect(mail.from).to eq(["test@example.com"])
+
+        expect(mail.subject).to eq("We’re printing your waste carriers registration cards")
+
+        expect(mail.body.encoded).to include(registration.reg_identifier)
+      end
+    end
+
+    describe ".send_awaiting_payment_email" do
+      let(:registration) { create(:registration, :has_required_data, :has_copy_cards_order) }
+      let(:order) { registration.finance_details.orders.last }
+
+      let(:mail) { OrderCopyCardsMailer.send_awaiting_payment_email(registration, order) }
+
+      it "send an email using the correct information" do
+        expect(mail.from).to eq(["test@example.com"])
+
+        expect(mail.subject).to eq("You need to pay for your waste carriers registration card order")
+
+        expect(mail.body.encoded).to include(registration.reg_identifier)
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/order_item_spec.rb
+++ b/spec/models/waste_carriers_engine/order_item_spec.rb
@@ -23,6 +23,10 @@ module WasteCarriersEngine
         expect(order_item.amount).to eq(10_000)
       end
 
+      it "should set the correct quantity" do
+        expect(order_item.quantity).to eq(1)
+      end
+
       it "should set the correct description" do
         expect(order_item.description).to eq("Renewal of registration")
       end
@@ -33,6 +37,10 @@ module WasteCarriersEngine
 
       it "should have a type of 'EDIT'" do
         expect(order_item.type).to eq(described_class::TYPES[:edit])
+      end
+
+      it "should set the correct quantity" do
+        expect(order_item.quantity).to eq(1)
       end
 
       it "should set the correct amount" do
@@ -54,6 +62,10 @@ module WasteCarriersEngine
 
       it "should set the correct amount" do
         expect(order_item.amount).to eq(3_000)
+      end
+
+      it "should set the correct quantity" do
+        expect(order_item.quantity).to eq(3)
       end
 
       it "should set the correct description" do

--- a/spec/presenters/waste_carriers_engine/order_copy_cards_mailer_presenter_spec.rb
+++ b/spec/presenters/waste_carriers_engine/order_copy_cards_mailer_presenter_spec.rb
@@ -17,6 +17,18 @@ module WasteCarriersEngine
       end
     end
 
+    describe "#total_cards" do
+      it "returns the order item's quantity" do
+        order_item = double(:order_item)
+        result = double(:result)
+
+        expect(order).to receive(:order_items).and_return([order_item])
+        expect(order_item).to receive(:quantity).and_return(result)
+
+        expect(subject.total_cards).to eq(result)
+      end
+    end
+
     describe "#order_description" do
       it "returns the order's description" do
         order_item = double(:order_item)


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-814

This will make sure we send an email with the correct subject and header wheter it refers to a 1 card order or to multiple cards order.