### PR TITLE
Add partial for error flash messages

### DIFF
--- a/app/views/shared/_error.html.erb
+++ b/app/views/shared/_error.html.erb
@@ -1,5 +1,10 @@
-<div class="error-summary flash-error" role="alert" aria-labelledby="error-summary-heading" tabindex="-1">
-  <span id="error-summary-heading">
+<div class="error-summary" role="alert" aria-labelledby="error-summary-heading-1">
+  <h2 class="heading-medium error-summary-heading" id="error-summary-heading-1">
     <%= message %>
-  </span>
+  </h2>
+  <% if details.present? %>
+    <p>
+      <%= details %>
+    </p>
+  <% end %>
 </div>

--- a/app/views/shared/_error.html.erb
+++ b/app/views/shared/_error.html.erb
@@ -1,0 +1,5 @@
+<div class="error-summary flash-error" role="alert" aria-labelledby="error-summary-heading" tabindex="-1">
+  <span id="error-summary-heading">
+    <%= message %>
+  </span>
+</div>


### PR DESCRIPTION
<img width="676" alt="Screenshot 2020-01-08 at 22 23 42" src="https://user-images.githubusercontent.com/1385397/72021378-cbc51d00-3265-11ea-8e21-2cbf72719449.png">
Style is implemented in the back-office: https://github.com/DEFRA/waste-carriers-back-office/pull/563