### PR TITLE
Add constant for payment types and scope for refund

### DIFF
--- a/app/models/waste_carriers_engine/payment.rb
+++ b/app/models/waste_carriers_engine/payment.rb
@@ -4,6 +4,19 @@ module WasteCarriersEngine
   class Payment
     include Mongoid::Document
 
+    PAYMENT_TYPES = [
+      CASH = "CASH",
+      CHEQUE = "CHEQUE",
+      POSTALORDER = "POSTALORDER",
+      BANKTRANSFER = "BANKTRANSFER",
+      WORLDPAY = "WORLDPAY",
+      WORLDPAY_MISSED = "WORLDPAY_MISSED",
+      REFUND = "REFUND",
+      WRITEOFFSMALL = "WRITEOFFSMALL",
+      WRITEOFFLARGE = "WRITEOFFLARGE",
+      REVERSAL = "REVERSAL"
+    ].freeze
+
     embedded_in :finance_details, class_name: "WasteCarriersEngine::FinanceDetails"
 
     field :orderKey, as: :order_key,                              type: String
@@ -20,6 +33,14 @@ module WasteCarriersEngine
     field :updatedByUser, as: :updated_by_user,                   type: String
     field :comment,                                               type: String
     field :paymentType, as: :payment_type,                        type: String
+
+    scope :refundable, (lambda do
+      where(
+        payment_type: {
+          "$in" => [CASH, CHEQUE, POSTALORDER, BANKTRANSFER, WORLDPAY, WORLDPAY_MISSED]
+        }
+      )
+    end)
 
     def self.new_from_worldpay(order, current_user)
       payment = Payment.new

--- a/spec/models/waste_carriers_engine/payment_spec.rb
+++ b/spec/models/waste_carriers_engine/payment_spec.rb
@@ -7,6 +7,27 @@ module WasteCarriersEngine
     let(:transient_registration) { build(:renewing_registration, :has_required_data) }
     let(:current_user) { build(:user) }
 
+    describe "scopes" do
+      describe ".refundable" do
+        let(:transient_registration) { build(:renewing_registration, :has_required_data, :has_finance_details) }
+
+        it "returns a list of payments that have a type which can be refunded" do
+          cash_payment = WasteCarriersEngine::Payment.new(payment_type: "CASH")
+          refund_payment = WasteCarriersEngine::Payment.new(payment_type: "REFUND")
+
+          transient_registration.finance_details.payments << cash_payment
+          transient_registration.finance_details.payments << refund_payment
+          transient_registration.save
+          transient_registration.reload
+
+          result = transient_registration.finance_details.payments.refundable
+
+          expect(result).to include(cash_payment)
+          expect(result).to_not include(refund_payment)
+        end
+      end
+    end
+
     describe "new_from_worldpay" do
       before do
         Timecop.freeze(Time.new(2018, 1, 1)) do


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-811

Adds a scope for refundable payments and creates constants for payment types