### PR TITLE
Set up EditRegistration model

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_copy_data_from_registration.rb
+++ b/app/models/concerns/waste_carriers_engine/can_copy_data_from_registration.rb
@@ -5,21 +5,19 @@ module WasteCarriersEngine
     extend ActiveSupport::Concern
 
     included do
-      after_initialize :copy_data_from_registration, if: :new_record?
+      after_initialize :copy_data_from_registration, if: -> { new_record? && valid? }
     end
 
     def copy_data_from_registration
-      # Don't try to get Registration data with an invalid reg_identifier
-      return unless valid? && new_record?
-
-      # Don't copy object IDs as Mongo should generate new unique ones
-      attributes = registration.attributes.except(*options[:ignorable_attributes])
-
-      assign_attributes(strip_whitespace(attributes))
-
+      copy_attributes_from_registration
       copy_addresses_from_registration if options[:copy_addresses]
       copy_people_from_registration if options[:copy_people]
       remove_invalid_attributes if options[:remove_invalid_attributes]
+    end
+
+    def copy_attributes_from_registration
+      attributes = registration.attributes.except(*options[:ignorable_attributes])
+      assign_attributes(strip_whitespace(attributes))
     end
 
     def copy_addresses_from_registration

--- a/app/models/concerns/waste_carriers_engine/can_copy_data_from_registration.rb
+++ b/app/models/concerns/waste_carriers_engine/can_copy_data_from_registration.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  module CanCopyDataFromRegistration
+    extend ActiveSupport::Concern
+
+    included do
+      after_initialize :copy_data_from_registration, if: :new_record?
+    end
+
+    private
+
+    def copy_data_from_registration
+      # Don't try to get Registration data with an invalid reg_identifier
+      return unless valid? && new_record?
+
+      # Don't copy object IDs as Mongo should generate new unique ones
+      attributes = registration.attributes.except("_id",
+                                                  "addresses",
+                                                  "key_people",
+                                                  "financeDetails",
+                                                  "conviction_search_result",
+                                                  "conviction_sign_offs",
+                                                  "declaration",
+                                                  "past_registrations",
+                                                  "copy_cards")
+
+      assign_attributes(strip_whitespace(attributes))
+
+      copy_addresses_from_registration
+      copy_people_from_registration
+    end
+
+    def copy_addresses_from_registration
+      registration.addresses.each do |address|
+        addresses << Address.new(address.attributes.except("_id"))
+      end
+    end
+
+    def copy_people_from_registration
+      registration.key_people.each do |key_person|
+        key_people << KeyPerson.new(key_person.attributes.except("_id", "conviction_search_result"))
+      end
+    end
+  end
+end

--- a/app/models/concerns/waste_carriers_engine/can_use_edit_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_edit_registration_workflow.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  module CanUseEditRegistrationWorkflow
+    extend ActiveSupport::Concern
+    include Mongoid::Document
+
+    included do
+      include AASM
+
+      field :workflow_state, type: String
+
+      aasm column: :workflow_state do
+        # States / forms
+        state :edit_form, initial: true
+      end
+    end
+  end
+end

--- a/app/models/waste_carriers_engine/edit_registration.rb
+++ b/app/models/waste_carriers_engine/edit_registration.rb
@@ -7,6 +7,20 @@ module WasteCarriersEngine
 
     validates :reg_identifier, "waste_carriers_engine/reg_identifier": true
 
+    COPY_DATA_OPTIONS = {
+      ignorable_attributes: %w[_id
+                               addresses
+                               key_people
+                               financeDetails
+                               conviction_search_result
+                               conviction_sign_offs
+                               declaration
+                               past_registrations
+                               copy_cards],
+      copy_addresses: true,
+      copy_people: true
+    }.freeze
+
     def registration
       @_registration ||= Registration.find_by(reg_identifier: reg_identifier)
     end

--- a/app/models/waste_carriers_engine/edit_registration.rb
+++ b/app/models/waste_carriers_engine/edit_registration.rb
@@ -2,6 +2,8 @@
 
 module WasteCarriersEngine
   class EditRegistration < TransientRegistration
+    include CanUseEditRegistrationWorkflow
+
     validates :reg_identifier, "waste_carriers_engine/reg_identifier": true
   end
 end

