### PR TITLE
Store a past_registration when completing an edit

### DIFF
--- a/app/services/waste_carriers_engine/edit_completion_service.rb
+++ b/app/services/waste_carriers_engine/edit_completion_service.rb
@@ -7,6 +7,7 @@ module WasteCarriersEngine
       @registration = @edit_registration.registration
 
       copy_names_to_contact_address
+      create_past_registration
       copy_data_to_registration
       delete_transient_registration
     end
@@ -16,6 +17,10 @@ module WasteCarriersEngine
     def copy_names_to_contact_address
       @edit_registration.contact_address.first_name = @edit_registration.first_name
       @edit_registration.contact_address.last_name = @edit_registration.last_name
+    end
+
+    def create_past_registration
+      PastRegistration.build_past_registration(@registration)
     end
 
     def copy_data_to_registration

--- a/app/services/waste_carriers_engine/edit_completion_service.rb
+++ b/app/services/waste_carriers_engine/edit_completion_service.rb
@@ -20,7 +20,7 @@ module WasteCarriersEngine
     end
 
     def create_past_registration
-      PastRegistration.build_past_registration(@registration)
+      PastRegistration.build_past_registration(@registration, :edit)
     end
 
     def copy_data_to_registration

--- a/spec/models/waste_carriers_engine/past_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/past_registration_spec.rb
@@ -27,19 +27,39 @@ module WasteCarriersEngine
         expect(past_registration.registered_address).to eq(registration.registered_address)
       end
 
-      context "if there is already a past_registration for this version of the registration" do
+      context "if :edit is given as an argument" do
+        let(:past_registration) { PastRegistration.build_past_registration(registration, :edit) }
+
+        it "sets the cause to 'edit'" do
+          expect(past_registration.cause).to eq("edit")
+        end
+      end
+
+      context "if there is already a past_registration with the same expiry date" do
         before do
           PastRegistration.build_past_registration(registration)
         end
 
-        it "returns nil" do
-          expect(past_registration).to eq(nil)
+        context "if the new version is not an edit" do
+          it "returns nil" do
+            expect(past_registration).to eq(nil)
+          end
+
+          it "does not create a new past_registration" do
+            past_registration_count = registration.past_registrations.count
+            past_registration
+            expect(registration.reload.past_registrations.count).to eq(past_registration_count)
+          end
         end
 
-        it "does not create a new past_registration" do
-          past_registration_count = registration.past_registrations.count
-          past_registration
-          expect(registration.reload.past_registrations.count).to eq(past_registration_count)
+        context "if the new version is an edit" do
+          let(:past_registration) { PastRegistration.build_past_registration(registration, :edit) }
+
+          it "does create a new past_registration" do
+            past_registration_count = registration.past_registrations.count
+            past_registration
+            expect(registration.reload.past_registrations.count).to eq(past_registration_count + 1)
+          end
         end
       end
     end

--- a/spec/services/waste_carriers_engine/edit_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/edit_completion_service_spec.rb
@@ -54,7 +54,7 @@ module WasteCarriersEngine
           expect(contact_address).to receive(:first_name=).with(first_name)
           expect(contact_address).to receive(:last_name=).with(last_name)
           # Creates a past_registration
-          expect(PastRegistration).to receive(:build_past_registration).with(registration)
+          expect(PastRegistration).to receive(:build_past_registration).with(registration, :edit)
           # Updates the registration
           expect(registration).to receive(:write_attributes).with(copyable_attributes)
           expect(registration).to receive(:save!)

--- a/spec/services/waste_carriers_engine/edit_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/edit_completion_service_spec.rb
@@ -53,6 +53,8 @@ module WasteCarriersEngine
           # Sets up the contact address data
           expect(contact_address).to receive(:first_name=).with(first_name)
           expect(contact_address).to receive(:last_name=).with(last_name)
+          # Creates a past_registration
+          expect(PastRegistration).to receive(:build_past_registration).with(registration)
           # Updates the registration
           expect(registration).to receive(:write_attributes).with(copyable_attributes)
           expect(registration).to receive(:save!)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-831

When a user makes an edit to a registration, we should store a new past_registration object containing the pre-edit version of the registration.

This will let us keep track of changes made by the edit.

This should happen at the point of completion. Cancelling an edit does not save a past_registration.