### PR TITLE
Add #zero_difference_balance method to FinanceDetails

### DIFF
--- a/app/models/waste_carriers_engine/finance_details.rb
+++ b/app/models/waste_carriers_engine/finance_details.rb
@@ -35,6 +35,11 @@ module WasteCarriersEngine
       @_unpaid_balance ||= [0, balance].max
     end
 
+    # This returns any amount of difference of the balance from 0
+    def zero_difference_balance
+      @_zero_difference_balance ||= [overpaid_balance, unpaid_balance].max
+    end
+
     def update_balance
       order_balance = orders.sum { |item| item[:total_amount] }
       # Select payments where the type is not WORLDPAY, or if it is, the status is AUTHORISED

--- a/spec/models/waste_carriers_engine/finance_details_spec.rb
+++ b/spec/models/waste_carriers_engine/finance_details_spec.rb
@@ -30,6 +30,40 @@ module WasteCarriersEngine
       end
     end
 
+    describe "zero_difference_balance" do
+      let(:transient_registration) { build(:renewing_registration, :has_required_data, :has_finance_details) }
+
+      subject { transient_registration.finance_details }
+
+      before do
+        transient_registration.finance_details.balance = balance
+      end
+
+      context "when the balance is 0" do
+        let(:balance) { 0 }
+
+        it "returns 0" do
+          expect(subject.zero_difference_balance).to be_zero
+        end
+      end
+
+      context "when the balance is less than 0" do
+        let(:balance) { -4 }
+
+        it "returns the difference from 0 balance" do
+          expect(subject.zero_difference_balance).to eq(4)
+        end
+      end
+
+      context "returns the difference from 0 balance" do
+        let(:balance) { 4 }
+
+        it "returns 0" do
+          expect(subject.zero_difference_balance).to eq(4)
+        end
+      end
+    end
+
     describe "overpaid_balance" do
       let(:transient_registration) { build(:renewing_registration, :has_required_data, :has_finance_details) }
 


### PR DESCRIPTION
Since we have the need to get a positive number referring to the difference from 0 of the balance, we have decided that we will add this knowledge to the model in order to reuse in different places