### PR TITLE
Ceased or revoked - start form

### DIFF
--- a/app/controllers/waste_carriers_engine/cease_or_revoke_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/cease_or_revoke_forms_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class CeaseOrRevokeFormsController < FormsController
+    def new
+      super(CeaseOrRevokeForm, "cease_or_revoke_form")
+    end
+
+    def create
+      super(CeaseOrRevokeForm, "cease_or_revoke_form")
+    end
+
+    private
+
+    def transient_registration_attributes
+      params.fetch(:cease_or_revoke_form).permit(metaData: %i[status revoked_reason])
+    end
+
+    # rubocop:disable Naming/MemoizedInstanceVariableName
+    def find_or_initialize_transient_registration(token)
+      @transient_registration ||= CeasedOrRevokedRegistration.where(reg_identifier: token).first ||
+                                  CeasedOrRevokedRegistration.where(token: token).first ||
+                                  CeasedOrRevokedRegistration.new(reg_identifier: token)
+    end
+    # rubocop:enable Naming/MemoizedInstanceVariableName
+  end
+end

--- a/app/forms/waste_carriers_engine/cease_or_revoke_form.rb
+++ b/app/forms/waste_carriers_engine/cease_or_revoke_form.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class CeaseOrRevokeForm < BaseForm
+    def self.can_navigate_flexibly?
+      false
+    end
+
+    delegate :metaData, to: :transient_registration
+    delegate :status, :revoked_reason, to: :metaData, allow_nil: true
+    delegate :contact_address, :company_name, :registration_type, :tier, to: :transient_registration
+
+    validate :validate_status
+    validate :validate_revoked_reason
+
+    private
+
+    def validate_status
+      return true if %w[INACTIVE REVOKED].include?(status)
+
+      errors.add(:status, :presence)
+
+      false
+    end
+
+    def validate_revoked_reason
+      if revoked_reason.blank?
+        errors.add(:revoked_reason, :presence)
+
+        false
+      elsif revoked_reason.size > 500
+        errors.add(:revoked_reason, :length)
+
+        false
+      end
+
+      true
+    end
+  end
+end

--- a/app/forms/waste_carriers_engine/ceased_or_revoked_confirm_form.rb
+++ b/app/forms/waste_carriers_engine/ceased_or_revoked_confirm_form.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class CeasedOrRevokedConfirmForm < BaseForm
+    # TODO
+  end
+end

--- a/app/models/waste_carriers_engine/ceased_or_revoked_registration.rb
+++ b/app/models/waste_carriers_engine/ceased_or_revoked_registration.rb
@@ -6,7 +6,7 @@ module WasteCarriersEngine
 
     validates :reg_identifier, "waste_carriers_engine/reg_identifier": true
 
-    delegate :status, to: :registration
+    delegate :company_name, :registration_type, :tier, :contact_address, to: :registration
 
     def registration
       @_registration ||= Registration.find_by(reg_identifier: reg_identifier)

--- a/app/services/waste_carriers_engine/ceased_or_revoked_registration_permission_checks_service.rb
+++ b/app/services/waste_carriers_engine/ceased_or_revoked_registration_permission_checks_service.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class CeasedOrRevokedRegistrationPermissionChecksService < BaseRegistrationPermissionChecksService
+
+    private
+
+    def all_checks_pass?
+      transient_registration_is_valid? && user_has_permission? && registation_is_active?
+    end
+
+    def user_has_permission?
+      return true if can?(:revoke, registration) && can?(:cease, registration)
+
+      permission_check_result.needs_permissions!
+
+      false
+    end
+
+    def registation_is_active?
+      return true if registration.active?
+
+      permission_check_result.invalid!
+
+      false
+    end
+  end
+end

--- a/app/services/waste_carriers_engine/flow_permission_checks_service.rb
+++ b/app/services/waste_carriers_engine/flow_permission_checks_service.rb
@@ -26,6 +26,8 @@ module WasteCarriersEngine
         RenewingRegistrationPermissionChecksService.run(params)
       when OrderCopyCardsRegistration
         OrderCopyCardsRegistrationPermissionChecksService.run(params)
+      when CeasedOrRevokedRegistration
+        CeasedOrRevokedRegistrationPermissionChecksService.run(params)
       else
         raise MissingFlowPermissionChecksService, "No permission service found for #{transient_registration.class}"
       end

