### PR TITLE
Add edit completion workflow

### DIFF
--- a/app/controllers/waste_carriers_engine/edit_complete_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/edit_complete_forms_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class EditCompleteFormsController < FormsController
+    def new
+      super(EditCompleteForm, "edit_complete_form")
+    end
+
+    # Overwrite create and go_back as you shouldn't be able to submit or go back
+    def create; end
+
+    def go_back; end
+  end
+end

--- a/app/controllers/waste_carriers_engine/edit_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/edit_forms_controller.rb
@@ -6,8 +6,9 @@ module WasteCarriersEngine
       super(EditForm, "edit_form")
     end
 
-    # Override this method as user shouldn't be able to "submit" this page
-    def create; end
+    def create
+      super(EditForm, "edit_form")
+    end
 
     private
 

--- a/app/forms/waste_carriers_engine/edit_complete_form.rb
+++ b/app/forms/waste_carriers_engine/edit_complete_form.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class EditCompleteForm < BaseForm
+    include CannotSubmit
+
+    def self.can_navigate_flexibly?
+      false
+    end
+  end
+end

--- a/app/models/concerns/waste_carriers_engine/can_use_edit_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_edit_registration_workflow.rb
@@ -13,6 +13,23 @@ module WasteCarriersEngine
       aasm column: :workflow_state do
         # States / forms
         state :edit_form, initial: true
+
+        state :declaration_form
+        state :edit_complete_form
+
+        # Transitions
+        event :next do
+          transitions from: :edit_form,
+                      to: :declaration_form
+
+          transitions from: :declaration_form,
+                      to: :edit_complete_form
+        end
+
+        event :back do
+          transitions from: :declaration_form,
+                      to: :edit_form
+        end
       end
     end
   end

--- a/app/views/waste_carriers_engine/edit_complete_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/edit_complete_forms/new.html.erb
@@ -1,0 +1,3 @@
+<div class="column-two-thirds">
+  <h1 class="heading-large"><%= t(".heading") %></h1>
+</div>

--- a/app/views/waste_carriers_engine/edit_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/edit_forms/new.html.erb
@@ -1,6 +1,17 @@
 <div class="text">
-  <h1 class="heading-large"><%= t(".heading", reg_identifier: @edit_form.reg_identifier) %></h1>
-  <pre>
-    <%= JSON.pretty_generate(@edit_form.transient_registration.attributes) %>
-  </pre>
+  <%= form_for(@edit_form) do |f| %>
+    <%= render("waste_carriers_engine/shared/errors", object: @edit_form) %>
+
+    <h1 class="heading-large"><%= t(".heading", reg_identifier: @edit_form.reg_identifier) %></h1>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+
+    <hr>
+
+    <pre>
+      <%= JSON.pretty_generate(@edit_form.transient_registration.attributes) %>
+    </pre>
+  <% end %>
 </div>

--- a/config/locales/forms/edit_complete_forms/en.yml
+++ b/config/locales/forms/edit_complete_forms/en.yml
@@ -1,0 +1,6 @@
+en:
+  waste_carriers_engine:
+    edit_complete_forms:
+      new:
+        title: Edit complete
+        heading: Edit complete

--- a/config/locales/forms/edit_forms/en.yml
+++ b/config/locales/forms/edit_forms/en.yml
@@ -4,3 +4,4 @@ en:
       new:
         title: Edit a registration
         heading: Edit %{reg_identifier}
+        next_button: Continue

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,11 @@ WasteCarriersEngine::Engine.routes.draw do
               only: %i[new create],
               path: "edit",
               path_names: { new: "" }
+
+    resources :edit_complete_forms,
+              only: %i[new create],
+              path: "edit-complete",
+              path_names: { new: "" }
     # End of edit flow
 
     resources :renewal_start_forms,

--- a/spec/forms/waste_carriers_engine/edit_complete_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/edit_complete_forms_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe EditCompleteForm, type: :model do
+  end
+end