--- a/app/models/waste_carriers_engine/edit_registration.rb
+++ b/app/models/waste_carriers_engine/edit_registration.rb
@@ -2,8 +2,13 @@
 
 module WasteCarriersEngine
   class EditRegistration < TransientRegistration
+    include CanCopyDataFromRegistration
     include CanUseEditRegistrationWorkflow
 
     validates :reg_identifier, "waste_carriers_engine/reg_identifier": true
+
+    def registration
+      @_registration ||= Registration.find_by(reg_identifier: reg_identifier)
+    end
   end
 end

--- a/app/models/waste_carriers_engine/edit_registration.rb
+++ b/app/models/waste_carriers_engine/edit_registration.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class EditRegistration < TransientRegistration
+    validates :reg_identifier, "waste_carriers_engine/reg_identifier": true
+  end
+end

--- a/spec/factories/edit_registration.rb
+++ b/spec/factories/edit_registration.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :edit_registration, class: WasteCarriersEngine::EditRegistration do
+    initialize_with { new(reg_identifier: create(:registration, :has_required_data, :is_active).reg_identifier) }
+  end
+end

--- a/spec/models/waste_carriers_engine/edit_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/edit_registration_spec.rb
@@ -6,9 +6,17 @@ module WasteCarriersEngine
   RSpec.describe EditRegistration, type: :model do
     subject(:edit_registration) { build(:edit_registration) }
 
+    context "default status" do
+      context "when an EditRegistration is created" do
+        it "has the state of :edit_form" do
+          expect(edit_registration).to have_state(:edit_form)
+        end
+      end
+    end
+
     context "Validations" do
       describe "reg_identifier" do
-        context "when a EditRegistration is created" do
+        context "when an EditRegistration is created" do
           it "is not valid if the reg_identifier is in the wrong format" do
             edit_registration.reg_identifier = "foo"
             expect(edit_registration).to_not be_valid

--- a/spec/models/waste_carriers_engine/edit_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/edit_registration_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe EditRegistration, type: :model do
+    subject(:edit_registration) { build(:edit_registration) }
+
+    context "Validations" do
+      describe "reg_identifier" do
+        context "when a EditRegistration is created" do
+          it "is not valid if the reg_identifier is in the wrong format" do
+            edit_registration.reg_identifier = "foo"
+            expect(edit_registration).to_not be_valid
+          end
+
+          it "is not valid if no matching registration exists" do
+            edit_registration.reg_identifier = "CBDU999999"
+            expect(edit_registration).to_not be_valid
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/edit_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/edit_registration_spec.rb
@@ -29,5 +29,43 @@ module WasteCarriersEngine
         end
       end
     end
+
+    describe "#initialize" do
+      context "when it is initialized with a registration" do
+        let(:registration) { create(:registration, :has_required_data) }
+        let(:edit_registration) { described_class.new(reg_identifier: registration.reg_identifier) }
+
+        copyable_properties = Registration.attribute_names - %w[_id
+                                                                addresses
+                                                                key_people
+                                                                financeDetails
+                                                                conviction_search_result
+                                                                conviction_sign_offs
+                                                                declaration
+                                                                past_registrations
+                                                                copy_cards]
+
+        copyable_properties.each do |property|
+          it "copies #{property} from the registration" do
+            expect(edit_registration[property]).to eq(registration[property])
+          end
+        end
+
+        it "copies the addresses from the registration" do
+          registration.addresses.each_with_index do |address, index|
+            copyable_attributes = address.attributes.except("_id")
+            expect(edit_registration.addresses[index].attributes).to include(copyable_attributes)
+          end
+        end
+
+        it "copies the key_people from the registration" do
+          registration.key_people.each_with_index do |person, index|
+            copyable_attributes = person.attributes.except("_id",
+                                                           "conviction_search_result")
+            expect(edit_registration.key_people[index].attributes).to include(copyable_attributes)
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-827

This PR sets up a new EditRegistration model to be used for editing. This will be a new type of TransientRegistration.

An EditRegistration should copy data from an existing Registration when it is created. It will also have its own workflow state machine.

This also includes some refactoring to reduce duplication between EditRegistration and RenewingRegistration.