--- a/app/views/waste_carriers_engine/cease_or_revoke_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/cease_or_revoke_forms/new.html.erb
@@ -1,0 +1,62 @@
+<%= render("waste_carriers_engine/shared/back", back_path: Rails.application.routes.url_helpers.registration_path(@transient_registration.reg_identifier)) %>
+
+<div class="text">
+  <%= form_for(@cease_or_revoke_form) do |f| %>
+    <%= f.fields_for :metaData do |f| %>
+      <%= render("waste_carriers_engine/shared/errors", object: @cease_or_revoke_form) %>
+
+      <h1 class="heading-large"><%= t(".heading", reg_identifier: @transient_registration.reg_identifier) %></h1>
+
+      <div class="panel wcr-panel wcr-panel-border-all">
+        <h2 class="heading-medium"><%= @cease_or_revoke_form.company_name %></h2>
+
+        <p class="lede">
+          <%= t(".tier.#{@cease_or_revoke_form.tier.downcase}") %> -
+          <%= t(".registration_type.#{@cease_or_revoke_form.registration_type}") %>
+        </p>
+        <p>
+          <%= displayable_address(@cease_or_revoke_form.contact_address).join(", ") %>
+        </p>
+      </div>
+
+      <div class="form-group <%= "form-group-error" if @cease_or_revoke_form.errors[:status].any? %>">
+        <fieldset>
+          <legend>
+            <p>
+              <%= t(".cease_or_revoke.legend") %>
+            </p>
+          </legend>
+
+          <% if @cease_or_revoke_form.errors[:status].any? %>
+            <span class="error-message"><%= @cease_or_revoke_form.errors[:status].join(", ") %></span>
+          <% end %>
+
+          <div class="multiple-choice">
+            <%= f.radio_button :status, "REVOKED", checked: @transient_registration.metaData&.status == "REVOKED" %>
+            <%= f.label :status, t(".cease_or_revoke.options.revoke"), value: "REVOKED" %>
+          </div>
+
+          <div class="multiple-choice">
+            <%= f.radio_button :status, "INACTIVE", checked: @transient_registration.metaData&.status == "INACTIVE" %>
+            <%= f.label :status, t(".cease_or_revoke.options.cease"), value: "INACTIVE" %>
+          </div>
+        </fieldset>
+      </div>
+
+      <div class="form-group <%= "form-group-error" if @cease_or_revoke_form.errors[:revoked_reason].any? %>">
+        <fieldset>
+          <% if @cease_or_revoke_form.errors[:revoked_reason].any? %>
+            <span class="error-message"><%= @cease_or_revoke_form.errors[:revoked_reason].join(", ") %></span>
+          <% end %>
+
+          <%= f.label :revoked_reason, t(".cease_or_revoke.reason"), class: "form-label" %>
+          <%= f.text_area :revoked_reason, class: "form-control form-control-3-4", rows: 5, value: @transient_registration.metaData&.revoked_reason %>
+        </fieldset>
+      </div>
+
+      <div class="form-group">
+        <%= f.submit t(".next_button"), class: "button" %>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/config/locales/forms/cease_or_revoke_forms/en.yml
+++ b/config/locales/forms/cease_or_revoke_forms/en.yml
@@ -17,9 +17,8 @@ en:
           legend: "What do you want to do?"
           options:
             revoke: "Revoke"
-            cease: "De-register"
+            cease: "Cease"
           reason: "Reason"
-        total_cost_info: "The total cost will be shown on the next page"
         contact_address:
           heading: "Contact address:"
         next_button: "Confirm"

--- a/config/locales/forms/cease_or_revoke_forms/en.yml
+++ b/config/locales/forms/cease_or_revoke_forms/en.yml
@@ -1,0 +1,35 @@
+en:
+  waste_carriers_engine:
+    cease_or_revoke_forms:
+      new:
+        heading: "Revoke or cease registration %{reg_identifier}"
+        tier:
+          upper: "Upper tier"
+          lower: "Lower tier"
+        registration_type:
+          carrier_dealer: "Carrier and dealer"
+          broker_dealer: "Broker and dealer"
+          carrier_broker_dealer: "Carrier, broker and dealer"
+        reason:
+          label: "Reason"
+          help_text: "Maximum 500 characters"
+        cease_or_revoke:
+          legend: "What do you want to do?"
+          options:
+            revoke: "Revoke"
+            cease: "De-register"
+          reason: "Reason"
+        total_cost_info: "The total cost will be shown on the next page"
+        contact_address:
+          heading: "Contact address:"
+        next_button: "Confirm"
+  activemodel:
+    errors:
+      models:
+        waste_carriers_engine/cease_or_revoke_form:
+          attributes:
+            status:
+              presence: "Select revoke or cease"
+            revoked_reason:
+              presence: "Enter a reason"
+              length: "Reason must be 500 characters or fewer"

