### PR TITLE
Add workflow and model for ceased or revoked

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_use_ceased_or_revoked_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_ceased_or_revoked_registration_workflow.rb
@@ -5,7 +5,6 @@ module WasteCarriersEngine
     extend ActiveSupport::Concern
     include Mongoid::Document
 
-    # rubocop:disable Metrics/BlockLength
     included do
       include AASM
 
@@ -34,6 +33,5 @@ module WasteCarriersEngine
         end
       end
     end
-    # rubocop:enable Metrics/BlockLength
   end
 end

--- a/app/models/concerns/waste_carriers_engine/can_use_ceased_or_revoked_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_ceased_or_revoked_registration_workflow.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  module CanUseCeasedOrRevokedRegistrationWorkflow
+    extend ActiveSupport::Concern
+    include Mongoid::Document
+
+    # rubocop:disable Metrics/BlockLength
+    included do
+      include AASM
+
+      field :workflow_state, type: String
+
+      aasm column: :workflow_state do
+        # States / forms
+        state :cease_or_revoke_form, initial: true
+
+        state :ceased_or_revoked_confirm_form
+        state :ceased_or_revoked_completed_form
+
+        # Transitions
+        event :next do
+          transitions from: :cease_or_revoke_form,
+                      to: :ceased_or_revoked_confirm_form
+
+          transitions from: :ceased_or_revoked_confirm_form,
+                      to: :ceased_or_revoked_completed_form
+
+        end
+
+        event :back do
+          transitions from: :ceased_or_revoked_confirm_form,
+                      to: :cease_or_revoke_form
+        end
+      end
+    end
+    # rubocop:enable Metrics/BlockLength
+  end
+end

--- a/app/models/waste_carriers_engine/ceased_or_revoked_registration.rb
+++ b/app/models/waste_carriers_engine/ceased_or_revoked_registration.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class CeasedOrRevokedRegistration < TransientRegistration
+    include CanUseCeasedOrRevokedRegistrationWorkflow
+
+    validates :reg_identifier, "waste_carriers_engine/reg_identifier": true
+
+    delegate :status, to: :registration
+
+    def registration
+      @_registration ||= Registration.find_by(reg_identifier: reg_identifier)
+    end
+  end
+end

--- a/spec/factories/ceased_or_revoked_registration.rb
+++ b/spec/factories/ceased_or_revoked_registration.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ceased_or_revoked_registration, class: WasteCarriersEngine::CeasedOrRevokedRegistration do
+    initialize_with { new(reg_identifier: build(:registration, :has_required_data, :is_active).reg_identifier) }
+  end
+end

--- a/spec/models/waste_carriers_engine/ceased_or_revoked_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/ceased_or_revoked_registration_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe CeasedOrRevokedRegistration, type: :model do
+    subject(:ceased_or_revoked_registration) { build(:ceased_or_revoked_registration) }
+
+    context "default status" do
+      context "when a CeasedOrRevokedRegistration is created" do
+        it "has the state of :cease_or_revoke_form" do
+          expect(ceased_or_revoked_registration).to have_state(:cease_or_revoke_form)
+        end
+      end
+    end
+
+    context "Validations" do
+      describe "reg_identifier" do
+        context "when a CeasedOrRevokedRegistration is created" do
+          it "is not valid if the reg_identifier is in the wrong format" do
+            ceased_or_revoked_registration.reg_identifier = "foo"
+
+            expect(ceased_or_revoked_registration).to_not be_valid
+          end
+
+          it "is not valid if no matching registration exists" do
+            ceased_or_revoked_registration.reg_identifier = "CBDU999999"
+
+            expect(ceased_or_revoked_registration).to_not be_valid
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/ceased_or_revoked_registration_workflow/cease_or_revoke_form_spec.rb
+++ b/spec/models/waste_carriers_engine/ceased_or_revoked_registration_workflow/cease_or_revoke_form_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe CeasedOrRevokedRegistration do
+    subject(:ceased_or_revoked_registration) { build(:ceased_or_revoked_registration) }
+
+    describe "#workflow_state" do
+      context ":cease_or_revoke_form state transitions" do
+        context "on next" do
+          it "can transition from a :cease_or_revoke_form state to a :ceased_or_revoked_confirm_form" do
+            ceased_or_revoked_registration.workflow_state = :cease_or_revoke_form
+
+            ceased_or_revoked_registration.next
+
+            expect(ceased_or_revoked_registration.workflow_state).to eq("ceased_or_revoked_confirm_form")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/ceased_or_revoked_registration_workflow/ceased_or_revoked_confirm_form_spec.rb
+++ b/spec/models/waste_carriers_engine/ceased_or_revoked_registration_workflow/ceased_or_revoked_confirm_form_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe CeasedOrRevokedRegistration do
+    subject(:ceased_or_revoked_registration) { build(:ceased_or_revoked_registration) }
+
+    describe "#workflow_state" do
+      context ":ceased_or_revoked_confirm_form state transitions" do
+        context "on next" do
+          it "can transition from a :ceased_or_revoked_confirm_form state to a :ceased_or_revoked_completed_form" do
+            ceased_or_revoked_registration.workflow_state = :ceased_or_revoked_confirm_form
+
+            ceased_or_revoked_registration.next
+
+            expect(ceased_or_revoked_registration.workflow_state).to eq("ceased_or_revoked_completed_form")
+          end
+        end
+
+        context "on back" do
+          it "can transition from a :ceased_or_revoked_confirm_form state to a :cease_or_revoke_form" do
+            ceased_or_revoked_registration.workflow_state = :ceased_or_revoked_confirm_form
+
+            ceased_or_revoked_registration.back
+
+            expect(ceased_or_revoked_registration.workflow_state).to eq("cease_or_revoke_form")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-807

This adds a new transient object called CeasedOrRevokedRegistration which will be used with the ceased or revoked workflow.