### PR TITLE
Cancel an edit

### DIFF
--- a/app/controllers/waste_carriers_engine/confirm_edit_cancelled_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/confirm_edit_cancelled_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class ConfirmEditCancelledFormsController < FormsController
+    def new
+      super(ConfirmEditCancelledForm, "confirm_edit_cancelled_form")
+    end
+
+    def create
+      super(ConfirmEditCancelledForm, "confirm_edit_cancelled_form")
+    end
+  end
+end

--- a/app/controllers/waste_carriers_engine/edit_cancelled_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/edit_cancelled_forms_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class EditCancelledFormsController < FormsController
+    def new
+      return unless super(EditCancelledForm, "edit_cancelled_form")
+
+      EditCancellationService.run(edit_registration: @transient_registration)
+    end
+
+    # Overwrite create and go_back as you shouldn't be able to submit or go back
+    def create; end
+
+    def go_back; end
+  end
+end

--- a/app/forms/waste_carriers_engine/confirm_edit_cancelled_form.rb
+++ b/app/forms/waste_carriers_engine/confirm_edit_cancelled_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class ConfirmEditCancelledForm < BaseForm
+    def submit(_params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      attributes = {}
+
+      super(attributes)
+    end
+  end
+end

--- a/app/forms/waste_carriers_engine/edit_cancelled_form.rb
+++ b/app/forms/waste_carriers_engine/edit_cancelled_form.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class EditCancelledForm < BaseForm
+    include CannotSubmit
+
+    def self.can_navigate_flexibly?
+      false
+    end
+  end
+end

--- a/app/models/concerns/waste_carriers_engine/can_use_edit_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_edit_registration_workflow.rb
@@ -41,7 +41,11 @@ module WasteCarriersEngine
         state :declaration_form
         state :edit_complete_form
 
-        # Transitions
+        # Cancel an edit
+        state :confirm_edit_cancelled_form
+        state :edit_cancelled_form
+
+        # Transition to individual edit forms
 
         event :edit_cbd_type do
           transitions from: :edit_form,
@@ -94,6 +98,12 @@ module WasteCarriersEngine
         event :edit_location do
           transitions from: :edit_form,
                       to: :location_form
+        end
+
+        # Cancellation
+        event :cancel_edit do
+          transitions from: :edit_form,
+                      to: :confirm_edit_cancelled_form
         end
 
         event :next do
@@ -164,6 +174,10 @@ module WasteCarriersEngine
 
           transitions from: :declaration_form,
                       to: :edit_complete_form
+
+          # Cancel an edit
+          transitions from: :confirm_edit_cancelled_form,
+                      to: :edit_cancelled_form
         end
 
         event :back do
@@ -222,6 +236,10 @@ module WasteCarriersEngine
 
           # Complete an edit
           transitions from: :declaration_form,
+                      to: :edit_form
+
+          # Cancelling the edit process
+          transitions from: :confirm_edit_cancelled_form,
                       to: :edit_form
         end
 

--- a/app/services/waste_carriers_engine/edit_cancellation_service.rb
+++ b/app/services/waste_carriers_engine/edit_cancellation_service.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class EditCancellationService < BaseService
+    def run(edit_registration:)
+      edit_registration.delete
+    end
+  end
+end

--- a/app/views/waste_carriers_engine/confirm_edit_cancelled_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/confirm_edit_cancelled_forms/new.html.erb
@@ -1,0 +1,15 @@
+<%= render("waste_carriers_engine/shared/back", back_path: back_confirm_edit_cancelled_forms_path(@confirm_edit_cancelled_form.token)) %>
+
+<div class="text">
+  <%= form_for(@confirm_edit_cancelled_form) do |f| %>
+    <%= render("waste_carriers_engine/shared/errors", object: @confirm_edit_cancelled_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <p><%= t(".paragraph_1") %></p>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/waste_carriers_engine/edit_cancelled_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/edit_cancelled_forms/new.html.erb
@@ -1,0 +1,9 @@
+<div class="text">
+  <h1 class="heading-large"><%= t(".heading") %></h1>
+
+  <p><%= t(".paragraph_1") %></p>
+
+  <%= link_to t(".next_button"),
+              Rails.application.routes.url_helpers.registration_path(@transient_registration.reg_identifier),
+              class: "button" %>
+</div>

--- a/app/views/waste_carriers_engine/shared/_edit_actions.html.erb
+++ b/app/views/waste_carriers_engine/shared/_edit_actions.html.erb
@@ -3,7 +3,7 @@
     <%= f.submit t(".next_button"), class: "button" %>
     <span class="edit_linker">
       <%= t(".button_linker") %>
-      <%= link_to t(".cancel_button"), "#" %>
+      <%= link_to t(".cancel_button"), new_confirm_edit_cancelled_form_path(@presenter.token) %>
     </span>
   </p>
 </div>

--- a/config/locales/forms/confirm_edit_cancelled_forms/en.yml
+++ b/config/locales/forms/confirm_edit_cancelled_forms/en.yml
@@ -1,0 +1,16 @@
+en:
+  waste_carriers_engine:
+    confirm_edit_cancelled_forms:
+      new:
+        title: Do you want to cancel this edit?
+        heading: Do you want to cancel this edit?
+        paragraph_1: Your changes will not be saved.
+        next_button: Cancel
+  activemodel:
+    errors:
+      models:
+        waste_carriers_engine/confirm_edit_cancelled_form:
+          attributes:
+            token:
+              invalid_format: "The token is not valid"
+              missing: "The token is missing"

--- a/config/locales/forms/edit_cancelled_forms/en.yml
+++ b/config/locales/forms/edit_cancelled_forms/en.yml
@@ -1,0 +1,16 @@
+en:
+  waste_carriers_engine:
+    edit_cancelled_forms:
+      new:
+        title: Edit cancelled
+        heading: Edit cancelled
+        paragraph_1: "Your changes have been discarded. The registration was not updated."
+        next_button: View registration
+  activemodel:
+    errors:
+      models:
+        waste_carriers_engine/edit_cancelled_form:
+          attributes:
+            token:
+              invalid_format: "The token is not valid"
+              missing: "The token is missing"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,11 +107,31 @@ WasteCarriersEngine::Engine.routes.draw do
                     to: "edit_forms#edit_location",
                     as: "location",
                     on: :collection
+
+                get "cancel",
+                    to: "edit_forms#cancel",
+                    as: "cancel",
+                    on: :collection
               end
 
     resources :edit_complete_forms,
               only: %i[new create],
               path: "edit-complete",
+              path_names: { new: "" }
+
+    resources :confirm_edit_cancelled_forms,
+              only: %i[new create],
+              path: "confirm-edit-cancelled",
+              path_names: { new: "" } do
+                get "back",
+                    to: "confirm_edit_cancelled_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+
+    resources :edit_cancelled_forms,
+              only: %i[new create],
+              path: "edit-cancelled",
               path_names: { new: "" }
     # End of edit flow
 

--- a/spec/models/waste_carriers_engine/edit_registration_workflow/confirm_edit_cancelled_form_spec.rb
+++ b/spec/models/waste_carriers_engine/edit_registration_workflow/confirm_edit_cancelled_form_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe EditRegistration, type: :model do
+    describe "#workflow_state" do
+      it_behaves_like "a simple bidirectional transition",
+                      previous_state: :edit_form,
+                      current_state: :confirm_edit_cancelled_form,
+                      next_state: :edit_cancelled_form,
+                      factory: :edit_registration
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/edit_registration_workflow/declaration_form_spec.rb
+++ b/spec/models/waste_carriers_engine/edit_registration_workflow/declaration_form_spec.rb
@@ -4,30 +4,12 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe EditRegistration do
-    subject(:edit_registration) { build(:edit_registration) }
-
     describe "#workflow_state" do
-      context ":declaration_form state transitions" do
-        context "on next" do
-          it "can transition from a :declaration_form state to a :edit_complete_form" do
-            edit_registration.workflow_state = :declaration_form
-
-            edit_registration.next
-
-            expect(edit_registration.workflow_state).to eq("edit_complete_form")
-          end
-        end
-
-        context "on back" do
-          it "can transition from a :declaration_form state to a :edit_form" do
-            edit_registration.workflow_state = :declaration_form
-
-            edit_registration.back
-
-            expect(edit_registration.workflow_state).to eq("edit_form")
-          end
-        end
-      end
+      it_behaves_like "a simple bidirectional transition",
+                      previous_state: :edit_form,
+                      current_state: :declaration_form,
+                      next_state: :edit_complete_form,
+                      factory: :edit_registration
     end
   end
 end

--- a/spec/models/waste_carriers_engine/edit_registration_workflow/edit_cancelled_form_spec.rb
+++ b/spec/models/waste_carriers_engine/edit_registration_workflow/edit_cancelled_form_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe EditRegistration, type: :model do
+    describe "#workflow_state" do
+      it_behaves_like "a fixed final state",
+                      current_state: :edit_cancelled_form,
+                      factory: :edit_registration
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/edit_registration_workflow/edit_complete_form_spec.rb
+++ b/spec/models/waste_carriers_engine/edit_registration_workflow/edit_complete_form_spec.rb
@@ -4,22 +4,10 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe EditRegistration, type: :model do
-    subject(:edit_registration) { build(:edit_registration) }
-
     describe "#workflow_state" do
-      context ":edit_complete_form state transitions" do
-        it "does not respond to the 'back' event" do
-          edit_registration.workflow_state = :edit_complete_form
-
-          expect(edit_registration).to_not allow_event(:back)
-        end
-
-        it "does not respond to the 'next' event" do
-          edit_registration.workflow_state = :edit_complete_form
-
-          expect(edit_registration).to_not allow_event(:next)
-        end
-      end
+      it_behaves_like "a fixed final state",
+                      current_state: :edit_complete_form,
+                      factory: :edit_registration
     end
   end
 end

--- a/spec/models/waste_carriers_engine/edit_registration_workflow/edit_form_spec.rb
+++ b/spec/models/waste_carriers_engine/edit_registration_workflow/edit_form_spec.rb
@@ -20,7 +20,8 @@ module WasteCarriersEngine
         ]
         transitionable_states = non_address_editable_form_states + %i[company_postcode_form
                                                                       contact_postcode_form
-                                                                      declaration_form]
+                                                                      declaration_form
+                                                                      confirm_edit_cancelled_form]
 
         context "when an EditRegistration's state is #{current_state}" do
           it "can only transition to the allowed states" do
