### PR TITLE
Add expire! method to registration model

### DIFF
--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -36,6 +36,12 @@ module WasteCarriersEngine
       renewable_tier? && renewable_status? && renewable_date?
     end
 
+    def expire!
+      metaData.status = "EXPIRED"
+
+      save!
+    end
+
     private
 
     def renewable_tier?

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -45,6 +45,16 @@ module WasteCarriersEngine
       end
     end
 
+    describe "#expire!" do
+      it "update the registration status to expired" do
+        registration = create(:registration, :is_active, :has_required_data)
+
+        registration.expire!
+
+        expect(registration).to be_expired
+      end
+    end
+
     describe "#tier" do
       context "when a registration has no tier" do
         let(:registration) { build(:registration, :has_required_data, tier: nil) }


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-739

This adds an `#expire!` method to the registrations model which will set the registration as expired. Will be used in the expire registration job.