### PR TITLE
Add charge adjust order item type and method

### DIFF
--- a/app/models/waste_carriers_engine/order_item.rb
+++ b/app/models/waste_carriers_engine/order_item.rb
@@ -15,7 +15,7 @@ module WasteCarriersEngine
 
     field :amount,                          type: Integer
     field :quantity,                        type: Integer
-    field :currency,                        type: String,   default: "GBP"
+    field :currency,                        type: String, default: "GBP"
     field :lastUpdated, as: :last_updated,  type: DateTime
     field :description,                     type: String
     field :reference,                       type: String

--- a/app/models/waste_carriers_engine/order_item.rb
+++ b/app/models/waste_carriers_engine/order_item.rb
@@ -9,12 +9,13 @@ module WasteCarriersEngine
     TYPES = HashWithIndifferentAccess.new(
       renew: "RENEW",
       edit: "EDIT",
-      copy_cards: "COPY_CARDS"
+      copy_cards: "COPY_CARDS",
+      charge_adjust: "CHARGE_ADJUST"
     )
 
     field :amount,                          type: Integer
     field :quantity,                        type: Integer
-    field :currency,                        type: String
+    field :currency,                        type: String,   default: "GBP"
     field :lastUpdated, as: :last_updated,  type: DateTime
     field :description,                     type: String
     field :reference,                       type: String
@@ -29,6 +30,10 @@ module WasteCarriersEngine
       order_item.quantity = 1
 
       order_item
+    end
+
+    def self.new_charge_adjust_item
+      new(type: TYPES[:charge_adjust])
     end
 
     def self.new_type_change_item

--- a/spec/models/waste_carriers_engine/order_item_spec.rb
+++ b/spec/models/waste_carriers_engine/order_item_spec.rb
@@ -12,6 +12,14 @@ module WasteCarriersEngine
 
     let(:transient_registration) { build(:renewing_registration, :has_required_data) }
 
+    describle ".new_charge_adjust_item"
+      it "returns an instance of itself of type :charge_adjust" do
+        result = described.new_charge_adjust_item
+
+        expect(result.type).to eq("CHARGE_ADJUST")
+      end
+    end
+
     describe "new_renewal_item" do
       let(:order_item) { described_class.new_renewal_item }
 

--- a/spec/models/waste_carriers_engine/order_item_spec.rb
+++ b/spec/models/waste_carriers_engine/order_item_spec.rb
@@ -12,7 +12,7 @@ module WasteCarriersEngine
 
     let(:transient_registration) { build(:renewing_registration, :has_required_data) }
 
-    describle ".new_charge_adjust_item"
+    describe ".new_charge_adjust_item" do
       it "returns an instance of itself of type :charge_adjust" do
         result = described.new_charge_adjust_item
 

--- a/spec/models/waste_carriers_engine/order_item_spec.rb
+++ b/spec/models/waste_carriers_engine/order_item_spec.rb
@@ -14,7 +14,7 @@ module WasteCarriersEngine
 
     describe ".new_charge_adjust_item" do
       it "returns an instance of itself of type :charge_adjust" do
-        result = described.new_charge_adjust_item
+        result = described_class.new_charge_adjust_item
 
         expect(result.type).to eq("CHARGE_ADJUST")
       end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-870

This adds a new order item type of CHARGE_ADJUST.