@@ -63,6 +64,12 @@ module WasteCarriersEngine
           it "changes to declaration_form after the 'next' event" do
             expected_state = :declaration_form
             event = :next
+            expect(subject).to transition_from(current_state).to(expected_state).on_event(event)
+          end
+
+          it "changes to confirm_edit_cancelled after the 'cancel_edit' event" do
+            expected_state = :confirm_edit_cancelled_form
+            event = :cancel_edit
             expect(subject).to transition_from(current_state).to(expected_state).on_event(event)
           end
         end

--- a/spec/requests/waste_carriers_engine/confirm_edit_cancelled_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/confirm_edit_cancelled_forms_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "ConfirmEditCancelledForms", type: :request do
+    describe "GET new_confirm_edit_cancelled_form_path" do
+      context "when a valid user is signed in" do
+        let(:user) { create(:user) }
+        before(:each) do
+          sign_in(user)
+        end
+
+        context "when no edit registration exists" do
+          it "redirects to the invalid page" do
+            get new_confirm_edit_cancelled_form_path("wibblewobblejellyonaplate")
+            expect(response).to redirect_to(page_path("invalid"))
+          end
+        end
+
+        context "when a valid edit registration exists" do
+          let(:transient_registration) do
+            create(:edit_registration,
+                   workflow_state: "confirm_edit_cancelled_form")
+          end
+
+          it "returns a 200 status" do
+            get new_confirm_edit_cancelled_form_path(transient_registration.token)
+
+            expect(response).to have_http_status(200)
+          end
+        end
+      end
+    end
+
+    describe "POST confirm_edit_cancelled_form_path" do
+      context "when a valid user is signed in" do
+        let(:user) { create(:user) }
+        before(:each) do
+          sign_in(user)
+        end
+
+        context "when no edit registration exists" do
+          it "redirects to the invalid page" do
+            post confirm_edit_cancelled_forms_path("wibblewobblejellyonaplate")
+            expect(response).to redirect_to(page_path("invalid"))
+          end
+        end
+
+        context "when a valid edit registration exists" do
+          let(:transient_registration) do
+            create(:edit_registration,
+                   workflow_state: "confirm_edit_cancelled_form")
+          end
+
+          it "redirects to the edit cancelled page" do
+            post confirm_edit_cancelled_forms_path(transient_registration.token)
+            expect(response).to redirect_to(new_edit_cancelled_form_path(transient_registration.token))
+          end
+        end
+      end
+    end
+
+    describe "GET back_confirm_edit_cancelled_forms_path" do
+      context "when a valid user is signed in" do
+        let(:user) { create(:user) }
+        before(:each) do
+          sign_in(user)
+        end
+
+        context "when a valid transient registration exists" do
+          let(:transient_registration) do
+            create(:edit_registration,
+                   workflow_state: "confirm_edit_cancelled_form")
+          end
+
+          context "when the back action is triggered" do
+            it "redirects to the edit form" do
+              get back_confirm_edit_cancelled_forms_path(transient_registration[:token])
+              expect(response).to redirect_to(new_edit_form_path(transient_registration[:token]))
+            end
+          end
+        end
+
+        context "when the transient registration is in the wrong state" do
+          let(:transient_registration) do
+            create(:edit_registration,
+                   workflow_state: "location_form")
+          end
+
+          context "when the back action is triggered" do
+            it "redirects to the correct form for the state" do
+              get back_confirm_edit_cancelled_forms_path(transient_registration[:token])
+              expect(response).to redirect_to(new_location_form_path(transient_registration[:token]))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/waste_carriers_engine/edit_cancelled_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/edit_cancelled_forms_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "EditCancelledForms", type: :request do
+    describe "GET new_edit_cancelled_form_path" do
+      context "when a valid user is signed in" do
+        let(:user) { create(:user) }
+        before(:each) do
+          sign_in(user)
+        end
+
+        context "when no edit registration exists" do
+          it "redirects to the invalid page" do
+            get new_edit_cancelled_form_path("wibblewobblejellyonaplate")
+            expect(response).to redirect_to(page_path("invalid"))
+          end
+        end
+
+        context "when a valid edit registration exists" do
+          let(:updated_email) { "updated@example.com" }
+          let(:updated_registered_address) { build(:address, :registered, postcode: "UP1 2DT") }
+          let(:updated_contact_address) { build(:address, :contact, postcode: "D1 1FF") }
+          let(:updated_person) { build(:key_person, :main, first_name: "Updated") }
+
+          let(:transient_registration) do
+            create(:edit_registration,
+                   workflow_state: "edit_cancelled_form")
+          end
+
+          context "when the workflow_state is correct" do
+            it "deletes the transient object" do
+              get new_edit_cancelled_form_path(transient_registration.token)
+
+              expect(WasteCarriersEngine::TransientRegistration.count).to eq(0)
+              expect(response).to have_http_status(200)
+            end
+          end
+
+          context "when the workflow_state is not correct" do
+            before do
+              transient_registration.update_attributes(workflow_state: "declaration_form")
+            end
+
+            it "redirects to the correct page and does not delete the transient object" do
+              get new_edit_cancelled_form_path(transient_registration.token)
+
+              expect(WasteCarriersEngine::TransientRegistration.count).to eq(1)
+              expect(response).to redirect_to(new_declaration_form_path(transient_registration.token))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/waste_carriers_engine/edit_cancellation_service_spec.rb
+++ b/spec/services/waste_carriers_engine/edit_cancellation_service_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe EditCancellationService do
+    describe "run" do
+      let(:edit_registration) { double(:edit_registration) }
+
+      it "deletes the edit_registration" do
+        expect(edit_registration).to receive(:delete)
+
+        described_class.run(edit_registration: edit_registration)
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/workflow_states/a_fixed_final_state.rb
+++ b/spec/support/shared_examples/workflow_states/a_fixed_final_state.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "a fixed final state" do |current_state:, factory:|
+  context "when a subject's state is #{current_state}" do
+    subject(:subject) { create(factory, workflow_state: current_state) }
+
+    context "when a subject's state is #{current_state}" do
+      it "can not transition to any states" do
+        permitted_states = Helpers::WorkflowStates.permitted_states(subject)
+        expect(permitted_states).to be_empty
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/workflow_states/a_simple_bidirectional_transition.rb
+++ b/spec/support/shared_examples/workflow_states/a_simple_bidirectional_transition.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "a simple bidirectional transition" do |previous_state:, current_state:, next_state:, factory:|
+  context "when a subject's state is #{current_state}" do
+    subject(:subject) { create(factory, workflow_state: current_state) }
+
+    it "can only transition to either #{previous_state} or #{next_state}" do
+      permitted_states = Helpers::WorkflowStates.permitted_states(subject)
+      expect(permitted_states).to match_array([previous_state, next_state])
+    end
+
+    it "changes to #{next_state} after the 'next' event" do
+      expect(subject).to transition_from(current_state).to(next_state).on_event(:next)
+    end
+
+    it "changes to #{previous_state} after the 'back' event" do
+      expect(subject).to transition_from(current_state).to(previous_state).on_event(:back)
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-832

It should be possible to cancel an in-progress edit.

Cancelling an edit destroys the EditRegistration without making any changes to the original Registration.

If a user returns to edit after cancelling, it creates a fresh EditRegistration with none of the previously cancelled changes.

We ask the user for confirmation before cancelling.