### PR TITLE
Fix missing text values on edit page

### DIFF
--- a/app/presenters/waste_carriers_engine/edit_form_presenter.rb
+++ b/app/presenters/waste_carriers_engine/edit_form_presenter.rb
@@ -74,8 +74,12 @@ module WasteCarriersEngine
     private
 
     def format_main_person(person)
-      role = I18n.t("#{LOCALES_KEY}.main_people.#{transient_registration.business_type}")
-      "#{person_name(person)} (#{role})"
+      role = I18n.t("#{LOCALES_KEY}.main_people.#{transient_registration.business_type}", default: "")
+      if role.present?
+        "#{person_name(person)} (#{role})"
+      else
+        person_name(person)
+      end
     end
 
     def person_name(person)

--- a/config/locales/forms/edit_forms/en.yml
+++ b/config/locales/forms/edit_forms/en.yml
@@ -55,6 +55,9 @@ en:
             limitedLiabilityPartnership: Limited liability partnership
             localAuthority: Local authority or public body
             charity: Charity or trust
+            overseas: Overseas
+            publicBody: Public body
+            authority: Local or regulatory authority
           main_people:
             localAuthority: chief executive
             limitedCompany: director
@@ -68,7 +71,7 @@ en:
             scotland: Scotland
             northern_ireland: Northern Ireland
             overseas: Not in the United Kingdom
-            not_set: "n/a"
+            not_set: "-"
           registration_type:
             carrier_dealer: Carrier and dealer
             broker_dealer: Broker and dealer

--- a/spec/requests/waste_carriers_engine/edit_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/edit_forms_spec.rb
@@ -48,6 +48,17 @@ module WasteCarriersEngine
               expect(response).to render_template("waste_carriers_engine/edit_forms/new")
               expect(response.code).to eq("200")
             end
+
+            context "when the registration business type is an old frontend one" do
+              let(:registration) { create(:registration, :has_required_data, :is_active, business_type: "publicBody") }
+
+              it "responds to the GET request with a 200 status code and renders the appropriate template" do
+                get new_edit_form_path(registration.reg_identifier)
+
+                expect(response).to render_template("waste_carriers_engine/edit_forms/new")
+                expect(response.code).to eq("200")
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-829

I tested this out with some alternate business types and ran into problems. Some of these are down to dodgy data (charities shouldn't really have main people, for example) but we also needed to take into account some of the business types that are still generated by the frontend. Basically, we want to fail a little more gracefully!

Also swapped a `n/a` for `-` when a location is not provided, to be consistent with the registration details page.