### PR TITLE
Fix renewal text issue on certificate

### DIFF
--- a/app/presenters/waste_carriers_engine/certificate_presenter.rb
+++ b/app/presenters/waste_carriers_engine/certificate_presenter.rb
@@ -51,13 +51,6 @@ module WasteCarriersEngine
              registration_type: I18n.t("#{LOCALES_KEY}.#{registrationType}"))
     end
 
-    def expires_after_pluralized
-      ActionController::Base.helpers.pluralize(
-        Rails.configuration.expires_after,
-        I18n.t("#{LOCALES_KEY}.year")
-      )
-    end
-
     def list_main_people
       list = key_people
              .select { |person| person.person_type == "KEY" }
@@ -65,8 +58,25 @@ module WasteCarriersEngine
       list.join("<br>").html_safe
     end
 
+    def renewal_message
+      if lower_tier?
+        I18n.t("#{LOCALES_KEY}.lower_renewal")
+      else
+        I18n.t("#{LOCALES_KEY}.upper_renewal", expires_after_pluralized: expires_after_pluralized)
+      end
+    end
+
     def assisted_digital?
       metaData.route == "ASSISTED_DIGITAL"
+    end
+
+    private
+
+    def expires_after_pluralized
+      ActionController::Base.helpers.pluralize(
+        Rails.configuration.expires_after,
+        I18n.t("#{LOCALES_KEY}.year")
+      )
     end
   end
 end

--- a/app/views/waste_carriers_engine/pdfs/certificate.html.erb
+++ b/app/views/waste_carriers_engine/pdfs/certificate.html.erb
@@ -136,7 +136,7 @@
 
             <!-- Renewal details section -->
             <div class="renewal">
-              <p class="certificate_text"><%= t ".upper_renewal_html", expires_after_pluralized: @presenter.expires_after_pluralized %></p>
+              <p class="certificate_text"><%= @presenter.renewal_message %></p>
               <% if @presenter.assisted_digital? %>
                 <p class="certificate_text"><%= t ".update_phone" %></p>
               <% end %>

--- a/config/locales/pdfs/certificate.en.yml
+++ b/config/locales/pdfs/certificate.en.yml
@@ -24,7 +24,8 @@ en:
         registration_date: "Date of registration"
         expiry_date: "Expiry date of registration (unless revoked)"
         heading2: "Making changes to your registration"
-        upper_renewal_html: "Your registration will last %{expires_after_pluralized} and will need to be renewed after this period. If any of your details change, you must notify us within 28 days of the change."
+        lower_renewal: "Your registration will last indefinitely so does not need to be renewed but you must update your registration details if they change, within 28 days of the change."
+        upper_renewal: "Your registration will last %{expires_after_pluralized} and will need to be renewed after this period. If any of your details change, you must notify us within 28 days of the change."
         year: "year"
         update_phone: "You can do this by calling the Environment Agency."
         registered_as:

--- a/spec/presenters/waste_carriers_engine/certificate_presenter_spec.rb
+++ b/spec/presenters/waste_carriers_engine/certificate_presenter_spec.rb
@@ -120,32 +120,6 @@ module WasteCarriersEngine
       end
     end
 
-    describe "#expires_after_pluralized" do
-      let(:registration) { create(:registration, :has_required_data) }
-
-      context "when the config is set to 1 year" do
-        before do
-          allow(Rails.configuration).to receive(:expires_after).and_return(1)
-        end
-
-        it "returns '1 year'" do
-          presenter = CertificatePresenter.new(registration, view)
-          expect(presenter.expires_after_pluralized).to eq("1 year")
-        end
-      end
-
-      context "when the config is set to 3 years" do
-        before do
-          allow(Rails.configuration).to receive(:expires_after).and_return(3)
-        end
-
-        it "returns '3 years'" do
-          presenter = CertificatePresenter.new(registration, view)
-          expect(presenter.expires_after_pluralized).to eq("3 years")
-        end
-      end
-    end
-
     describe "#list_main_people" do
       let(:registration) { create(:registration, :has_required_data, :has_mulitiple_key_people) }
 
@@ -170,6 +144,45 @@ module WasteCarriersEngine
         it "returns 'false'" do
           presenter = CertificatePresenter.new(registration, view)
           expect(presenter.assisted_digital?).to be false
+        end
+      end
+    end
+
+    describe "#renewal_message" do
+      let(:registration) { create(:registration, :has_required_data) }
+
+      context "when the registration is lower tier" do
+        before { registration.tier = "LOWER" }
+
+        it "returns the correct message" do
+          presenter = CertificatePresenter.new(registration, view)
+          expect(presenter.renewal_message).to eq("Your registration will last indefinitely so does not need to be renewed but you must update your registration details if they change, within 28 days of the change.")
+        end
+      end
+
+      context "when the registration is upper tier" do
+        before { registration.tier = "UPPER" }
+
+        context "when the config is set to 1 year" do
+          before do
+            allow(Rails.configuration).to receive(:expires_after).and_return(1)
+          end
+
+          it "returns '1 year'" do
+            presenter = CertificatePresenter.new(registration, view)
+            expect(presenter.renewal_message).to eq("Your registration will last 1 year and will need to be renewed after this period. If any of your details change, you must notify us within 28 days of the change.")
+          end
+        end
+
+        context "when the config is set to 3 years" do
+          before do
+            allow(Rails.configuration).to receive(:expires_after).and_return(3)
+          end
+
+          it "returns '3 years'" do
+            presenter = CertificatePresenter.new(registration, view)
+            expect(presenter.renewal_message).to eq("Your registration will last 3 years and will need to be renewed after this period. If any of your details change, you must notify us within 28 days of the change.")
+          end
         end
       end
     end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-834

Lower tier registrations should not display a message about needing to renew.