### PR TITLE
Return default postcode when building XML for Worldpay

### DIFF
--- a/app/services/waste_carriers_engine/worldpay_xml_service.rb
+++ b/app/services/waste_carriers_engine/worldpay_xml_service.rb
@@ -79,7 +79,7 @@ module WasteCarriersEngine
 
       address1 = [address.house_number, address.address_line_1].join(" ")
       address2 = address.address_line_2
-      postcode = address.postcode.presence || "00000"
+      postcode = address.postcode.presence || "UNKNOWN"
       city = address.town_city
       country_code = look_up_country_code(address.country)
 

--- a/app/services/waste_carriers_engine/worldpay_xml_service.rb
+++ b/app/services/waste_carriers_engine/worldpay_xml_service.rb
@@ -79,7 +79,7 @@ module WasteCarriersEngine
 
       address1 = [address.house_number, address.address_line_1].join(" ")
       address2 = address.address_line_2
-      postcode = address.postcode
+      postcode = address.postcode.presence || "00000"
       city = address.town_city
       country_code = look_up_country_code(address.country)
 


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-769

This fixes a bug on the creation of the XML sent to worldpay for which the request was rejected when a postcode was missing.