### PR TITLE
Remove log of worldpay

### DIFF
--- a/app/services/concerns/waste_carriers_engine/can_send_worldpay_request.rb
+++ b/app/services/concerns/waste_carriers_engine/can_send_worldpay_request.rb
@@ -9,7 +9,7 @@ module WasteCarriersEngine
       private
 
       def send_request(xml)
-        Rails.logger.debug "Sending initial request to WorldPay: #{xml}"
+        Rails.logger.debug "Sending initial request to WorldPay"
 
         begin
           response = RestClient::Request.execute(
@@ -21,7 +21,7 @@ module WasteCarriersEngine
             }
           )
 
-          Rails.logger.debug "Received response from WorldPay: #{response}"
+          Rails.logger.debug "Received response from WorldPay"
 
           response
         end


### PR DESCRIPTION
Since we run production mode in `debugging`, we don't want this logging to apply to all our requests