### PR TITLE
Add scopes for finding registrations to expire

### DIFF
--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -28,6 +28,8 @@ module WasteCarriersEngine
               inclusion: { in: %w[UPPER LOWER] }
 
     scope :active, -> { where("metaData.status" => "ACTIVE") }
+    scope :expired_at_end_of_today, -> { where(:expires_on.lte => Time.now.in_time_zone("London").end_of_day) }
+    scope :upper_tier, -> { where(tier: "UPPER") }
 
     alias pending_manual_conviction_check? conviction_check_required?
     alias pending_payment? unpaid_balance?

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -45,6 +45,44 @@ module WasteCarriersEngine
       end
     end
 
+    describe "scopes" do
+      describe ".active" do
+        it "returns active registrations" do
+          active_registration = create(:registration, :has_required_data, :is_active)
+          revoked_registration = create(:registration, :has_required_data, :is_revoked)
+
+          result = described_class.active
+
+          expect(result).to include(active_registration)
+          expect(result).to_not include(revoked_registration)
+        end
+      end
+
+      describe ".expired_at_end_of_today" do
+        it "returns registrations that have expired at the end of current day" do
+          expired_registration = create(:registration, :has_required_data, expires_on: Time.now.beginning_of_day + 4.hours)
+          active_registration = create(:registration, :has_required_data, expires_on: Time.now.end_of_day + 4.hours)
+
+          result = described_class.expired_at_end_of_today
+
+          expect(result).to include(expired_registration)
+          expect(result).to_not include(active_registration)
+        end
+      end
+
+      describe ".upper_tier" do
+        it "returns upper tier registrations" do
+          upper_tier_registration = create(:registration, :has_required_data, tier: "UPPER")
+          lower_tier_registration = create(:registration, :has_required_data, tier: "LOWER")
+
+          result = described_class.upper_tier
+
+          expect(result).to include(upper_tier_registration)
+          expect(result).to_not include(lower_tier_registration)
+        end
+      end
+    end
+
     describe "#tier" do
       context "when a registration has no tier" do
         let(:registration) { build(:registration, :has_required_data, tier: nil) }


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-739

This adds the necessary scopes to find registrations to expire.