--- a/spec/models/waste_carriers_engine/edit_registration_workflow/declaration_form_spec.rb
+++ b/spec/models/waste_carriers_engine/edit_registration_workflow/declaration_form_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe EditRegistration do
+    subject(:edit_registration) { build(:edit_registration) }
+
+    describe "#workflow_state" do
+      context ":declaration_form state transitions" do
+        context "on next" do
+          it "can transition from a :declaration_form state to a :edit_complete_form" do
+            edit_registration.workflow_state = :declaration_form
+
+            edit_registration.next
+
+            expect(edit_registration.workflow_state).to eq("edit_complete_form")
+          end
+        end
+
+        context "on back" do
+          it "can transition from a :declaration_form state to a :edit_form" do
+            edit_registration.workflow_state = :declaration_form
+
+            edit_registration.back
+
+            expect(edit_registration.workflow_state).to eq("edit_form")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/edit_registration_workflow/edit_complete_form_spec.rb
+++ b/spec/models/waste_carriers_engine/edit_registration_workflow/edit_complete_form_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe EditRegistration, type: :model do
+    subject(:edit_registration) { build(:edit_registration) }
+
+    describe "#workflow_state" do
+      context ":edit_complete_form state transitions" do
+        it "does not respond to the 'back' event" do
+          edit_registration.workflow_state = :edit_complete_form
+
+          expect(edit_registration).to_not allow_event(:back)
+        end
+
+        it "does not respond to the 'next' event" do
+          edit_registration.workflow_state = :edit_complete_form
+
+          expect(edit_registration).to_not allow_event(:next)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/edit_registration_workflow/edit_form_spec.rb
+++ b/spec/models/waste_carriers_engine/edit_registration_workflow/edit_form_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe EditRegistration do
+    subject(:edit_registration) { build(:edit_registration) }
+
+    describe "#workflow_state" do
+      context ":edit_form state transitions" do
+        context "on next" do
+          it "can transition from a :edit_form state to a :declaration_form" do
+            edit_registration.workflow_state = :edit_form
+
+            edit_registration.next
+
+            expect(edit_registration.workflow_state).to eq("declaration_form")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/waste_carriers_engine/edit_complete_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/edit_complete_forms_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "EditCompleteForms", type: :request do
+    describe "GET new_edit_complete_form_path" do
+      context "when a valid user is signed in" do
+        let(:user) { create(:user) }
+        before(:each) do
+          sign_in(user)
+        end
+
+        context "when no edit registration exists" do
+          it "redirects to the invalid page" do
+            get new_edit_complete_form_path("wibblewobblejellyonaplate")
+            expect(response).to redirect_to(page_path("invalid"))
+          end
+        end
+
+        context "when a valid edit registration exists" do
+          let(:transient_registration) do
+            create(:edit_registration,
+                   workflow_state: "edit_complete_form")
+          end
+
+          context "when the workflow_state is correct" do
+            it "loads the page" do
+              get new_edit_complete_form_path(transient_registration.token)
+              expect(response).to have_http_status(200)
+            end
+          end
+
+          context "when the workflow_state is not correct" do
+            before do
+              transient_registration.update_attributes(workflow_state: "declaration_form")
+            end
+
+            it "redirects to the correct page" do
+              get new_edit_complete_form_path(transient_registration.token)
+              expect(response).to redirect_to(new_declaration_form_path(transient_registration.token))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/waste_carriers_engine/edit_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/edit_forms_spec.rb
@@ -66,5 +66,86 @@ module WasteCarriersEngine
         end
       end
     end
+
+    describe "POST edit_forms_path" do
+      context "when a user is signed in" do
+        let(:user) { create(:user) }
+
+        before(:each) do
+          sign_in(user)
+        end
+
+        context "when no matching registration exists" do
+          it "redirects to the invalid token error page and does not create a new transient registration" do
+            original_tr_count = EditRegistration.count
+
+            post edit_forms_path("CBDU99999")
+
+            expect(response).to redirect_to(page_path("invalid"))
+            expect(EditRegistration.count).to eq(original_tr_count)
+          end
+        end
+
+        context "when the token doesn't match the format" do
+          it "redirects to the invalid token error page and does not create a new transient registration" do
+            original_tr_count = EditRegistration.count
+
+            post edit_forms_path("foo")
+
+            expect(EditRegistration.count).to eq(original_tr_count)
+            expect(response).to redirect_to(page_path("invalid"))
+          end
+        end
+
+        context "when a matching registration exists" do
+          let(:registration) { create(:registration, :has_required_data, :is_active) }
+
+          it "creates a transient registration with correct data, returns a 302 response and redirects to the declaration" do
+            expected_tr_count = EditRegistration.count + 1
+
+            post edit_forms_path(registration.reg_identifier)
+
+            transient_registration = EditRegistration.find_by(reg_identifier: registration.reg_identifier)
+
+            expect(expected_tr_count).to eq(EditRegistration.count)
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_declaration_form_path(transient_registration.token))
+          end
+        end
+
+        context "when a matching registration exists" do
+          let!(:edit_registration) { create(:edit_registration) }
+
+          it "does not create a new transient registration, returns a 302 response and redirects to the declaration" do
+            expected_tr_count = EditRegistration.count
+
+            post edit_forms_path(edit_registration.reg_identifier)
+
+            expect(expected_tr_count).to eq(EditRegistration.count)
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_declaration_form_path(edit_registration.token))
+          end
+        end
+      end
+
+      context "when a user is not signed in" do
+        let(:registration) { create(:registration, :has_required_data) }
+
+        before(:each) do
+          user = create(:user)
+          sign_out(user)
+        end
+
+        it "returns a 302 response, redirects to the login page and does not create a new transient registration" do
+          original_tr_count = EditRegistration.count
+
+          post edit_forms_path(registration.reg_identifier)
+
+          expect(response).to redirect_to(new_user_session_path)
+          expect(response).to have_http_status(302)
+          expect(EditRegistration.count).to eq(original_tr_count)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-830

This PR covers adding the workflow for completing an edit, so going from the main edit page through declaration to the 'edit complete' page.

This doesn't cover actually completing the edit (that's RUBY-831) or any payments (RUBY-833).