### PR TITLE
Add defra-ruby-email to project

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       aasm (~> 4.12)
       countries
       defra_ruby_alert (~> 1.0.0)
+      defra_ruby_email
       defra_ruby_validators
       high_voltage (~> 3.0)
       jbuilder (~> 2.0)
@@ -83,6 +84,8 @@ GEM
     debug_inspector (0.0.3)
     defra_ruby_alert (1.0.0)
       airbrake (~> 5.8.1)
+    defra_ruby_email (0.2.0)
+      rails (~> 4.2.11.1)
     defra_ruby_style (0.1.4)
       rubocop (~> 0.79)
     defra_ruby_validators (2.3.1)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -531,6 +531,8 @@ WasteCarriersEngine::Engine.routes.draw do
               end
   end
 
+  mount DefraRubyEmail::Engine => "/email"
+
   # See http://patrickperey.com/railscast-053-handling-exceptions/
   get "(errors)/:status",
       to: "errors#show",

--- a/lib/waste_carriers_engine.rb
+++ b/lib/waste_carriers_engine.rb
@@ -76,6 +76,13 @@ module WasteCarriersEngine
       end
     end
 
+    # Last Email caching and retrieval functionality
+    def use_last_email_cache=(value)
+      DefraRubyEmail.configure do |configuration|
+        configuration.enable = change_string_to_boolean_for(value)
+      end
+    end
+
     private
 
     # If the setting's value is "true", then set to a boolean true. Otherwise,

--- a/lib/waste_carriers_engine/engine.rb
+++ b/lib/waste_carriers_engine/engine.rb
@@ -4,6 +4,7 @@ require "aasm"
 require "mongoid"
 require "high_voltage"
 require "defra_ruby/alert"
+require "defra_ruby_email"
 require "defra_ruby_validators"
 
 module WasteCarriersEngine

--- a/waste_carriers_engine.gemspec
+++ b/waste_carriers_engine.gemspec
@@ -45,6 +45,10 @@ Gem::Specification.new do |s|
   # defra_ruby_alert is a gem we created to manage airbrake across projects
   s.add_dependency "defra_ruby_alert", "~> 1.0.0"
 
+  # Used as part of testing. When enabled adds a /last-email route from which
+  # details of the last email sent by the app can be accessed
+  s.add_dependency "defra_ruby_email"
+
   # Used to build and parse XML requests
   s.add_dependency "nokogiri"
 


### PR DESCRIPTION
Currently the [Waste Exemptions service](https://github.com/DEFRA/waste-exemptions-engine/pull/112) and the [Waste Carriers Frontend](https://github.com/DEFRA/waste-carriers-frontend/pull/227) have the ability to intercept and play back the details of the last email sent.

This feature is only enabled in our non-production environments and is used as part of our acceptance tests. However our QA @andrewhick has rightly pointed out that the functionality is inconsistent across our services.

Waste Exemptions has it throughout, Waste Carriers only has it in the old app, and Flood Risk Activity Exemptions doesn't have it at all. This makes writing and maintaining acceptance tests across the 3 services difficult and inconsistent so we have been asked to resolve the issue.

Rather than duplicate the existing code even more, we have created [defra-ruby-email](https://github.com/DEFRA/defra-ruby-email) a reusable engine that can be mounted into an application to provide the same functionality.

Having created the gem, this change covers adding it to the Waste Carriers front and back office apps so they too can benefit from the feature.