### PR TITLE
Deal with potential location changes in overseas? check

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -95,7 +95,13 @@ module WasteCarriersEngine
         business_type == "charity"
       end
 
+      def uk_location?
+        %w[england scotland wales northern_ireland].include?(location)
+      end
+
       def overseas?
+        return false if uk_location?
+
         location == "overseas" || business_type == "overseas"
       end
 

--- a/spec/forms/waste_carriers_engine/company_address_manual_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/company_address_manual_forms_spec.rb
@@ -18,8 +18,9 @@ module WasteCarriersEngine
         # Don't use FactoryBot for this as we need to make sure it initializes with a specific object
         let(:company_address_manual_form) { CompanyAddressManualForm.new(transient_registration) }
 
-        context "when the business type is overseas" do
+        context "when the business is overseas" do
           before(:each) do
+            transient_registration.location = "overseas"
             transient_registration.business_type = "overseas"
           end
 
@@ -211,8 +212,9 @@ module WasteCarriersEngine
             transient_registration.company_address.country = nil
           end
 
-          context "when the business_type is not overseas" do
+          context "when the business is not overseas" do
             before(:each) do
+              company_address_manual_form.transient_registration.location = "england"
               company_address_manual_form.transient_registration.business_type = "limitedCompany"
             end
 
@@ -221,8 +223,9 @@ module WasteCarriersEngine
             end
           end
 
-          context "when the business_type is overseas" do
+          context "when the business is overseas" do
             before(:each) do
+              company_address_manual_form.transient_registration.location = "overseas"
               company_address_manual_form.transient_registration.business_type = "overseas"
             end
 

--- a/spec/forms/waste_carriers_engine/contact_address_manual_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/contact_address_manual_forms_spec.rb
@@ -211,9 +211,10 @@ module WasteCarriersEngine
             contact_address_manual_form.contact_address.country = nil
           end
 
-          context "when the business_type is not overseas" do
+          context "when the business is not overseas" do
             before(:each) do
-              contact_address_manual_form.transient_registration.business_type = "limitedContact"
+              contact_address_manual_form.transient_registration.location = "england"
+              contact_address_manual_form.transient_registration.business_type = "limitedCompany"
             end
 
             it "is valid" do
@@ -221,8 +222,9 @@ module WasteCarriersEngine
             end
           end
 
-          context "when the business_type is overseas" do
+          context "when the business is overseas" do
             before(:each) do
+              contact_address_manual_form.transient_registration.location = "overseas"
               contact_address_manual_form.transient_registration.business_type = "overseas"
             end
 

--- a/spec/support/shared_examples/can_have_registration_attributes.rb
+++ b/spec/support/shared_examples/can_have_registration_attributes.rb
@@ -28,39 +28,6 @@ RSpec.shared_examples "Can have registration attributes" do |factory:|
     end
   end
 
-  describe "#overseas?" do
-    let(:business_type) { nil }
-    let(:resource) { build(factory, location: location, business_type: business_type) }
-
-    context "when the location is outside the UK" do
-      let(:location) { "overseas" }
-
-      it "returns true" do
-        expect(resource.overseas?).to be_truthy
-      end
-    end
-
-    context "when the location is not outside the UK" do
-      let(:location) { nil }
-
-      context "when the business_type is overseas" do
-        let(:business_type) { "overseas" }
-
-        it "returns true" do
-          expect(resource.overseas?).to be_truthy
-        end
-      end
-
-      context "when the business_type is not overseas" do
-        let(:business_type) { "soleTrader" }
-
-        it "returns false" do
-          expect(resource.overseas?).to be_falsey
-        end
-      end
-    end
-  end
-
   describe "#uk_location?" do
     let(:resource) { build(factory, location: location) }
 

--- a/spec/support/shared_examples/can_have_registration_attributes.rb
+++ b/spec/support/shared_examples/can_have_registration_attributes.rb
@@ -61,6 +61,75 @@ RSpec.shared_examples "Can have registration attributes" do |factory:|
     end
   end
 
+  describe "#uk_location?" do
+    let(:resource) { build(factory, location: location) }
+
+    %w[england scotland wales northern_ireland].each do |uk_location|
+      context "when the location is #{uk_location}" do
+        let(:location) { uk_location }
+
+        it "returns true" do
+          expect(resource.uk_location?).to be_truthy
+        end
+      end
+    end
+
+    context "when the location is overseas" do
+      let(:location) { "overseas" }
+
+      it "returns false" do
+        expect(resource.uk_location?).to be_falsey
+      end
+    end
+
+    context "when the location is nil" do
+      let(:location) { nil }
+
+      it "returns false" do
+        expect(resource.uk_location?).to be_falsey
+      end
+    end
+  end
+
+  describe "#overseas?" do
+    let(:location) { nil }
+    let(:business_type) { nil }
+    let(:resource) { build(factory, location: location, business_type: business_type) }
+
+    context "when the location is within the UK" do
+      it "returns false" do
+        expect(resource).to receive(:uk_location?).and_return(false)
+        expect(resource.overseas?).to be_falsey
+      end
+    end
+
+    context "when the location is outside the UK" do
+      let(:location) { "overseas" }
+
+      it "returns true" do
+        expect(resource.overseas?).to be_truthy
+      end
+    end
+
+    context "when the location is nil" do
+      context "when the business_type is overseas" do
+        let(:business_type) { "overseas" }
+
+        it "returns true" do
+          expect(resource.overseas?).to be_truthy
+        end
+      end
+
+      context "when the business_type is not overseas" do
+        let(:business_type) { "soleTrader" }
+
+        it "returns false" do
+          expect(resource.overseas?).to be_falsey
+        end
+      end
+    end
+  end
+
   describe "#lower_tier?" do
     let(:resource) { build(factory, tier: tier) }
 

--- a/spec/support/shared_examples/can_have_registration_attributes.rb
+++ b/spec/support/shared_examples/can_have_registration_attributes.rb
@@ -65,7 +65,7 @@ RSpec.shared_examples "Can have registration attributes" do |factory:|
 
     context "when the location is within the UK" do
       it "returns false" do
-        expect(resource).to receive(:uk_location?).and_return(false)
+        expect(resource).to receive(:uk_location?).and_return(true)
         expect(resource.overseas?).to be_falsey
       end
     end


### PR DESCRIPTION
There was a gap in our logic for https://github.com/DEFRA/waste-carriers-engine/pull/687. If a user had previously said they were based overseas when registering, `business_type` was set to `overseas`. Then if they selected a different location on renewal, `overseas?` would still respond true.

So this PR adds an extra `uk_location?` check to make sure we don't have this happen!