### PR TITLE
Fix methods checking whether a reg is overseas

### DIFF
--- a/app/forms/concerns/waste_carriers_engine/can_validate_manual_address.rb
+++ b/app/forms/concerns/waste_carriers_engine/can_validate_manual_address.rb
@@ -5,14 +5,14 @@ module WasteCarriersEngine
     extend ActiveSupport::Concern
 
     included do
-      delegate :business_is_overseas?, to: :transient_registration
+      delegate :overseas?, to: :transient_registration
 
       validates :house_number, presence: true, length: { maximum: 200 }
       validates :address_line_1, presence: true, length: { maximum: 160 }
       validates :address_line_2, length: { maximum: 70 }
       validates :town_city, presence: true, length: { maximum: 30 }
       validates :postcode, length: { maximum: 30 }
-      validates :country, presence: true, if: :business_is_overseas?
+      validates :country, presence: true, if: :overseas?
       validates :country, length: { maximum: 50 }
     end
   end

--- a/app/forms/waste_carriers_engine/company_address_manual_form.rb
+++ b/app/forms/waste_carriers_engine/company_address_manual_form.rb
@@ -5,7 +5,7 @@ module WasteCarriersEngine
     include CanClearAddressFinderError
     include CanValidateManualAddress
 
-    delegate :business_is_overseas?, :company_address, :business_type, to: :transient_registration
+    delegate :overseas?, :company_address, :business_type, to: :transient_registration
     delegate :house_number, :address_line_1, :address_line_2, to: :company_address, allow_nil: true
     delegate :postcode, :town_city, :country, to: :company_address, allow_nil: true
 
@@ -30,7 +30,7 @@ module WasteCarriersEngine
     def saved_address_still_valid?
       temp_postcode = transient_registration.temp_company_postcode
 
-      business_is_overseas? || temp_postcode.nil? || temp_postcode == postcode
+      overseas? || temp_postcode.nil? || temp_postcode == postcode
     end
   end
 end

--- a/app/forms/waste_carriers_engine/contact_address_manual_form.rb
+++ b/app/forms/waste_carriers_engine/contact_address_manual_form.rb
@@ -5,7 +5,7 @@ module WasteCarriersEngine
     include CanClearAddressFinderError
     include CanValidateManualAddress
 
-    delegate :business_is_overseas?, :contact_address, to: :transient_registration
+    delegate :overseas?, :contact_address, to: :transient_registration
     delegate :house_number, :address_line_1, :postcode, to: :contact_address, allow_nil: true
     delegate :address_line_2, :town_city, :country, to: :contact_address, allow_nil: true
 
@@ -30,7 +30,7 @@ module WasteCarriersEngine
     def saved_address_still_valid?
       temp_postcode = transient_registration.temp_contact_postcode
 
-      business_is_overseas? || temp_postcode.nil? || temp_postcode == postcode
+      overseas? || temp_postcode.nil? || temp_postcode == postcode
     end
   end
 end

--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -99,11 +99,6 @@ module WasteCarriersEngine
         location == "overseas" || business_type == "overseas"
       end
 
-      # Concerns don't support alias_method, so this is here until we can deprecate it!
-      def business_is_overseas?
-        overseas?
-      end
-
       def upper_tier?
         tier == "UPPER"
       end

--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -96,11 +96,12 @@ module WasteCarriersEngine
       end
 
       def overseas?
-        location == "overseas"
+        location == "overseas" || business_type == "overseas"
       end
 
+      # Concerns don't support alias_method, so this is here until we can deprecate it!
       def business_is_overseas?
-        business_type == "overseas"
+        overseas?
       end
 
       def upper_tier?

--- a/app/views/waste_carriers_engine/company_address_manual_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/company_address_manual_forms/new.html.erb
@@ -13,7 +13,7 @@
 
     <h1 class="heading-large"><%= t(".heading.#{@company_address_manual_form.business_type}") %></h1>
 
-    <% unless @company_address_manual_form.business_is_overseas? %>
+    <% unless @company_address_manual_form.overseas? %>
       <div class="form-group">
         <label class="form-label"><%= t(".preset_postcode_label") %></label>
         <span class="postcode"><%= @company_address_manual_form.postcode %></span>
@@ -22,7 +22,7 @@
     <% end %>
 
     <%= f.fields_for :company_address do |f| %>
