### PR TITLE
Create a new EditRegistration

### DIFF
--- a/app/controllers/waste_carriers_engine/edit_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/edit_forms_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class EditFormsController < FormsController
+    def new
+      super(EditForm, "edit_form")
+    end
+
+    # Override this method as user shouldn't be able to "submit" this page
+    def create; end
+
+    private
+
+    # rubocop:disable Naming/MemoizedInstanceVariableName
+    def find_or_initialize_transient_registration(token)
+      @transient_registration ||= EditRegistration.where(reg_identifier: token).first ||
+                                  EditRegistration.where(token: token).first ||
+                                  EditRegistration.new(reg_identifier: token)
+    end
+    # rubocop:enable Naming/MemoizedInstanceVariableName
+  end
+end

--- a/app/forms/waste_carriers_engine/edit_form.rb
+++ b/app/forms/waste_carriers_engine/edit_form.rb
@@ -2,8 +2,6 @@
 
 module WasteCarriersEngine
   class EditForm < BaseForm
-    delegate :reg_identifier, to: :transient_registration
-
     after_initialize :persist_registration
 
     private

--- a/app/forms/waste_carriers_engine/edit_form.rb
+++ b/app/forms/waste_carriers_engine/edit_form.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class EditForm < BaseForm
+    delegate :reg_identifier, to: :transient_registration
+
+    after_initialize :persist_registration
+
+    private
+
+    def persist_registration
+      transient_registration.save! unless transient_registration.persisted?
+    end
+  end
+end

--- a/app/services/waste_carriers_engine/edit_registration_permission_checks_service.rb
+++ b/app/services/waste_carriers_engine/edit_registration_permission_checks_service.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class EditRegistrationPermissionChecksService < BaseRegistrationPermissionChecksService
+
+    private
+
+    def all_checks_pass?
+      transient_registration_is_valid? && user_has_permission? && registation_is_active?
+    end
+
+    def user_has_permission?
+      return true if can?(:edit, registration)
+
+      permission_check_result.needs_permissions!
+
+      false
+    end
+
+    def registation_is_active?
+      return true if registration.active?
+
+      permission_check_result.invalid!
+
+      false
+    end
+  end
+end

--- a/app/services/waste_carriers_engine/flow_permission_checks_service.rb
+++ b/app/services/waste_carriers_engine/flow_permission_checks_service.rb
@@ -24,6 +24,8 @@ module WasteCarriersEngine
       case transient_registration
       when RenewingRegistration
         RenewingRegistrationPermissionChecksService.run(params)
+      when EditRegistration
+        EditRegistrationPermissionChecksService.run(params)
       when OrderCopyCardsRegistration
         OrderCopyCardsRegistrationPermissionChecksService.run(params)
       when CeasedOrRevokedRegistration

--- a/app/views/waste_carriers_engine/edit_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/edit_forms/new.html.erb
@@ -1,3 +1,6 @@
 <div class="text">
   <h1 class="heading-large"><%= t(".heading", reg_identifier: @edit_form.reg_identifier) %></h1>
+  <pre>
+    <%= JSON.pretty_generate(@edit_form.transient_registration.attributes) %>
+  </pre>
 </div>

--- a/app/views/waste_carriers_engine/edit_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/edit_forms/new.html.erb
@@ -1,0 +1,3 @@
+<div class="text">
+  <h1 class="heading-large"><%= t(".heading", reg_identifier: @edit_form.reg_identifier) %></h1>
+</div>

--- a/config/locales/forms/edit_forms/en.yml
+++ b/config/locales/forms/edit_forms/en.yml
@@ -1,0 +1,6 @@
+en:
+  waste_carriers_engine:
+    edit_forms:
+      new:
+        title: Edit a registration
+        heading: Edit %{reg_identifier}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,13 @@ WasteCarriersEngine::Engine.routes.draw do
               end
     # End of ceased or revoked flow
 
+    # Edit flow
+    resources :edit_forms,
+              only: %i[new create],
+              path: "edit",
+              path_names: { new: "" }
+    # End of edit flow
+
     resources :renewal_start_forms,
               only: %i[new create],
               path: "renew",

--- a/spec/dummy/app/models/ability.rb
+++ b/spec/dummy/app/models/ability.rb
@@ -6,6 +6,7 @@ class Ability
   def initialize(user)
     can :read, WasteCarriersEngine::Registration, account_email: user.email
     can :manage, WasteCarriersEngine::RenewingRegistration, account_email: user.email
+    can :edit, WasteCarriersEngine::Registration
     can :order_copy_cards, WasteCarriersEngine::Registration
     can :cease, WasteCarriersEngine::Registration
     can :revoke, WasteCarriersEngine::Registration

