### PR TITLE
Complete an edit

### DIFF
--- a/app/controllers/waste_carriers_engine/edit_complete_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/edit_complete_forms_controller.rb
@@ -3,7 +3,9 @@
 module WasteCarriersEngine
   class EditCompleteFormsController < FormsController
     def new
-      super(EditCompleteForm, "edit_complete_form")
+      return unless super(EditCompleteForm, "edit_complete_form")
+
+      EditCompletionService.run(edit_registration: @transient_registration)
     end
 
     # Overwrite create and go_back as you shouldn't be able to submit or go back

--- a/app/services/waste_carriers_engine/edit_completion_service.rb
+++ b/app/services/waste_carriers_engine/edit_completion_service.rb
@@ -5,6 +5,14 @@ module WasteCarriersEngine
     def run(edit_registration:)
       @edit_registration = edit_registration
       @registration = @edit_registration.registration
+
+      delete_transient_registration
+    end
+
+    private
+
+    def delete_transient_registration
+      @edit_registration.delete
     end
   end
 end

--- a/app/services/waste_carriers_engine/edit_completion_service.rb
+++ b/app/services/waste_carriers_engine/edit_completion_service.rb
@@ -4,6 +4,7 @@ module WasteCarriersEngine
   class EditCompletionService < BaseService
     def run(edit_registration:)
       @edit_registration = edit_registration
+      @registration = @edit_registration.registration
     end
   end
 end

--- a/app/services/waste_carriers_engine/edit_completion_service.rb
+++ b/app/services/waste_carriers_engine/edit_completion_service.rb
@@ -6,13 +6,37 @@ module WasteCarriersEngine
       @edit_registration = edit_registration
       @registration = @edit_registration.registration
 
+      copy_data_to_registration
       delete_transient_registration
     end
 
     private
 
+    def copy_data_to_registration
+      copy_attributes
+      @registration.save!
+    end
+
     def delete_transient_registration
       @edit_registration.delete
+    end
+
+    def copy_attributes
+      copyable_attributes = @edit_registration.attributes.except("_id",
+                                                                 "token",
+                                                                 "account_email",
+                                                                 "created_at",
+                                                                 "financeDetails",
+                                                                 "temp_cards",
+                                                                 "temp_company_postcode",
+                                                                 "temp_contact_postcode",
+                                                                 "temp_os_places_error",
+                                                                 "temp_payment_method",
+                                                                 "temp_tier_check",
+                                                                 "_type",
+                                                                 "workflow_state")
+
+      @registration.write_attributes(copyable_attributes)
     end
   end
 end

--- a/app/services/waste_carriers_engine/edit_completion_service.rb
+++ b/app/services/waste_carriers_engine/edit_completion_service.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class EditCompletionService < BaseService
+    def run(edit_registration:)
+      @edit_registration = edit_registration
+    end
+  end
+end

--- a/app/views/waste_carriers_engine/edit_complete_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/edit_complete_forms/new.html.erb
@@ -1,3 +1,5 @@
 <div class="column-two-thirds">
   <h1 class="heading-large"><%= t(".heading") %></h1>
+  <p><%= t(".paragraph_1") %></p>
+  <p><%= link_to t(".next_button"), Rails.application.routes.url_helpers.registration_path(@transient_registration.reg_identifier), class: "button" %></p>
 </div>

--- a/config/locales/forms/edit_complete_forms/en.yml
+++ b/config/locales/forms/edit_complete_forms/en.yml
@@ -4,3 +4,5 @@ en:
       new:
         title: Edit complete
         heading: Edit complete
+        paragraph_1: Your changes have been saved and the registration has been updated.
+        next_button: View registration

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -17,6 +17,7 @@ FactoryBot.define do
       metaData { build(:metaData, :has_required_data) }
 
       has_addresses
