### PR TITLE
Don't send confirmation email for fully AD copy card orders

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -111,6 +111,10 @@ module WasteCarriersEngine
         tier == "LOWER"
       end
 
+      def ad_contact_email?
+        contact_email.blank? || contact_email == WasteCarriersEngine.configuration.assisted_digital_email
+      end
+
       # Some business types should not have a company_no
       def company_no_required?
         return false if overseas?

--- a/app/models/concerns/waste_carriers_engine/can_use_order_copy_cards_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_order_copy_cards_workflow.rb
@@ -33,11 +33,9 @@ module WasteCarriersEngine
                       to: :copy_cards_bank_transfer_form,
                       unless: :paying_by_card?
 
-          # TODO: after: :complete_order
           transitions from: :copy_cards_bank_transfer_form,
                       to: :copy_cards_order_completed_form
 
-          # TODO: after: :complete_order
           transitions from: :worldpay_form,
                       to: :copy_cards_order_completed_form
         end
@@ -60,13 +58,6 @@ module WasteCarriersEngine
 
     def paying_by_card?
       temp_payment_method == "card"
-    end
-
-    def _complete_order
-      # TODO
-      # copy data to registration
-      # update reegistration status (can be pending / awaiting payment) maybe not needed
-      # delete transient object
     end
   end
 end

--- a/app/services/waste_carriers_engine/order_copy_cards_completion_service.rb
+++ b/app/services/waste_carriers_engine/order_copy_cards_completion_service.rb
@@ -21,7 +21,7 @@ module WasteCarriersEngine
 
       delete_transient_registration
 
-      send_confirmation_email if valid_user_email_address?
+      send_confirmation_email unless @transient_registration.ad_contact_email?
     end
 
     def update_registration
@@ -46,14 +46,6 @@ module WasteCarriersEngine
 
     def copy_cards_order
       @_copy_cards_order ||= transient_registration.finance_details.orders.last
-    end
-
-    def valid_user_email_address?
-      email = @transient_registration.contact_email
-      return false if email.blank?
-      return false if email == WasteCarriersEngine.configuration.assisted_digital_email
-
-      true
     end
   end
 end

--- a/app/services/waste_carriers_engine/order_copy_cards_completion_service.rb
+++ b/app/services/waste_carriers_engine/order_copy_cards_completion_service.rb
@@ -21,7 +21,7 @@ module WasteCarriersEngine
 
       delete_transient_registration
 
-      send_confirmation_email
+      send_confirmation_email if valid_user_email_address?
     end
 
     def update_registration
@@ -46,6 +46,14 @@ module WasteCarriersEngine
 
     def copy_cards_order
       @_copy_cards_order ||= transient_registration.finance_details.orders.last
+    end
+
+    def valid_user_email_address?
+      email = @transient_registration.contact_email
+      return false if email.blank?
+      return false if email == WasteCarriersEngine.configuration.assisted_digital_email
+
+      true
     end
   end
 end

--- a/app/views/waste_carriers_engine/copy_cards_order_completed_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/copy_cards_order_completed_forms/new.html.erb
@@ -1,9 +1,9 @@
 <h1 class="heading-large"><%= t(".heading") %></h1>
 
 <% if @transient_registration.temp_payment_method == "card" %>
-  <%= render("shared/success", message: t(".payment_success_message_html", email: @transient_registration.contact_email)) %>
+  <%= render("shared/success", message: t(".payment_success_message.#{@transient_registration.ad_contact_email?}_html", email: @transient_registration.contact_email)) %>
 <% else %>
-  <%= render("shared/message", message: t(".awaiting_payment_message_html", email: @transient_registration.contact_email)) %>
+  <%= render("shared/message", message: t(".awaiting_payment_message.#{@transient_registration.ad_contact_email?}_html", email: @transient_registration.contact_email)) %>
 <% end %>
 
 <div class="text">

--- a/config/locales/forms/copy_cards_order_completed_forms/en.yml
+++ b/config/locales/forms/copy_cards_order_completed_forms/en.yml
@@ -4,8 +4,12 @@ en:
       new:
         title: "Confirm order of registration cards"
         heading: "Confirmation of order"
-        awaiting_payment_message_html: "Order is awaiting payment.<br>We've sent an email with payment details to %{email}."
-        payment_success_message_html: "Order completed.<br>Payment has cleared.<br>We have sent a confirmation email to %{email}."
+        awaiting_payment_message:
+          "true_html": "Order is awaiting payment."
+          "false_html": "Order is awaiting payment.<br>We've sent an email with payment details to %{email}."
+        payment_success_message:
+          "true_html": "Order completed.<br>Payment has cleared."
+          "false_html": "Order completed.<br>Payment has cleared.<br>We have sent a confirmation email to %{email}."
         details_table:
           cards_label: "Number of cards ordered"
           total_cost: "Total cost"

