### PR TITLE
Copy contact name to contact address when completing edit

### DIFF
--- a/app/services/waste_carriers_engine/edit_completion_service.rb
+++ b/app/services/waste_carriers_engine/edit_completion_service.rb
@@ -6,11 +6,17 @@ module WasteCarriersEngine
       @edit_registration = edit_registration
       @registration = @edit_registration.registration
 
+      copy_names_to_contact_address
       copy_data_to_registration
       delete_transient_registration
     end
 
     private
+
+    def copy_names_to_contact_address
+      @edit_registration.contact_address.first_name = @edit_registration.first_name
+      @edit_registration.contact_address.last_name = @edit_registration.last_name
+    end
 
     def copy_data_to_registration
       copy_attributes

--- a/spec/services/waste_carriers_engine/edit_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/edit_completion_service_spec.rb
@@ -32,16 +32,27 @@ module WasteCarriersEngine
     let(:attributes) do
       copyable_attributes.merge(uncopyable_attributes)
     end
+
+    let(:first_name) { "Foo" }
+    let(:last_name) { "Bar" }
+    let(:contact_address) { double(:address) }
+
     let(:registration) { double(:edit_registration) }
     let(:edit_registration) do
       double(:edit_registration,
              attributes: attributes,
-             registration: registration)
+             registration: registration,
+             contact_address: contact_address,
+             first_name: first_name,
+             last_name: last_name)
     end
 
     describe ".run" do
       context "when given an edit_registration" do
-        it "deletes the edit_registration" do
+        it "updates the registration and deletes the edit_registration" do
+          # Sets up the contact address data
+          expect(contact_address).to receive(:first_name=).with(first_name)
+          expect(contact_address).to receive(:last_name=).with(last_name)
           # Updates the registration
           expect(registration).to receive(:write_attributes).with(copyable_attributes)
           expect(registration).to receive(:save!)


### PR DESCRIPTION
Spotted this had been left out of the edit completion service. The contact name should be included in the contact address for postal reasons.

If the contact name is edited, or the contact address is edited, this would previously become out of sync. So we add a method to copy over the name, as we do in the RenewalCompletionService.

In the future we should refactor so we don't store this data in two places!