### PR TITLE
Add confirm form to revoke or cease flow

### DIFF
--- a/app/controllers/waste_carriers_engine/ceased_or_revoked_confirm_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/ceased_or_revoked_confirm_forms_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class CeasedOrRevokedConfirmFormsController < FormsController
+    def new
+      super(CeasedOrRevokedConfirmForm, "ceased_or_revoked_confirm_form")
+    end
+
+    def create
+      find_or_initialize_transient_registration(params[:token])
+
+      CeasedOrRevokedCompletionService.run(@transient_registration)
+
+      status = @transient_registration.status
+      ceased_or_revoked = I18n.t(
+        "waste_carriers_engine.ceased_or_revoked_confirm_forms.create.ceased_or_revoked.#{status}",
+      )
+      message = I18n.t(
+        "waste_carriers_engine.ceased_or_revoked_confirm_forms.create.submit_message",
+        reg_identifier: @transient_registration.reg_identifier,
+        revoked_or_ceased: ceased_or_revoked
+      )
+
+      flash[:message] = message
+
+      return redirect_to("/")
+    end
+  end
+end

--- a/app/controllers/waste_carriers_engine/ceased_or_revoked_confirm_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/ceased_or_revoked_confirm_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteCarriersEngine
 
       status = @transient_registration.status
       ceased_or_revoked = I18n.t(
-        "waste_carriers_engine.ceased_or_revoked_confirm_forms.create.ceased_or_revoked.#{status}",
+        "waste_carriers_engine.ceased_or_revoked_confirm_forms.create.ceased_or_revoked.#{status}"
       )
       message = I18n.t(
         "waste_carriers_engine.ceased_or_revoked_confirm_forms.create.submit_message",
@@ -23,7 +23,7 @@ module WasteCarriersEngine
 
       flash[:message] = message
 
-      return redirect_to("/")
+      redirect_to("/")
     end
   end
 end

--- a/app/forms/waste_carriers_engine/ceased_or_revoked_confirm_form.rb
+++ b/app/forms/waste_carriers_engine/ceased_or_revoked_confirm_form.rb
@@ -2,6 +2,6 @@
 
 module WasteCarriersEngine
   class CeasedOrRevokedConfirmForm < BaseForm
-    # TODO
+    delegate :contact_address, :company_name, :registration_type, :tier, to: :transient_registration
   end
 end

--- a/app/views/waste_carriers_engine/ceased_or_revoked_confirm_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/ceased_or_revoked_confirm_forms/new.html.erb
@@ -1,0 +1,29 @@
+<%= render("waste_carriers_engine/shared/back", back_path: back_ceased_or_revoked_confirm_forms_path(token: @transient_registration.token)) %>
+
+<div class="text">
+  <%= form_for(@ceased_or_revoked_confirm_form) do |f| %>
+    <h1 class="heading-large">
+      <%= t(".heading", reg_identifier: @transient_registration.reg_identifier, revoke_or_cease: t(".revoke_or_cease.#{@transient_registration.status}")) %>
+    </h1>
+
+    <div class="panel wcr-panel wcr-panel-border-all">
+      <h2 class="heading-medium"><%= @ceased_or_revoked_confirm_form.company_name %></h2>
+
+      <p class="lede">
+        <%= t(".tier.#{@ceased_or_revoked_confirm_form.tier.downcase}") %> -
+        <%= t(".registration_type.#{@ceased_or_revoked_confirm_form.registration_type}") %>
+      </p>
+      <p>
+        <%= displayable_address(@ceased_or_revoked_confirm_form.contact_address).join(", ") %>
+      </p>
+    </div>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button", revoke_or_cease: t(".revoke_or_cease.#{@transient_registration.status}")), class: "button" %>
+
+      <div class="form-button-link">
+        <%= link_to t(".cancel"), delete_transient_registration_path(@ceased_or_revoked_confirm_form.transient_registration.token) %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/config/locales/forms/ceased_or_revoked_confirm_forms/en.yml
+++ b/config/locales/forms/ceased_or_revoked_confirm_forms/en.yml
@@ -1,0 +1,24 @@
+en:
+  waste_carriers_engine:
+    ceased_or_revoked_confirm_forms:
+      new:
+        heading: "Confirm %{revoke_or_cease} for registration %{reg_identifier}"
+        revoke_or_cease:
+          revoked: "revoke"
+          inactive: "cease"
+        tier:
+          upper: "Upper tier"
+          lower: "Lower tier"
+        registration_type:
+          carrier_dealer: "Carrier and dealer"
+          broker_dealer: "Broker and dealer"
+          carrier_broker_dealer: "Carrier, broker and dealer"
+        contact_address:
+          heading: "Contact address:"
+        next_button: "Confirm %{revoke_or_cease}"
+        cancel: "Cancel"
+      create:
+        submit_message: "%{reg_identifier} has been %{revoked_or_ceased}"
+        revoked_or_ceased:
+          revoke: "revoked"
+          inactive: "ceased"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,14 +52,10 @@ WasteCarriersEngine::Engine.routes.draw do
               path: "ceased-or-revoked-confirm",
               path_names: { new: "" } do
                 get "back",
-                    to: "ceased_or_revoked_confirm_form#go_back",
+                    to: "ceased_or_revoked_confirm_forms#go_back",
                     as: "back",
                     on: :collection
               end
-
-    resources :ceased_or_revoked_completed_forms,
-              only: %i[create],
-              path: "ceased-or-revoked-complete"
     # End of ceased or revoked flow
 
     resources :renewal_start_forms,

--- a/spec/requests/waste_carriers_engine/ceased_or_revoked_confirm_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/ceased_or_revoked_confirm_forms_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "CopyCardsOrderCompletedForm", type: :request do
+    describe "GET new_ceased_or_revoked_confirm_form_path" do
+      context "when a user is signed in" do
+        let(:user) { create(:user) }
+
+        before(:each) do
+          sign_in(user)
+        end
+
+        context "when no matching registration exists" do
+          it "redirects to the invalid token error page" do
+            get new_ceased_or_revoked_confirm_form_path("CBDU999999999")
+            expect(response).to redirect_to(page_path("invalid"))
+          end
+        end
+
+        context "when a matching registration exists" do
+          let(:transient_registration) do
+            create(
+              :ceased_or_revoked_registration,
+              workflow_state: "ceased_or_revoked_confirm_form",
+              metaData: {
+                status: "REVOKED"
+              }
+            )
+          end
+
+          it "renders the appropriate template and responds with a 200 status code" do
+            get new_ceased_or_revoked_confirm_form_path(transient_registration.token)
+
+            expect(response).to render_template("waste_carriers_engine/ceased_or_revoked_confirm_forms/new")
+            expect(response.code).to eq("200")
+          end
+        end
+      end
+
+      context "when a user is not signed in" do
+        before(:each) do
+          user = create(:user)
+          sign_out(user)
+        end
+
+        it "returns a 302 response" do
+          get new_ceased_or_revoked_confirm_form_path("foo")
+          expect(response).to have_http_status(302)
+        end
+
+        it "redirects to the sign in page" do
+          get new_ceased_or_revoked_confirm_form_path("foo")
+          expect(response).to redirect_to(new_user_session_path)
+        end
+      end
+    end
+
+    describe "POST ceased_or_revoked_confirm_forms_path" do
+      context "when a valid user is signed in" do
+        let(:user) { create(:user) }
+        before(:each) do
+          sign_in(user)
+        end
+
+        context "when a valid transient registration exists" do
+          let(:transient_registration) do
+            create(
+              :ceased_or_revoked_registration,
+              workflow_state: "ceased_or_revoked_confirm_form",
+              metaData: {
+                status: "REVOKED",
+                revokedReason: "Revoked Reason"
+              }
+            )
+          end
+
+          context "when the workflow_state is correct" do
+            it "deletes the transient object, copy data to the registration, redirects to the main dashboard page" do
+              registration = transient_registration.registration
+              previous_email_count = ActionMailer::Base.deliveries.count
+
+              post ceased_or_revoked_confirm_forms_path(transient_registration.token)
+
+              registration.reload
+
+              expect(WasteCarriersEngine::TransientRegistration.count).to eq(0)
+              expect(registration.metaData.status).to eq("REVOKED")
+              expect(registration.metaData.revokedReason).to eq("Revoked Reason")
+              expect(response).to have_http_status(302)
+              expect(response).to redirect_to(root_path)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/waste_carriers_engine/ceased_or_revoked_confirm_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/ceased_or_revoked_confirm_forms_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 module WasteCarriersEngine
-  RSpec.describe "CopyCardsOrderCompletedForm", type: :request do
+  RSpec.describe "CeasedOrRevokedConfirmForm", type: :request do
     describe "GET new_ceased_or_revoked_confirm_form_path" do
       context "when a user is signed in" do
         let(:user) { create(:user) }

--- a/spec/requests/waste_carriers_engine/ceased_or_revoked_confirm_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/ceased_or_revoked_confirm_forms_spec.rb
@@ -79,7 +79,6 @@ module WasteCarriersEngine
           context "when the workflow_state is correct" do
             it "deletes the transient object, copy data to the registration, redirects to the main dashboard page" do
               registration = transient_registration.registration
-              previous_email_count = ActionMailer::Base.deliveries.count
 
               post ceased_or_revoked_confirm_forms_path(transient_registration.token)
 


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-807

This adds the confirm form and view for the revoke or cease form

Flash message will come in separate PR

<img width="625" alt="Screenshot 2019-12-30 at 13 40 20" src="https://user-images.githubusercontent.com/1385397/71586463-3792e180-2b12-11ea-80cb-f4193d3186a2.png">
<img width="642" alt="Screenshot 2019-12-30 at 13 40 10" src="https://user-images.githubusercontent.com/1385397/71586464-3792e180-2b12-11ea-8187-d771fe111c5d.png">