--- a/lib/waste_carriers_engine.rb
+++ b/lib/waste_carriers_engine.rb
@@ -23,6 +23,8 @@ module WasteCarriersEngine
   end
 
   class Configuration
+    # AD config
+    attr_accessor :assisted_digital_email
     # Companies house API config
     attr_reader :companies_house_host, :companies_house_api_key
 

--- a/spec/dummy/config/initializers/waste_carriers_engine.rb
+++ b/spec/dummy/config/initializers/waste_carriers_engine.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 WasteCarriersEngine.configure do |config|
+  # Assisted digital config
+  config.assisted_digital_email = ENV["WCRS_ASSISTED_DIGITAL_EMAIL"]
+
   # Companies House API config
   config.companies_house_host = ENV["WCRS_COMPANIES_HOUSE_URL"] || "https://api.companieshouse.gov.uk/company/"
   config.companies_house_api_key = ENV["WCRS_COMPANIES_HOUSE_API_KEY"]

--- a/spec/services/waste_carriers_engine/order_copy_cards_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/order_copy_cards_completion_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 module WasteCarriersEngine
   RSpec.describe OrderCopyCardsCompletionService do
     describe ".run" do
-      let(:contact_email) { "foo@example.com" }
+      let(:ad_contact_email) { false }
       let(:finance_details) { double(:finance_details) }
       let(:transient_finance_details) { double(:transient_finance_details) }
       let(:registration) { double(:registration, finance_details: finance_details) }
@@ -14,7 +14,7 @@ module WasteCarriersEngine
           :transient_registration,
           registration: registration,
           finance_details: transient_finance_details,
-          contact_email: contact_email
+          ad_contact_email?: ad_contact_email
         )
       end
 
@@ -92,47 +92,8 @@ module WasteCarriersEngine
         described_class.run(transient_registration)
       end
 
-      context "when the contact email is blank" do
-        let(:contact_email) { nil }
-
-        it "does not send an email" do
-          orders = double(:orders)
-          payments = double(:payments)
-          transient_order = double(:transient_order)
-          transient_payment = double(:transient_payment)
-
-          # Merge finance details
-          allow(registration).to receive(:finance_details).and_return(finance_details)
-          allow(transient_registration).to receive(:finance_details).and_return(transient_finance_details)
-          expect(finance_details).to receive(:update_balance)
-
-          ## Merge orders
-          allow(finance_details).to receive(:orders).and_return(orders)
-          allow(transient_finance_details).to receive(:orders).and_return([transient_order])
-          expect(orders).to receive(:<<).with(transient_order)
-
-          ## Merge payments
-          expect(finance_details).to receive(:payments).and_return(payments).twice
-          expect(transient_finance_details).to receive(:payments).and_return([transient_payment]).twice
-          expect(payments).to receive(:<<).with(transient_payment)
-
-          # Deletes transient registration
-          expect(transient_registration).to receive(:delete)
-
-          # Save registration
-          expect(registration).to receive(:save!)
-
-          # Don't send email
-          expect(OrderCopyCardsMailer).to_not receive(:send_order_completed_email)
-
-          described_class.run(transient_registration)
-        end
-      end
-
-      context "when the contact email is the AD default" do
-        before do
-          allow(WasteCarriersEngine.configuration).to receive(:assisted_digital_email).and_return(contact_email)
-        end
+      context "when the registration has an AD contact email" do
+        let(:ad_contact_email) { true }
 
         it "does not send an email" do
           orders = double(:orders)

--- a/spec/support/shared_examples/can_have_registration_attributes.rb
+++ b/spec/support/shared_examples/can_have_registration_attributes.rb
@@ -106,6 +106,40 @@ RSpec.shared_examples "Can have registration attributes" do |factory:|
     end
   end
 
+  describe "#ad_contact_email?" do
+    context "when the contact email is nil" do
+      before do
+        resource.contact_email = nil
+      end
+
+      it "returns true" do
+        expect(resource.ad_contact_email?).to eq(true)
+      end
+    end
+
+    context "when the contact email is the NCCC default" do
+      before do
+        email = "nccc@example.com"
+        allow(WasteCarriersEngine.configuration).to receive(:assisted_digital_email).and_return(email)
+        resource.contact_email = email
+      end
+
+      it "returns true" do
+        expect(resource.ad_contact_email?).to eq(true)
+      end
+    end
+
+    context "when the contact email is an external email" do
+      before do
+        resource.contact_email = "foo@example.com"
+      end
+
+      it "returns false" do
+        expect(resource.ad_contact_email?).to eq(false)
+      end
+    end
+  end
+
   describe "#company_no_required?" do
     test_values = {
       limitedCompany: true,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-896

When additional copy cards are ordered, if there is no contact email or it's the default NCCC inbox, we should not send any sort of confirmation email.