-      <%= render("waste_carriers_engine/shared/manual_address", form: @company_address_manual_form, f: f, overseas: @company_address_manual_form.business_is_overseas?) %>
+      <%= render("waste_carriers_engine/shared/manual_address", form: @company_address_manual_form, f: f, overseas: @company_address_manual_form.overseas?) %>
     <% end %>
 
     <div class="form-group">

--- a/app/views/waste_carriers_engine/contact_address_manual_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/contact_address_manual_forms/new.html.erb
@@ -13,7 +13,7 @@
 
     <h1 class="heading-large"><%= t(".heading") %></h1>
 
-    <% unless @contact_address_manual_form.business_is_overseas? %>
+    <% unless @contact_address_manual_form.overseas? %>
       <div class="form-group">
         <label class="form-label"><%= t(".preset_postcode_label") %></label>
         <span class="postcode"><%= @contact_address_manual_form.postcode %></span>
@@ -22,7 +22,7 @@
     <% end %>
 
     <%= f.fields_for :contact_address do |f| %>
-      <%= render("waste_carriers_engine/shared/manual_address", form: @contact_address_manual_form, f: f, overseas: @contact_address_manual_form.business_is_overseas?) %>
+      <%= render("waste_carriers_engine/shared/manual_address", form: @contact_address_manual_form, f: f, overseas: @contact_address_manual_form.overseas?) %>
     <% end %>
 
     <div class="form-group">

--- a/spec/support/shared_examples/can_have_registration_attributes.rb
+++ b/spec/support/shared_examples/can_have_registration_attributes.rb
@@ -28,6 +28,39 @@ RSpec.shared_examples "Can have registration attributes" do |factory:|
     end
   end
 
+  describe "#overseas?" do
+    let(:business_type) { nil }
+    let(:resource) { build(factory, location: location, business_type: business_type) }
+
+    context "when the location is outside the UK" do
+      let(:location) { "overseas" }
+
+      it "returns true" do
+        expect(resource.overseas?).to be_truthy
+      end
+    end
+
+    context "when the location is not outside the UK" do
+      let(:location) { nil }
+
+      context "when the business_type is overseas" do
+        let(:business_type) { "overseas" }
+
+        it "returns true" do
+          expect(resource.overseas?).to be_truthy
+        end
+      end
+
+      context "when the business_type is not overseas" do
+        let(:business_type) { "soleTrader" }
+
+        it "returns false" do
+          expect(resource.overseas?).to be_falsey
+        end
+      end
+    end
+  end
+
   describe "#lower_tier?" do
     let(:resource) { build(factory, tier: tier) }
 


### PR DESCRIPTION
Nothing like a good Friday night bug! 🐞 

I found this issue when I created a new overseas registration in the frontend for testing purposes.

I noticed that while I could set the location to "overseas", I still saw the business type screen. In the engine, overseas regs skip this form and set the business type automatically, but this isn't the case in the frontend. There isn't an `overseas` option on this form so you have to select something else.

So the registration I created had a `location` of `overseas`, but a `business_type` of `limitedCompany`.

However, this caused problems when I loaded it into the engine to test the edit feature. When I tried to edit the address, it showed me the UK version of the form, with the wrong postcode behaviour and no country field:

![image](https://user-images.githubusercontent.com/13369917/75065781-69587100-54e1-11ea-96d6-e5a746e5d960.png)

This turned out to be because we had two methods in CanHaveRegistrationAttributes called `overseas?` (which checked the `location` attribute) and `business_is_overseas?` (which checked the `business_type` attribute).

This meant that I could create a registration which returned `true` for `overseas?` but `false` for `business_is_overseas?`.

This isn't a problem when the manual address form is loaded as part of the renewal process, as users have to go through the location form first and it updates the `business_type` to `overseas` as well, making the response from the two methods consistent.

But when I loaded the form as part of an edit, it called `business_is_overseas?` on my registration, got a `false` and rendered the UK version of the form.

To fix this, I've merged the functions so we just have `overseas?` returning true if either the location or the business_type are the correct match. This should cover all the possible versions of an overseas registration:

- registrations created before the location form was added, which would have a `location` of `nil` and a `business_type` of `overseas`
- registrations created after the location form was added, which would have a `location` of `overseas` and a `business_type` of some other value
- registrations which have been renewed, and so have a `location` and `business_type` both set to `overseas`
- and, for the future, registrations created in the front-office, which also have a `location` and `business_type` both set to `overseas`

I think it might be worth trying to clean up our data, but probably not until the frontend is decommissioned and we know any registrations we create will be consistent.