--- a/config/locales/models/ceased_or_revoked_registrations/en.yml
+++ b/config/locales/models/ceased_or_revoked_registrations/en.yml
@@ -1,0 +1,10 @@
+en:
+  activemodel:
+    errors:
+      models:
+        waste_carriers_engine/ceased_or_revoked_registration:
+          attributes:
+            reg_identifier:
+              invalid_format: "The registration ID is not in a valid format"
+              no_registration: "There is no registration matching this ID"
+              renewal_in_progress: "This renewal is already in progress"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,12 +38,12 @@ WasteCarriersEngine::Engine.routes.draw do
     # End of order copy cards flow
 
     # Ceased or revoked flow
-    resources :cease_or_revoke_form,
+    resources :cease_or_revoke_forms,
               only: %i[new create],
-              path: "ceased-or-revoked",
+              path: "cease-or-revoke",
               path_names: { new: "" }
 
-    resources :ceased_or_revoked_confirm_form,
+    resources :ceased_or_revoked_confirm_forms,
               only: %i[new create],
               path: "ceased-or-revoked-confirm",
               path_names: { new: "" } do
@@ -53,7 +53,7 @@ WasteCarriersEngine::Engine.routes.draw do
                     on: :collection
               end
 
-    resources :ceased_or_revoked_completed_form,
+    resources :ceased_or_revoked_completed_forms,
               only: %i[create],
               path: "ceased-or-revoked-complete"
     # End of ceased or revoked flow

--- a/spec/dummy/app/models/ability.rb
+++ b/spec/dummy/app/models/ability.rb
@@ -7,5 +7,7 @@ class Ability
     can :read, WasteCarriersEngine::Registration, account_email: user.email
     can :manage, WasteCarriersEngine::RenewingRegistration, account_email: user.email
     can :order_copy_cards, WasteCarriersEngine::Registration
+    can :cease, WasteCarriersEngine::Registration
+    can :revoke, WasteCarriersEngine::Registration
   end
 end

--- a/spec/factories/ceased_or_revoked_registration.rb
+++ b/spec/factories/ceased_or_revoked_registration.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :ceased_or_revoked_registration, class: WasteCarriersEngine::CeasedOrRevokedRegistration do
-    initialize_with { new(reg_identifier: build(:registration, :has_required_data, :is_active).reg_identifier) }
+    initialize_with { new(reg_identifier: create(:registration, :has_required_data, :is_active).reg_identifier) }
   end
 end

