### PR TITLE
Redirect to correct back office dashboard

### DIFF
--- a/app/controllers/waste_carriers_engine/ceased_or_revoked_confirm_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/ceased_or_revoked_confirm_forms_controller.rb
@@ -24,7 +24,7 @@ module WasteCarriersEngine
 
       flash[:message] = message
 
-      redirect_to("/")
+      redirect_to("/bo")
     end
   end
 end

--- a/spec/requests/waste_carriers_engine/ceased_or_revoked_confirm_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/ceased_or_revoked_confirm_forms_spec.rb
@@ -88,7 +88,7 @@ module WasteCarriersEngine
               expect(registration.metaData.status).to eq("REVOKED")
               expect(registration.metaData.revokedReason).to eq("Revoked Reason")
               expect(response).to have_http_status(302)
-              expect(response).to redirect_to(root_path)
+              expect(response).to redirect_to("/bo")
             end
           end
         end


### PR DESCRIPTION
QA have noticed that when completing a ceased or revoked request the user is redirected to the old code dashboard rather than the new. This fixes it.