+      has_paid_finance_details
 
       key_people do
         [build(:key_person, :has_required_data, :main),
@@ -26,6 +27,10 @@ FactoryBot.define do
 
     trait :has_addresses do
       addresses { [build(:address, :has_required_data, :registered, :from_os_places), build(:address, :has_required_data, :contact, :from_os_places)] }
+    end
+
+    trait :has_paid_finance_details do
+      finance_details { build(:finance_details, :has_paid_order_and_payment) }
     end
 
     trait :has_copy_cards_order do

--- a/spec/requests/waste_carriers_engine/copy_cards_order_completed_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/copy_cards_order_completed_forms_spec.rb
@@ -36,12 +36,12 @@ module WasteCarriersEngine
               get new_copy_cards_order_completed_form_path(transient_registration.token)
 
               finance_details = registration.reload.finance_details
-              order = finance_details.orders.first
+              order = finance_details.orders.last
               order_item = order.order_items.first
 
               expect(WasteCarriersEngine::TransientRegistration.count).to eq(0)
 
-              expect(finance_details.orders.count).to eq(1)
+              expect(finance_details.orders.count).to eq(2)
               expect(finance_details.balance).to eq(500)
               expect(order.order_items.count).to eq(1)
               expect(order_item.type).to eq("COPY_CARDS")

--- a/spec/requests/waste_carriers_engine/edit_complete_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/edit_complete_forms_spec.rb
@@ -19,16 +19,45 @@ module WasteCarriersEngine
         end
 
         context "when a valid edit registration exists" do
+          let(:updated_email) { "updated@example.com" }
+          let(:updated_registered_address) { build(:address, :registered, postcode: "UP1 2DT") }
+          let(:updated_contact_address) { build(:address, :contact, postcode: "D1 1FF") }
+          let(:updated_person) { build(:key_person, :main, first_name: "Updated") }
+
           let(:transient_registration) do
             create(:edit_registration,
+                   contact_email: updated_email,
+                   addresses: [updated_registered_address, updated_contact_address],
+                   key_people: [updated_person],
                    workflow_state: "edit_complete_form")
           end
+          let(:registration) { transient_registration.registration }
 
           context "when the workflow_state is correct" do
-            it "deletes the transient object" do
-              get new_edit_complete_form_path(transient_registration.token)
+            it "updates the registration with the new data and deletes the transient object" do
+              old_finance_details = registration.finance_details
 
+              get new_edit_complete_form_path(transient_registration.token)
+              registration.reload
+
+              # Update base attributes
+              expect(registration.contact_email).to eq(updated_email)
+
+              # Update key people
+              expect(registration.main_people.count).to eq(1)
+              expect(registration.main_people.first.first_name).to eq(updated_person.first_name)
+
+              # Update addresses
+              expect(registration.addresses.count).to eq(2)
+              expect(registration.registered_address.postcode).to eq(updated_registered_address.postcode)
+              expect(registration.contact_address.postcode).to eq(updated_contact_address.postcode)
+
+              # But don't modify finance details
+              expect(registration.finance_details).to eq(old_finance_details)
+
+              # Delete the transient registration
               expect(WasteCarriersEngine::TransientRegistration.count).to eq(0)
+
               expect(response).to have_http_status(200)
             end
           end
@@ -38,8 +67,19 @@ module WasteCarriersEngine
               transient_registration.update_attributes(workflow_state: "declaration_form")
             end
 
-            it "redirects to the correct page" do
+            it "redirects to the correct page, does not update the registration and does not delete the transient object" do
               get new_edit_complete_form_path(transient_registration.token)
+              registration.reload
+
+              expect(registration.contact_email).to_not eq(updated_email)
+
+              expect(registration.main_people.first.first_name).to_not eq(updated_person.first_name)
+
+              expect(registration.registered_address.postcode).to_not eq(updated_registered_address.postcode)
+              expect(registration.contact_address.postcode).to_not eq(updated_contact_address.postcode)
+
+              expect(WasteCarriersEngine::TransientRegistration.count).to eq(1)
+
               expect(response).to redirect_to(new_declaration_form_path(transient_registration.token))
             end
           end

--- a/spec/requests/waste_carriers_engine/edit_complete_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/edit_complete_forms_spec.rb
@@ -37,6 +37,7 @@ module WasteCarriersEngine
             it "updates the registration with the new data and deletes the transient object" do
               old_account_email = registration.account_email
               old_finance_details = registration.finance_details
+              old_relevant_people = registration.relevant_people
 
               get new_edit_complete_form_path(transient_registration.token)
               registration.reload
@@ -56,6 +57,7 @@ module WasteCarriersEngine
               # But don't modify finance details or other non-editable attributes
               expect(registration.account_email).to eq(old_account_email)
               expect(registration.finance_details).to eq(old_finance_details)
+              expect(registration.relevant_people).to eq(old_relevant_people)
 
               # Delete the transient registration
               expect(WasteCarriersEngine::TransientRegistration.count).to eq(0)

--- a/spec/requests/waste_carriers_engine/edit_complete_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/edit_complete_forms_spec.rb
@@ -25,8 +25,10 @@ module WasteCarriersEngine
           end
 
           context "when the workflow_state is correct" do
-            it "loads the page" do
+            it "deletes the transient object" do
               get new_edit_complete_form_path(transient_registration.token)
+
+              expect(WasteCarriersEngine::TransientRegistration.count).to eq(0)
               expect(response).to have_http_status(200)
             end
           end

--- a/spec/requests/waste_carriers_engine/edit_complete_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/edit_complete_forms_spec.rb
@@ -35,6 +35,7 @@ module WasteCarriersEngine
 
           context "when the workflow_state is correct" do
             it "updates the registration with the new data and deletes the transient object" do
+              old_account_email = registration.account_email
               old_finance_details = registration.finance_details
 
               get new_edit_complete_form_path(transient_registration.token)
@@ -52,7 +53,8 @@ module WasteCarriersEngine
               expect(registration.registered_address.postcode).to eq(updated_registered_address.postcode)
               expect(registration.contact_address.postcode).to eq(updated_contact_address.postcode)
 
-              # But don't modify finance details
+              # But don't modify finance details or other non-editable attributes
+              expect(registration.account_email).to eq(old_account_email)
               expect(registration.finance_details).to eq(old_finance_details)
 
               # Delete the transient registration

--- a/spec/services/waste_carriers_engine/edit_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/edit_completion_service_spec.rb
@@ -9,12 +9,14 @@ module WasteCarriersEngine
       double(:edit_registration,
              registration: registration)
     end
-    let(:service) { described_class.run(edit_registration: edit_registration) }
 
     describe ".run" do
       context "when given an edit_registration" do
-        it "returns the registration" do
-          expect(service).to eq(registration)
+        it "deletes the edit_registration" do
+          # Deletes transient registration
+          expect(edit_registration).to receive(:delete)
+
+          described_class.run(edit_registration: edit_registration)
         end
       end
     end

--- a/spec/services/waste_carriers_engine/edit_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/edit_completion_service_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe EditCompletionService do
+    let(:edit_registration) { double(:edit_registration) }
+    let(:service) { described_class.run(edit_registration: edit_registration) }
+
+    describe ".run" do
+      context "when given an edit_registration" do
+        it "returns the edit_registration" do
+          expect(service).to eq(edit_registration)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/waste_carriers_engine/edit_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/edit_completion_service_spec.rb
@@ -4,13 +4,17 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe EditCompletionService do
-    let(:edit_registration) { double(:edit_registration) }
+    let(:registration) { double(:edit_registration) }
+    let(:edit_registration) do
+      double(:edit_registration,
+             registration: registration)
+    end
     let(:service) { described_class.run(edit_registration: edit_registration) }
 
     describe ".run" do
       context "when given an edit_registration" do
-        it "returns the edit_registration" do
-          expect(service).to eq(edit_registration)
+        it "returns the registration" do
+          expect(service).to eq(registration)
         end
       end
     end

--- a/spec/services/waste_carriers_engine/edit_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/edit_completion_service_spec.rb
@@ -4,15 +4,47 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe EditCompletionService do
+    let(:copyable_attributes) do
+      {
+        # Don't include all attributes - we just need to have some examples
+        "addresses" => {},
+        "contact_email" => nil,
+        "keyPeople" => {}
+      }
+    end
+    let(:uncopyable_attributes) do
+      {
+        "_id" => nil,
+        "token" => nil,
+        "account_email" => nil,
+        "created_at" => nil,
+        "financeDetails" => nil,
+        "temp_cards" => nil,
+        "temp_company_postcode" => nil,
+        "temp_contact_postcode" => nil,
+        "temp_os_places_error" => nil,
+        "temp_payment_method" => nil,
+        "temp_tier_check" => nil,
+        "_type" => nil,
+        "workflow_state" => nil
+      }
+    end
+    let(:attributes) do
+      copyable_attributes.merge(uncopyable_attributes)
+    end
     let(:registration) { double(:edit_registration) }
     let(:edit_registration) do
       double(:edit_registration,
+             attributes: attributes,
              registration: registration)
     end
 
     describe ".run" do
       context "when given an edit_registration" do
         it "deletes the edit_registration" do
+          # Updates the registration
+          expect(registration).to receive(:write_attributes).with(copyable_attributes)
+          expect(registration).to receive(:save!)
           # Deletes transient registration
           expect(edit_registration).to receive(:delete)
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-831

Completing an edit should update the registration with the new data and delete the old EditRegistration record.

This PR covers setting up the 'edit complete' page and making sure the edit actually completes as specified.