### PR TITLE
Display time edit was started and last modified

### DIFF
--- a/app/presenters/waste_carriers_engine/edit_form_presenter.rb
+++ b/app/presenters/waste_carriers_engine/edit_form_presenter.rb
@@ -4,6 +4,22 @@ module WasteCarriersEngine
   class EditFormPresenter < BasePresenter
     LOCALES_KEY = ".waste_carriers_engine.edit_forms.new.values"
 
+    def created_at
+      formatted_datetime = transient_registration.created_at.to_formatted_s(:time_on_day_month_year)
+
+      I18n.t(".waste_carriers_engine.edit_forms.new.edit_meta.created_at", created_at: formatted_datetime)
+    end
+
+    def updated_at
+      formatted_datetime = transient_registration.metaData.last_modified.to_formatted_s(:time_on_day_month_year)
+
+      I18n.t(".waste_carriers_engine.edit_forms.new.edit_meta.updated_at", updated_at: formatted_datetime)
+    end
+
+    def display_updated_at?
+      transient_registration.created_at < transient_registration.metaData.last_modified
+    end
+
     def account_email
       transient_registration.account_email
     end
@@ -30,12 +46,6 @@ module WasteCarriersEngine
 
     def contact_email
       transient_registration.contact_email
-    end
-
-    def created_at
-      formatted_datetime = transient_registration.created_at.to_formatted_s(:time_on_day_month_year)
-
-      I18n.t(".waste_carriers_engine.edit_forms.new.edit_meta.created_at", created_at: formatted_datetime)
     end
 
     def location

--- a/app/views/waste_carriers_engine/edit_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/edit_forms/new.html.erb
@@ -10,6 +10,11 @@
       <p>
         <%= @presenter.created_at %>
       </p>
+      <% if @presenter.display_updated_at? %>
+        <p>
+          <%= @presenter.updated_at %>
+        </p>
+      <% end %>
       <p>
         <span class="strong">
           <%= t(".edit_meta.warning") %>

--- a/config/locales/forms/edit_forms/en.yml
+++ b/config/locales/forms/edit_forms/en.yml
@@ -5,7 +5,8 @@ en:
         title: Edit a registration
         heading: Edit %{reg_identifier} registration
         edit_meta:
-          created_at: "Edit started %{created_at}."
+          created_at: "This edit was started at %{created_at}."
+          updated_at: "It was last updated at %{updated_at}. There may be unsaved changes."
           warning: You need to confirm these changes if you want to keep them.
         sections:
           registration_and_account:


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-829

This matches the behaviour we have in WEX. We've updated the wireframe to use this as well.

Actions are always present as the edit object is persisted as soon as it is started (like WEX) so we always want to be able to cancel out.