### PR TITLE
Fix view certificate for lower tier registrations

### DIFF
--- a/app/presenters/waste_carriers_engine/certificate_presenter.rb
+++ b/app/presenters/waste_carriers_engine/certificate_presenter.rb
@@ -45,7 +45,9 @@ module WasteCarriersEngine
     end
 
     def tier_and_registration_type
-      I18n.t("#{LOCALES_KEY}.registered_as",
+      return I18n.t("#{LOCALES_KEY}.registered_as.lower") if lower_tier?
+
+      I18n.t("#{LOCALES_KEY}.registered_as.upper.",
              registration_type: I18n.t("#{LOCALES_KEY}.#{registrationType}"))
     end
 

--- a/app/views/waste_carriers_engine/pdfs/certificate.html.erb
+++ b/app/views/waste_carriers_engine/pdfs/certificate.html.erb
@@ -123,10 +123,12 @@
                   <td class="table-column-text"><%=t ".registration_date" %></td>
                   <td><%= @presenter.metaData.date_activated.in_time_zone("London").to_date %></td>
                 </tr>
-                <tr>
-                  <td class="table-column-text"><%=t ".expiry_date" %></td>
-                  <td><%= @presenter.expires_on.in_time_zone("London").to_date %></td>
-                </tr>
+                <% if @presenter.upper_tier? %>
+                  <tr>
+                    <td class="table-column-text"><%=t ".expiry_date" %></td>
+                    <td><%= @presenter.expires_on.in_time_zone("London").to_date %></td>
+                  </tr>
+                <% end %>
               </tbody>
             </table>
 

--- a/config/locales/pdfs/certificate.en.yml
+++ b/config/locales/pdfs/certificate.en.yml
@@ -27,7 +27,9 @@ en:
         upper_renewal_html: "Your registration will last %{expires_after_pluralized} and will need to be renewed after this period. If any of your details change, you must notify us within 28 days of the change."
         year: "year"
         update_phone: "You can do this by calling the Environment Agency."
-        registered_as: "An upper tier waste %{registration_type}"
+        registered_as:
+          lower: "A lower tier waste carrier, broker and dealer"
+          upper: "An upper tier waste %{registration_type}"
         carrier_dealer: "carrier and dealer"
         broker_dealer: "broker and dealer"
         carrier_broker_dealer: "carrier, broker and dealer"

--- a/spec/presenters/waste_carriers_engine/certificate_presenter_spec.rb
+++ b/spec/presenters/waste_carriers_engine/certificate_presenter_spec.rb
@@ -90,20 +90,32 @@ module WasteCarriersEngine
     end
 
     describe "#tier_and_registration_type" do
-      let(:registration) { create(:registration, :has_required_data) }
+      context "when the registration is upper tier" do
+        let(:registration) { create(:registration, :has_required_data) }
 
-      test_values = {
-        carrier_dealer: "An upper tier waste carrier and dealer",
-        broker_dealer: "An upper tier waste broker and dealer",
-        carrier_broker_dealer: "An upper tier waste carrier, broker and dealer"
-      }
-      test_values.each do |carrier_type, expected|
-        context "when the registration is a '#{carrier_type}'" do
-          it "returns '#{expected}'" do
-            registration.registration_type = carrier_type
-            presenter = CertificatePresenter.new(registration, view)
-            expect(presenter.tier_and_registration_type).to eq(expected)
+        test_values = {
+          carrier_dealer: "An upper tier waste carrier and dealer",
+          broker_dealer: "An upper tier waste broker and dealer",
+          carrier_broker_dealer: "An upper tier waste carrier, broker and dealer"
+        }
+        test_values.each do |carrier_type, expected|
+          context "and is a '#{carrier_type}'" do
+            it "returns '#{expected}'" do
+              registration.registration_type = carrier_type
+              presenter = CertificatePresenter.new(registration, view)
+              expect(presenter.tier_and_registration_type).to eq(expected)
+            end
           end
+        end
+      end
+
+      context "when the registration is lower tier" do
+        let(:registration) { create(:registration, :has_required_data, tier: "LOWER") }
+        expected_value = "A lower tier waste carrier, broker and dealer"
+
+        it "returns '#{expected_value}'" do
+          presenter = CertificatePresenter.new(registration, view)
+          expect(presenter.tier_and_registration_type).to eq(expected_value)
         end
       end
     end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-834

We have recently worked on adding the ability to see the certificate we generate when a registration is complete from the back office. However in QA it was found that an error occurs when you try and use the link for a lower tier registration.

Upon investigation we found this error in the logs

```bash
I, [2020-02-12T14:26:56.768579 #27414]  INFO -- :   Rendered /srv/ruby/waste-carriers-back-office/shared/bundle/ruby/2.4.0/bundler/gems/waste-carriers-engine-e39f56f6bac0/app/views/waste_carriers_engine/pdfs/certificate.html.erb (3.8ms)
I, [2020-02-12T14:26:56.769213 #27414]  INFO -- : Completed 500 Internal Server Error in 11ms
F, [2020-02-12T14:26:56.776346 #27414] FATAL -- :
ActionView::Template::Error (undefined method `in_time_zone' for nil:NilClass):
    125:                 </tr>
    126:                 <tr>
    127:                   <td class="table-column-text"><%=t ".expiry_date" %></td>
    128:                   <td><%= @presenter.expires_on.in_time_zone("London").to_date %></td>
    129:                 </tr>
    130:               </tbody>
    131:             </table>
  app/controllers/certificates_controller.rb:10:in `show'
```

It looks like the current code is always assuming an expiry date will be present which is not the case for lower tier registrations (they never expire). So this change will focus on updating the certificate view not to expect that property.

<details>
<summary>Working example</summary>

<img width="576" alt="Screenshot 2020-02-12 at 16 13 20" src="https://user-images.githubusercontent.com/1789650/74353990-9b1b5a80-4db2-11ea-97b3-3a6a369a0110.png">
  
</details>