### PR TITLE
Always use source reg's account_email during edit

### DIFF
--- a/app/models/waste_carriers_engine/edit_registration.rb
+++ b/app/models/waste_carriers_engine/edit_registration.rb
@@ -9,6 +9,7 @@ module WasteCarriersEngine
 
     COPY_DATA_OPTIONS = {
       ignorable_attributes: %w[_id
+                               account_email
                                addresses
                                key_people
                                financeDetails

--- a/app/presenters/waste_carriers_engine/edit_form_presenter.rb
+++ b/app/presenters/waste_carriers_engine/edit_form_presenter.rb
@@ -5,7 +5,7 @@ module WasteCarriersEngine
     LOCALES_KEY = ".waste_carriers_engine.edit_forms.new.values"
 
     def account_email
-      transient_registration.account_email
+      transient_registration.registration.account_email
     end
 
     def business_type

--- a/spec/models/waste_carriers_engine/edit_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/edit_registration_spec.rb
@@ -36,6 +36,7 @@ module WasteCarriersEngine
         let(:edit_registration) { described_class.new(reg_identifier: registration.reg_identifier) }
 
         copyable_properties = Registration.attribute_names - %w[_id
+                                                                account_email
                                                                 addresses
                                                                 key_people
                                                                 financeDetails


### PR DESCRIPTION
We don't want to edit the account_email as part of the edit. The only way to do this should be to transfer the registration.

However, if the registration is transferred while there's an in-progress edit, we want to display the new email. And we also don't want to accidentally switch it back to the old email when the edit is completed.

To support this, this change:

- stops us from copying an account_email to the EditRegistration when it is created
- displays the base Registration's account_email on the edit form so it's always accurate