### PR TITLE
Add excess amount method to finance details

### DIFF
--- a/app/models/waste_carriers_engine/finance_details.rb
+++ b/app/models/waste_carriers_engine/finance_details.rb
@@ -27,11 +27,11 @@ module WasteCarriersEngine
     end
 
     # This amounts are used in a number of finance operations.
-    def amount_in_excess
+    def overpaid_balance
       @_amount_in_excess ||= balance <= 0 ? (balance * -1) : 0
     end
 
-    def amount_to_pay
+    def unpaid_balance
       @_amount_to_pay ||= [0, balance].max
     end
 

--- a/app/models/waste_carriers_engine/finance_details.rb
+++ b/app/models/waste_carriers_engine/finance_details.rb
@@ -26,6 +26,11 @@ module WasteCarriersEngine
       finance_details
     end
 
+    # This amount is used in a large number of finance operations.
+    def amount_in_excess
+      @_amount_in_excess ||= balance <= 0 ? (balance * -1) : 0
+    end
+
     def update_balance
       order_balance = orders.sum { |item| item[:total_amount] }
       # Select payments where the type is not WORLDPAY, or if it is, the status is AUTHORISED

--- a/app/models/waste_carriers_engine/finance_details.rb
+++ b/app/models/waste_carriers_engine/finance_details.rb
@@ -28,11 +28,11 @@ module WasteCarriersEngine
 
     # These amounts are used in a number of finance operations.
     def overpaid_balance
-      @_amount_in_excess ||= balance <= 0 ? (balance * -1) : 0
+      @_overpaid_balance ||= balance <= 0 ? (balance * -1) : 0
     end
 
     def unpaid_balance
-      @_amount_to_pay ||= [0, balance].max
+      @_unpaid_balance ||= [0, balance].max
     end
 
     def update_balance

--- a/app/models/waste_carriers_engine/finance_details.rb
+++ b/app/models/waste_carriers_engine/finance_details.rb
@@ -26,7 +26,7 @@ module WasteCarriersEngine
       finance_details
     end
 
-    # This amounts are used in a number of finance operations.
+    # These amounts are used in a number of finance operations.
     def overpaid_balance
       @_amount_in_excess ||= balance <= 0 ? (balance * -1) : 0
     end

--- a/app/models/waste_carriers_engine/finance_details.rb
+++ b/app/models/waste_carriers_engine/finance_details.rb
@@ -26,9 +26,13 @@ module WasteCarriersEngine
       finance_details
     end
 
-    # This amount is used in a large number of finance operations.
+    # This amounts are used in a number of finance operations.
     def amount_in_excess
       @_amount_in_excess ||= balance <= 0 ? (balance * -1) : 0
+    end
+
+    def amount_to_pay
+      @_amount_to_pay ||= [0, balance].max
     end
 
     def update_balance

--- a/spec/models/waste_carriers_engine/finance_details_spec.rb
+++ b/spec/models/waste_carriers_engine/finance_details_spec.rb
@@ -64,6 +64,40 @@ module WasteCarriersEngine
       end
     end
 
+    describe "amount_to_pay" do
+      let(:transient_registration) { build(:renewing_registration, :has_required_data, :has_finance_details) }
+
+      subject { transient_registration.finance_details }
+
+      before do
+        transient_registration.finance_details.balance = balance
+      end
+
+      context "when the balance is 0" do
+        let(:balance) { 0 }
+
+        it "returns 0" do
+          expect(subject.amount_to_pay).to be_zero
+        end
+      end
+
+      context "when the balance is more than 0" do
+        let(:balance) { 4 }
+
+        it "returns the balance" do
+          expect(subject.amount_to_pay).to eq(4)
+        end
+      end
+
+      context "when the balaance is less than 0" do
+        let(:balance) { -4 }
+
+        it "returns 0" do
+          expect(subject.amount_to_pay).to be_zero
+        end
+      end
+    end
+
     describe "update_balance" do
       let(:finance_details) { build(:finance_details) }
 

--- a/spec/models/waste_carriers_engine/finance_details_spec.rb
+++ b/spec/models/waste_carriers_engine/finance_details_spec.rb
@@ -30,6 +30,40 @@ module WasteCarriersEngine
       end
     end
 
+    describe "amount_in_excess" do
+      let(:transient_registration) { build(:renewing_registration, :has_required_data, :has_finance_details) }
+
+      subject { transient_registration.finance_details }
+
+      before do
+        transient_registration.finance_details.balance = balance
+      end
+
+      context "when the balance is 0" do
+        let(:balance) { 0 }
+
+        it "returns 0" do
+          expect(subject.amount_in_excess).to be_zero
+        end
+      end
+
+      context "when the balance is less than 0" do
+        let(:balance) { -4 }
+
+        it "returns the balance but in positive" do
+          expect(subject.amount_in_excess).to eq(4)
+        end
+      end
+
+      context "when the balaance is more than 0" do
+        let(:balance) { 4 }
+
+        it "returns 0" do
+          expect(subject.amount_in_excess).to be_zero
+        end
+      end
+    end
+
     describe "update_balance" do
       let(:finance_details) { build(:finance_details) }
 

--- a/spec/models/waste_carriers_engine/finance_details_spec.rb
+++ b/spec/models/waste_carriers_engine/finance_details_spec.rb
@@ -30,7 +30,7 @@ module WasteCarriersEngine
       end
     end
 
-    describe "amount_in_excess" do
+    describe "overpaid_balance" do
       let(:transient_registration) { build(:renewing_registration, :has_required_data, :has_finance_details) }
 
       subject { transient_registration.finance_details }
@@ -43,7 +43,7 @@ module WasteCarriersEngine
         let(:balance) { 0 }
 
         it "returns 0" do
-          expect(subject.amount_in_excess).to be_zero
+          expect(subject.overpaid_balance).to be_zero
         end
       end
 
@@ -51,7 +51,7 @@ module WasteCarriersEngine
         let(:balance) { -4 }
 
         it "returns the balance but in positive" do
-          expect(subject.amount_in_excess).to eq(4)
+          expect(subject.overpaid_balance).to eq(4)
         end
       end
 
@@ -59,12 +59,12 @@ module WasteCarriersEngine
         let(:balance) { 4 }
 
         it "returns 0" do
-          expect(subject.amount_in_excess).to be_zero
+          expect(subject.overpaid_balance).to be_zero
         end
       end
     end
 
-    describe "amount_to_pay" do
+    describe "unpaid_balance" do
       let(:transient_registration) { build(:renewing_registration, :has_required_data, :has_finance_details) }
 
       subject { transient_registration.finance_details }
@@ -77,7 +77,7 @@ module WasteCarriersEngine
         let(:balance) { 0 }
 
         it "returns 0" do
-          expect(subject.amount_to_pay).to be_zero
+          expect(subject.unpaid_balance).to be_zero
         end
       end
 
@@ -85,7 +85,7 @@ module WasteCarriersEngine
         let(:balance) { 4 }
 
         it "returns the balance" do
-          expect(subject.amount_to_pay).to eq(4)
+          expect(subject.unpaid_balance).to eq(4)
         end
       end
 
@@ -93,7 +93,7 @@ module WasteCarriersEngine
         let(:balance) { -4 }
 
         it "returns 0" do
-          expect(subject.amount_to_pay).to be_zero
+          expect(subject.unpaid_balance).to be_zero
         end
       end
     end


### PR DESCRIPTION
Since there are a lot of finance operations that deal with excess amounts, such as write offs and refund, I have decided that is best to add the method that calculate the excess amount in the model so that we don't need to duplicate it in multiple helper or presenters.