### PR TITLE
Don't check convictions when doing an edit

### DIFF
--- a/app/controllers/waste_carriers_engine/declaration_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/declaration_forms_controller.rb
@@ -9,13 +9,17 @@ module WasteCarriersEngine
     def create
       return unless super(DeclarationForm, "declaration_form")
 
-      WasteCarriersEngine::ConvictionDataService.run(@transient_registration)
+      WasteCarriersEngine::ConvictionDataService.run(@transient_registration) if should_check_convictions?
     end
 
     private
 
     def transient_registration_attributes
       params.fetch(:declaration_form, {}).permit(:declaration)
+    end
+
+    def should_check_convictions?
+      @transient_registration.is_a?(RenewingRegistration) || @transient_registration.is_a?(NewRegistration)
     end
   end
 end


### PR DESCRIPTION
Submitting the declaration form runs the conviction checks by default. This is fine for renewals and new registrations. However the edit workflow also uses this form, but we don't want to run the conviction checks during editing.

This PR makes a small tweak to only check convictions for particular journeys.