### PR TITLE
Fix broken 'Finished' link on renewal end pages

### DIFF
--- a/app/controllers/waste_carriers_engine/renewal_complete_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/renewal_complete_forms_controller.rb
@@ -2,6 +2,8 @@
 
 module WasteCarriersEngine
   class RenewalCompleteFormsController < FormsController
+    helper JourneyLinksHelper
+
     def new
       return unless super(RenewalCompleteForm, "renewal_complete_form")
 

--- a/app/controllers/waste_carriers_engine/renewal_received_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/renewal_received_forms_controller.rb
@@ -2,6 +2,8 @@
 
 module WasteCarriersEngine
   class RenewalReceivedFormsController < FormsController
+    helper JourneyLinksHelper
+
     def new
       super(RenewalReceivedForm, "renewal_received_form")
     end

--- a/app/helpers/waste_carriers_engine/application_helper.rb
+++ b/app/helpers/waste_carriers_engine/application_helper.rb
@@ -46,15 +46,6 @@ module WasteCarriersEngine
       end
     end
 
-    def dashboard_link(current_user)
-      return unless current_user.present?
-
-      id = current_user.id
-      root = Rails.configuration.wcrs_frontend_url
-      I18n.t("waste_carriers_engine.dashboard_link", root: root, id: id)
-      # "#{root}/user/#{id}/registrations"
-    end
-
     def displayable_address(address)
       return [] unless address.present?
 

--- a/app/helpers/waste_carriers_engine/journey_links_helper.rb
+++ b/app/helpers/waste_carriers_engine/journey_links_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  module JourneyLinksHelper
+    def renewal_finished_link(*)
+      # Designed to be overridden in host apps if needed
+      main_app.root_path
+    end
+  end
+end

--- a/app/views/waste_carriers_engine/renewal_complete_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/renewal_complete_forms/new.html.erb
@@ -49,7 +49,7 @@
 
       <p><%= link_to(t(".survey_link_text"), t("layouts.application.feedback_url")) %> <%= t(".survey_link_hint") %></p>
 
-      <%= link_to t(".next_button"), dashboard_link(current_user), class: 'button' %>
+      <%= link_to t(".next_button"), renewal_finished_link(reg_identifier: @renewal_complete_form.reg_identifier), class: 'button' %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/waste_carriers_engine/renewal_received_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/renewal_received_forms/new.html.erb
@@ -40,7 +40,7 @@
 
       <p><%= link_to(t(".survey_link_text"), t("layouts.application.feedback_url")) %> <%= t(".survey_link_hint") %></p>
 
-      <%= link_to t(".next_button"), dashboard_link(current_user), class: 'button' %>
+      <%= link_to t(".next_button"), renewal_finished_link(reg_identifier: @renewal_received_form.reg_identifier), class: 'button' %>
     <% end %>
 
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,7 +1,6 @@
 ---
 en:
   waste_carriers_engine:
-    dashboard_link: "%{root}/user/%{id}/registrations"
     errors:
       messages:
         weak_password: Your password is not strong enough. It must include at least one lowercase letter, uppercase letter and number

--- a/spec/helpers/waste_carriers_engine/application_helper_spec.rb
+++ b/spec/helpers/waste_carriers_engine/application_helper_spec.rb
@@ -49,18 +49,6 @@ module WasteCarriersEngine
       end
     end
 
-    describe "dashboard_link" do
-      before do
-        allow(Rails.configuration).to receive(:wcrs_frontend_url).and_return("http://www.example.com")
-      end
-
-      it "returns the correct value" do
-        user = build(:user)
-        expected_url = "http://www.example.com/user/#{user.id}/registrations"
-        expect(helper.dashboard_link(user)).to eq(expected_url)
-      end
-    end
-
     describe "displayable_address" do
       let(:address) do
         build(:address,

--- a/spec/helpers/waste_carriers_engine/journey_links_helper_spec.rb
+++ b/spec/helpers/waste_carriers_engine/journey_links_helper_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe WasteCarriersEngine::JourneyLinksHelper, type: :helper do
+    describe "renewal_finished_link" do
+      it "returns the correct value" do
+        expect(helper.renewal_finished_link).to eq("/")
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-859

We spotted that the 'Finished' button on the 'Renewal complete' and 'Renewal received' buttons was not behaving properly. For front office users, we now want to redirect straight to the front office dashboard; for back office users, we want to redirect to the new 'view details' page in the back office.

So we'll just provide a new default method in the engine and let the host apps override it as needed.