--- a/spec/requests/waste_carriers_engine/cease_or_revoke_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/cease_or_revoke_forms_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "CeaseOrRevokeForms", type: :request do
+    describe "GET new_cease_or_revoke_form_path" do
+      context "when a user is signed in" do
+        let(:user) { create(:user) }
+
+        before(:each) do
+          sign_in(user)
+        end
+
+        context "when no matching registration exists" do
+          it "redirects to the invalid token error page" do
+            get new_cease_or_revoke_form_path("CBDU999999999")
+
+            expect(response).to redirect_to(page_path("invalid"))
+          end
+        end
+
+        context "when the token doesn't match the format" do
+          it "redirects to the invalid token error page" do
+            get new_cease_or_revoke_form_path("foo")
+
+            expect(response).to redirect_to(page_path("invalid"))
+          end
+        end
+
+        context "when a matching registration exists" do
+          context "when the given registration is not active" do
+            let(:registration) { create(:registration, :has_required_data, :is_pending) }
+
+            it "redirects to the page" do
+              get new_cease_or_revoke_form_path(registration.reg_identifier)
+
+              expect(response).to redirect_to(page_path("invalid"))
+            end
+          end
+
+          context "when the given registration is active" do
+            let(:registration) { create(:registration, :has_required_data, :is_active) }
+
+            it "responds to the GET request with a 200 status code and renders the appropriate template" do
+              get new_cease_or_revoke_form_path(registration.reg_identifier)
+
+              expect(response).to render_template("waste_carriers_engine/cease_or_revoke_forms/new")
+              expect(response.code).to eq("200")
+            end
+
+            context "when an order is in progress" do
+              let!(:transient_registration) { create(:ceased_or_revoked_registration, workflow_state: "ceased_or_revoked_confirm_form") }
+
+              context "when the token is a reg_identifier" do
+                it "redirects to the correct workflow state form" do
+                  get new_cease_or_revoke_form_path(transient_registration.registration.reg_identifier)
+
+                  expect(response).to redirect_to(new_ceased_or_revoked_confirm_form_path(transient_registration.token))
+                end
+              end
+
+              it "redirects to the correct workflow state form" do
+                get new_cease_or_revoke_form_path(transient_registration.token)
+
+                expect(response).to redirect_to(new_ceased_or_revoked_confirm_form_path(transient_registration.token))
+              end
+            end
+          end
+        end
+      end
+
+      context "when a user is not signed in" do
+        before(:each) do
+          user = create(:user)
+          sign_out(user)
+        end
+
+        it "returns a 302 response and redirects to the sign in page" do
+          get new_cease_or_revoke_form_path("foo")
+
+          expect(response).to have_http_status(302)
+          expect(response).to redirect_to(new_user_session_path)
+        end
+      end
+    end
+
+    describe "POST cease_or_revoke_forms_path" do
+      context "when a user is signed in" do
+        let(:user) { create(:user) }
+
+        before(:each) do
+          sign_in(user)
+        end
+
+        context "when no matching registration exists" do
+          it "redirects to the invalid token error page and does not create a new transient registration" do
+            original_tr_count = CeasedOrRevokedRegistration.count
+
+            post cease_or_revoke_forms_path("CBDU99999")
+
+            expect(response).to redirect_to(page_path("invalid"))
+            expect(CeasedOrRevokedRegistration.count).to eq(original_tr_count)
+          end
+        end
+
+        context "when the token doesn't match the format" do
+          it "redirects to the invalid token error page and does not create a new transient registration" do
+            original_tr_count = CeasedOrRevokedRegistration.count
+
+            post cease_or_revoke_forms_path("foo")
+
+            expect(CeasedOrRevokedRegistration.count).to eq(original_tr_count)
+            expect(response).to redirect_to(page_path("invalid"))
+          end
+        end
+
+        context "when a matching registration exists" do
+          let(:registration) { create(:registration, :has_required_data, :is_active) }
+
+          context "when valid params are submitted" do
+            let(:valid_params) { { token: registration.reg_identifier, metaData: { status: "REVOKED", revoked_reason: "Some reason" } } }
+
+            it "creates a transient registration with correct data, returns a 302 response and redirects to the " do
+              expected_tr_count = CeasedOrRevokedRegistration.count + 1
+
+              post cease_or_revoke_forms_path(registration.reg_identifier), cease_or_revoke_form: valid_params
+
+              transient_registration = CeasedOrRevokedRegistration.find_by(reg_identifier: registration.reg_identifier)
+
+              expect(expected_tr_count).to eq(CeasedOrRevokedRegistration.count)
+              expect(transient_registration.metaData.status).to eq("REVOKED")
+              expect(transient_registration.metaData.revoked_reason).to eq("Some reason")
+
+              expect(response).to have_http_status(302)
+              expect(response).to redirect_to(new_ceased_or_revoked_confirm_form_path(transient_registration.token))
+            end
+          end
+
+          context "when invalid params are submitted" do
+            let(:invalid_params) { { token: registration.reg_identifier, metaData: {} } }
+
+            it "returns a 200 response and render the new form" do
+              post cease_or_revoke_forms_path(registration.reg_identifier), cease_or_revoke_form: invalid_params
+
+              expect(response).to have_http_status(200)
+              expect(response).to render_template("waste_carriers_engine/cease_or_revoke_forms/new")
+            end
+          end
+        end
+      end
+
+      context "when a user is not signed in" do
+        let(:registration) { create(:registration, :has_required_data) }
+        let(:valid_params) { { token: registration.reg_identifier } }
+
+        before(:each) do
+          user = create(:user)
+          sign_out(user)
+        end
+
+        it "returns a 302 response, redirects to the login page and does not create a new transient registration" do
+          original_tr_count = CeasedOrRevokedRegistration.count
+
+          post cease_or_revoke_forms_path(registration.reg_identifier), renewal_start_form: valid_params
+
+          expect(response).to redirect_to(new_user_session_path)
+          expect(response).to have_http_status(302)
+          expect(CeasedOrRevokedRegistration.count).to eq(original_tr_count)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/waste_carriers_engine/flow_permission_checks_service_spec.rb
+++ b/spec/services/waste_carriers_engine/flow_permission_checks_service_spec.rb
@@ -29,6 +29,16 @@ module WasteCarriersEngine
         end
       end
 
+      context "when the transient object is an CeasedOrRevokedRegistration" do
+        let(:transient_registration) { CeasedOrRevokedRegistration.new }
+
+        it "runs the correct permission check service and return a result" do
+          expect(CeasedOrRevokedRegistrationPermissionChecksService).to receive(:run).with(params).and_return(result)
+
+          expect(described_class.run(params)).to eq(result)
+        end
+      end
+
       context "when there is no permission check service for the given transient object" do
         let(:transient_registration) { double(:transient_registration) }
 


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-807

This adds all the code that will deal with the start of the journey for the ceased and revoked form. 

<img width="646" alt="Screenshot 2019-12-27 at 18 39 42" src="https://user-images.githubusercontent.com/1385397/71528750-5a868100-28d9-11ea-92b9-7bbe69918180.png">
<img width="692" alt="Screenshot 2019-12-27 at 18 39 35" src="https://user-images.githubusercontent.com/1385397/71528751-5a868100-28d9-11ea-874b-76bd21e6aaf7.png">
