### PR TITLE
Fix bug on redirect after error

### DIFF
--- a/app/services/concerns/waste_carriers_engine/can_send_worldpay_request.rb
+++ b/app/services/concerns/waste_carriers_engine/can_send_worldpay_request.rb
@@ -11,6 +11,7 @@ module WasteCarriersEngine
       def send_request(xml)
         Rails.logger.debug "Sending initial request to WorldPay"
 
+        response = nil
         begin
           response = RestClient::Request.execute(
             method: :get,
@@ -22,9 +23,12 @@ module WasteCarriersEngine
           )
 
           Rails.logger.debug "Received response from WorldPay"
-
-          response
+        rescue StandardError => e
+          Rails.logger.error("Error sending refund to worldpay: #{e}")
+          Airbrake.notify(e, message: "Error on WorldPay refund request")
         end
+
+        response
       end
 
       def url


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-811

This fixes a bug for which an error in the request made to worldpay when the service is down was causing a 500 error rather than a redirect back with error message. This should fix it.