### PR TITLE
Add delete path to transient registrations

### DIFF
--- a/app/controllers/waste_carriers_engine/transient_registrations_controller.rb
+++ b/app/controllers/waste_carriers_engine/transient_registrations_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class TransientRegistrationsController < ApplicationController
+    before_action :authenticate_user!
+
+    def destroy
+      transient_registration = TransientRegistration.find_by(token: params[:token])
+
+      transient_registration.destroy!
+
+      redirect_to registrations_path(reg_identifier: transient_registration.reg_identifier)
+    end
+  end
+end

--- a/app/controllers/waste_carriers_engine/transient_registrations_controller.rb
+++ b/app/controllers/waste_carriers_engine/transient_registrations_controller.rb
@@ -6,10 +6,13 @@ module WasteCarriersEngine
 
     def destroy
       transient_registration = TransientRegistration.find_by(token: params[:token])
+      redirect_path = Rails.application.routes.url_helpers.registration_path(
+        reg_identifier: transient_registration.reg_identifier
+      )
 
       transient_registration.destroy!
 
-      redirect_to Rails.application.routes.url_helpers.registration_path(reg_identifier: transient_registration.reg_identifier)
+      redirect_to redirect_path
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/transient_registrations_controller.rb
+++ b/app/controllers/waste_carriers_engine/transient_registrations_controller.rb
@@ -9,7 +9,7 @@ module WasteCarriersEngine
 
       transient_registration.destroy!
 
-      redirect_to registrations_path(reg_identifier: transient_registration.reg_identifier)
+      redirect_to Rails.application.routes.url_helpers.registration_path(reg_identifier: transient_registration.reg_identifier)
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,10 @@
 WasteCarriersEngine::Engine.routes.draw do
   resources :registrations, only: [:index] unless Rails.env.production?
 
+  get "transient-registration/:token/destroy",
+    to: "transient_registrations#destroy",
+    as: "delete_transient_registration"
+
   scope "/:token" do
     # Order copy cards flow
     resources :copy_cards_forms,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,8 @@ WasteCarriersEngine::Engine.routes.draw do
   resources :registrations, only: [:index] unless Rails.env.production?
 
   get "transient-registration/:token/destroy",
-    to: "transient_registrations#destroy",
-    as: "delete_transient_registration"
+      to: "transient_registrations#destroy",
+      as: "delete_transient_registration"
 
   scope "/:token" do
     # Order copy cards flow

--- a/spec/requests/waste_carriers_engine/transient_registrations_spec.rb
+++ b/spec/requests/waste_carriers_engine/transient_registrations_spec.rb
@@ -20,7 +20,7 @@ module WasteCarriersEngine
             get delete_transient_registration_path(transient_registration[:token])
 
             expect(response).to have_http_status(302)
-            expect(response).to redirect_to(registrations_path(reg_identifier: transient_registration.reg_identifier))
+            expect(response).to redirect_to(Rails.application.routes.url_helpers.registration_path(reg_identifier: transient_registration.reg_identifier))
             expect(TransientRegistration.count).to eq(expected_count)
           end
         end

--- a/spec/requests/waste_carriers_engine/transient_registrations_spec.rb
+++ b/spec/requests/waste_carriers_engine/transient_registrations_spec.rb
@@ -19,7 +19,6 @@ module WasteCarriersEngine
           end
 
           it "deletes the transient registration, returns a 302 status and redirects to the registration page" do
-            reg_identifier = transient_registration.reg_identifier
             expected_count = TransientRegistration.count - 1
 
             get delete_transient_registration_path(transient_registration[:token])

--- a/spec/requests/waste_carriers_engine/transient_registrations_spec.rb
+++ b/spec/requests/waste_carriers_engine/transient_registrations_spec.rb
@@ -16,11 +16,14 @@ module WasteCarriersEngine
           it "deletes the transient registration, returns a 302 status and redirects to the registration page" do
             transient_registration = create(:renewing_registration, :has_required_data)
             expected_count = TransientRegistration.count - 1
+            redirect_path = Rails.application.routes.url_helpers.registration_path(
+              reg_identifier: transient_registration.reg_identifier
+            )
 
             get delete_transient_registration_path(transient_registration[:token])
 
             expect(response).to have_http_status(302)
-            expect(response).to redirect_to(Rails.application.routes.url_helpers.registration_path(reg_identifier: transient_registration.reg_identifier))
+            expect(response).to redirect_to(redirect_path)
             expect(TransientRegistration.count).to eq(expected_count)
           end
         end

--- a/spec/requests/waste_carriers_engine/transient_registrations_spec.rb
+++ b/spec/requests/waste_carriers_engine/transient_registrations_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "TransientRegistration", type: :request do
+    describe "GET delete_transient_registration_path" do
+      context "when a valid user is signed in" do
+        let(:user) { create(:user) }
+
+        before(:each) do
+          sign_in(user)
+        end
+
+        context "when a valid transient registration exists" do
+          let(:transient_registration) do
+            create(:renewing_registration,
+                   :has_required_data)
+          end
+
+          it "deletes the transient registration, returns a 302 status and redirects to the registration page" do
+            reg_identifier = transient_registration.reg_identifier
+            expected_count = TransientRegistration.count - 1
+
+            get delete_transient_registration_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(registrations_path(reg_identifier: transient_registration.reg_identifier))
+            expect(TransientRegistration.count).to eq(expected_count)
+          end
+        end
+      end
+
+      context "when a valid user is not signed in" do
+        it "returns a 302 status and redirects to the login page" do
+          get delete_transient_registration_path("foo")
+
+          expect(response).to have_http_status(302)
+          expect(response).to redirect_to("/users/sign_in")
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/waste_carriers_engine/transient_registrations_spec.rb
+++ b/spec/requests/waste_carriers_engine/transient_registrations_spec.rb
@@ -13,12 +13,8 @@ module WasteCarriersEngine
         end
 
         context "when a valid transient registration exists" do
-          let(:transient_registration) do
-            create(:renewing_registration,
-                   :has_required_data)
-          end
-
           it "deletes the transient registration, returns a 302 status and redirects to the registration page" do
+            transient_registration = create(:renewing_registration, :has_required_data)
             expected_count = TransientRegistration.count - 1
 
             get delete_transient_registration_path(transient_registration[:token])


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-807

We have now the need to delete transient registrations through UI functionality. Since we have no JS support to generate `DELETE` method links, we have achieved it by changing the route so that it accept "get" requests. The rest of the code follows the conventions.