--- a/spec/requests/waste_carriers_engine/edit_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/edit_forms_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "EditForms", type: :request do
+    describe "GET new_edit_form_path" do
+      context "when a user is signed in" do
+        let(:user) { create(:user) }
+
+        before(:each) do
+          sign_in(user)
+        end
+
+        context "when no matching registration exists" do
+          it "redirects to the invalid token error page" do
+            get new_edit_form_path("CBDU999999999")
+
+            expect(response).to redirect_to(page_path("invalid"))
+          end
+        end
+
+        context "when the token doesn't match the format" do
+          it "redirects to the invalid token error page" do
+            get new_edit_form_path("foo")
+
+            expect(response).to redirect_to(page_path("invalid"))
+          end
+        end
+
+        context "when a matching registration exists" do
+          context "when the given registration is not active" do
+            let(:registration) { create(:registration, :has_required_data, :is_pending) }
+
+            it "redirects to the invalid error page" do
+              get new_edit_form_path(registration.reg_identifier)
+
+              expect(response).to redirect_to(page_path("invalid"))
+            end
+          end
+
+          context "when the given registration is active" do
+            let(:registration) { create(:registration, :has_required_data, :is_active) }
+
+            it "responds to the GET request with a 200 status code and renders the appropriate template" do
+              get new_edit_form_path(registration.reg_identifier)
+
+              expect(response).to render_template("waste_carriers_engine/edit_forms/new")
+              expect(response.code).to eq("200")
+            end
+          end
+        end
+      end
+
+      context "when a user is not signed in" do
+        before(:each) do
+          user = create(:user)
+          sign_out(user)
+        end
+
+        it "returns a 302 response and redirects to the sign in page" do
+          get new_edit_form_path("foo")
+
+          expect(response).to have_http_status(302)
+          expect(response).to redirect_to(new_user_session_path)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/waste_carriers_engine/edit_registration_permission_checks_service_spec.rb
+++ b/spec/services/waste_carriers_engine/edit_registration_permission_checks_service_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe EditRegistrationPermissionChecksService do
+    let(:transient_registration) { double(:transient_registration) }
+    let(:user) { double(:user) }
+    let(:result) { double(:result) }
+    let(:params) { { transient_registration: transient_registration, user: user } }
+
+    describe ".run" do
+      before do
+        expect(transient_registration).to receive(:valid?).and_return(valid)
+        expect(PermissionChecksResult).to receive(:new).and_return(result)
+      end
+
+      context "when the transient registration is not valid" do
+        let(:valid) { false }
+
+        it "returns an invalid result" do
+          expect(result).to receive(:invalid!)
+
+          expect(described_class.run(params)).to eq(result)
+        end
+      end
+
+      context "when the transient registration is valid" do
+        let(:valid) { true }
+        let(:registration) { double(:registration) }
+        let(:ability) { double(:ability) }
+
+        before do
+          allow(transient_registration).to receive(:registration).and_return(registration)
+
+          expect(Ability).to receive(:new).with(user).and_return(ability)
+          expect(ability).to receive(:can?).with(:edit, registration).and_return(can)
+        end
+
+        context "when the user does not have the correct permissions" do
+          let(:can) { false }
+
+          it "returns a missing permissions result" do
+            expect(result).to receive(:needs_permissions!)
+
+            expect(described_class.run(params)).to eq(result)
+          end
+        end
+
+        context "when the user has the correct permissions" do
+          let(:can) { true }
+          let(:registration) { double(:registration) }
+
+          before do
+            allow(transient_registration).to receive(:registration).and_return(registration)
+
+            expect(registration).to receive(:active?).and_return(active)
+          end
+
+          context "when the registration is not active" do
+            let(:active) { false }
+
+            it "returns an invalid result" do
+              expect(result).to receive(:invalid!)
+
+              expect(described_class.run(params)).to eq(result)
+            end
+          end
+
+          context "when the registration is active" do
+            let(:active) { true }
+
+            it "returns a pass result" do
+              expect(result).to receive(:pass!)
+
+              expect(described_class.run(params)).to eq(result)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/waste_carriers_engine/flow_permission_checks_service_spec.rb
+++ b/spec/services/waste_carriers_engine/flow_permission_checks_service_spec.rb
@@ -19,6 +19,16 @@ module WasteCarriersEngine
         end
       end
 
+      context "when the transient object is an edit registration" do
+        let(:transient_registration) { EditRegistration.new }
+
+        it "runs the correct permission check service and return a result" do
+          expect(EditRegistrationPermissionChecksService).to receive(:run).with(params).and_return(result)
+
+          expect(described_class.run(params)).to eq(result)
+        end
+      end
+
       context "when the transient object is an order copy cards registration" do
         let(:transient_registration) { OrderCopyCardsRegistration.new }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-827

When a user hits a certain route, it should start an edit and create a new EditRegistration.

This should include a permissions check, as we only want back office agency users to be able to access this.