### PR TITLE
Externalise Worldpay code into concerns

### DIFF
--- a/app/services/concerns/waste_carriers_engine/can_build_worldpay_xml.rb
+++ b/app/services/concerns/waste_carriers_engine/can_build_worldpay_xml.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  module CanBuildWorldpayXml
+    extend ActiveSupport::Concern
+
+    included do
+      private
+
+      def build_doctype(xml)
+        xml.doc.create_internal_subset(
+          "paymentService",
+          "-//WorldPay/DTD WorldPay PaymentService v1/EN",
+          "http://dtd.worldpay.com/paymentService_v1.dtd"
+        )
+      end
+
+      def merchant_code
+        @_merchant_code ||= Rails.configuration.worldpay_merchantcode
+      end
+    end
+  end
+end

--- a/app/services/concerns/waste_carriers_engine/can_send_worldpay_request.rb
+++ b/app/services/concerns/waste_carriers_engine/can_send_worldpay_request.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  module CanSendWorldpayRequest
+    extend ActiveSupport::Concern
+
+    included do
+      private
+
+      def send_request(xml)
+        Rails.logger.debug "Sending initial request to WorldPay: #{xml}"
+
+        begin
+          response = RestClient::Request.execute(
+            method: :get,
+            url: url,
+            payload: xml,
+            headers: {
+              "Authorization" => authorization
+            }
+          )
+
+          Rails.logger.debug "Received response from WorldPay: #{response}"
+
+          response
+        end
+      end
+
+      def url
+        @_url ||= Rails.configuration.worldpay_url
+      end
+
+      def authorization
+        @_authorization ||= "Basic " + Base64.encode64(username + ":" + password).to_s
+      end
+
+      def username
+        @_username ||= Rails.configuration.worldpay_username
+      end
+
+      def password
+        @_password ||= Rails.configuration.worldpay_password
+      end
+    end
+  end
+end

--- a/app/services/concerns/waste_carriers_engine/can_send_worldpay_request.rb
+++ b/app/services/concerns/waste_carriers_engine/can_send_worldpay_request.rb
@@ -4,6 +4,7 @@ module WasteCarriersEngine
   module CanSendWorldpayRequest
     extend ActiveSupport::Concern
 
+    # rubocop:disable Metrics/BlockLength
     included do
       private
 
@@ -42,5 +43,6 @@ module WasteCarriersEngine
         @_password ||= Rails.configuration.worldpay_password
       end
     end
+    # rubocop:enable Metrics/BlockLength
   end
 end

--- a/app/services/waste_carriers_engine/worldpay_xml_service.rb
+++ b/app/services/waste_carriers_engine/worldpay_xml_service.rb
@@ -4,6 +4,8 @@ require "countries"
 
 module WasteCarriersEngine
   class WorldpayXmlService
+    include CanBuildWorldpayXml
+
     def initialize(transient_registration, order, current_user)
       @transient_registration = transient_registration
       @order = order
@@ -11,8 +13,6 @@ module WasteCarriersEngine
     end
 
     def build_xml
-      merchant_code = Rails.configuration.worldpay_merchantcode
-
       builder = Nokogiri::XML::Builder.new do |xml|
         build_doctype(xml)
 
@@ -27,14 +27,6 @@ module WasteCarriersEngine
     end
 
     private
-
-    def build_doctype(xml)
-      xml.doc.create_internal_subset(
-        "paymentService",
-        "-//WorldPay/DTD WorldPay PaymentService v1/EN",
-        "http://dtd.worldpay.com/paymentService_v1.dtd"
-      )
-    end
 
     def build_order(xml)
       order_code = @order.order_code


### PR DESCRIPTION
This is an initial refactoring to the code that produces the Worldpay xml and send Worldpay requests. This only externalise common bits that can be reused with requests for refunds.