### PR TITLE
Build new registration workflow for Upper tier

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 module WasteCarriersEngine
+  # rubocop:disable Metrics/ModuleLength
   module CanUseNewRegistrationWorkflow
     extend ActiveSupport::Concern
     include Mongoid::Document
 
+    # rubocop:disable Metrics/BlockLength
     included do
       include AASM
 
@@ -16,11 +18,53 @@ module WasteCarriersEngine
         # Start
         state :start_form, initial: true
 
-        # Location
-        state :location_form
-
         # Renew
         state :renew_registration_form
+
+        # Location
+        state :location_form
+        state :register_in_northern_ireland_form
+        state :register_in_scotland_form
+        state :register_in_wales_form
+
+        state :business_type_form
+
+        state :other_businesses_form
+        state :service_provided_form
+        state :construction_demolition_form
+        state :waste_types_form
+
+        state :cbd_type_form
+        state :registration_number_form
+
+        state :company_name_form
+        state :company_postcode_form
+        state :company_address_form
+        state :company_address_manual_form
+
+        state :main_people_form
+
+        state :declare_convictions_form
+        state :conviction_details_form
+
+        state :contact_name_form
+        state :contact_phone_form
+        state :contact_email_form
+        state :contact_postcode_form
+        state :contact_address_form
+        state :contact_address_manual_form
+
+        state :check_your_answers_form
+        state :declaration_form
+        state :cards_form
+        state :payment_summary_form
+        state :worldpay_form
+        state :bank_transfer_form
+
+        state :renewal_complete_form
+        state :renewal_received_form
+
+        state :cannot_renew_lower_tier_form
 
         # Transitions
         event :next do
@@ -32,6 +76,178 @@ module WasteCarriersEngine
           transitions from: :start_form,
                       to: :renew_registration_form,
                       if: :should_renew?
+
+          # Location
+
+          transitions from: :location_form,
+                      to: :register_in_northern_ireland_form,
+                      if: :should_register_in_northern_ireland?
+
+          transitions from: :location_form,
+                      to: :register_in_scotland_form,
+                      if: :should_register_in_scotland?
+
+          transitions from: :location_form,
+                      to: :register_in_wales_form,
+                      if: :should_register_in_wales?
+
+          transitions from: :location_form,
+                      to: :other_businesses_form,
+                      if: :overseas?
+
+          transitions from: :location_form,
+                      to: :business_type_form
+
+          transitions from: :register_in_northern_ireland_form,
+                      to: :business_type_form
+
+          transitions from: :register_in_scotland_form,
+                      to: :business_type_form
+
+          transitions from: :register_in_wales_form,
+                      to: :business_type_form
+
+          # End location
+
+          transitions from: :business_type_form,
+                      to: :cannot_renew_lower_tier_form,
+                      if: :switch_to_lower_tier_based_on_business_type?
+
+          transitions from: :business_type_form,
+                      to: :other_businesses_form
+
+          # Smart answers
+
+          transitions from: :other_businesses_form,
+                      to: :construction_demolition_form,
+                      if: :only_carries_own_waste?
+
+          transitions from: :other_businesses_form,
+                      to: :service_provided_form
+
+          transitions from: :service_provided_form,
+                      to: :waste_types_form,
+                      if: :waste_is_main_service?
+
+          transitions from: :service_provided_form,
+                      to: :construction_demolition_form
+
+          transitions from: :waste_types_form,
+                      to: :cannot_renew_lower_tier_form,
+                      if: :switch_to_lower_tier_based_on_smart_answers?
+
+          transitions from: :waste_types_form,
+                      to: :cbd_type_form
+
+          transitions from: :construction_demolition_form,
+                      to: :cannot_renew_lower_tier_form,
+                      if: :switch_to_lower_tier_based_on_smart_answers?
+
+          transitions from: :construction_demolition_form,
+                      to: :cbd_type_form
+
+          # End smart answers
+
+          transitions from: :cbd_type_form,
+                      to: :company_name_form,
+                      if: :skip_registration_number?
+
+          transitions from: :cbd_type_form,
+                      to: :registration_number_form
+
+          transitions from: :registration_number_form,
+                      to: :company_name_form
+
+          transitions from: :company_name_form,
+                      to: :company_address_manual_form,
+                      if: :overseas?
+
+          transitions from: :company_name_form,
+                      to: :company_postcode_form
+
+          # Registered address
+
+          transitions from: :company_postcode_form,
+                      to: :company_address_manual_form,
+                      if: :skip_to_manual_address?
+
+          transitions from: :company_postcode_form,
+                      to: :company_address_form
+
+          transitions from: :company_address_form,
+                      to: :company_address_manual_form,
+                      if: :skip_to_manual_address?
+
+          transitions from: :company_address_form,
+                      to: :main_people_form
+
+          transitions from: :company_address_manual_form,
+                      to: :main_people_form
+
+          # End registered address
+
+          transitions from: :main_people_form,
+                      to: :declare_convictions_form
+
+          transitions from: :declare_convictions_form,
+                      to: :conviction_details_form,
+                      if: :declared_convictions?
+
+          transitions from: :declare_convictions_form,
+                      to: :contact_name_form
+
+          transitions from: :conviction_details_form,
+                      to: :contact_name_form
+
+          transitions from: :contact_name_form,
+                      to: :contact_phone_form
+
+          transitions from: :contact_phone_form,
+                      to: :contact_email_form
+
+          transitions from: :contact_email_form,
+                      to: :contact_address_manual_form,
+                      if: :overseas?
+
+          transitions from: :contact_email_form,
+                      to: :contact_postcode_form
+
+          # Contact address
+
+          transitions from: :contact_postcode_form,
+                      to: :contact_address_manual_form,
+                      if: :skip_to_manual_address?
+
+          transitions from: :contact_postcode_form,
+                      to: :contact_address_form
+
+          transitions from: :contact_address_form,
+                      to: :contact_address_manual_form,
+                      if: :skip_to_manual_address?
+
+          transitions from: :contact_address_form,
+                      to: :check_your_answers_form
+
+          transitions from: :contact_address_manual_form,
+                      to: :check_your_answers_form
+
+          # End contact address
+
+          transitions from: :check_your_answers_form,
+                      to: :declaration_form
+
+          transitions from: :declaration_form,
+                      to: :cards_form
+
+          transitions from: :cards_form,
+                      to: :payment_summary_form
+
+          transitions from: :payment_summary_form,
+                      to: :worldpay_form,
+                      if: :paying_by_card?
+
+          transitions from: :payment_summary_form,
+                      to: :bank_transfer_form
         end
 
         # Transitions
@@ -41,6 +257,186 @@ module WasteCarriersEngine
 
           transitions from: :renew_registration_form,
                       to: :start_form
+
+          # Location
+
+          transitions from: :location_form,
+                      to: :renewal_start_form
+
+          transitions from: :register_in_northern_ireland_form,
+                      to: :location_form
+
+          transitions from: :register_in_scotland_form,
+                      to: :location_form
+
+          transitions from: :register_in_wales_form,
+                      to: :location_form
+
+          # End location
+
+          transitions from: :business_type_form,
+                      to: :register_in_northern_ireland_form,
+                      if: :should_register_in_northern_ireland?
+
+          transitions from: :business_type_form,
+                      to: :register_in_scotland_form,
+                      if: :should_register_in_scotland?
+
+          transitions from: :business_type_form,
+                      to: :register_in_wales_form,
+                      if: :should_register_in_wales?
+
+          transitions from: :business_type_form,
+                      to: :location_form
+
+          # Smart answers
+
+          transitions from: :other_businesses_form,
+                      to: :location_form,
+                      if: :overseas?
+
+          transitions from: :other_businesses_form,
+                      to: :business_type_form
+
+          transitions from: :service_provided_form,
+                      to: :other_businesses_form
+
+          transitions from: :waste_types_form,
+                      to: :service_provided_form
+
+          transitions from: :construction_demolition_form,
+                      to: :other_businesses_form,
+                      if: :only_carries_own_waste?
+
+          transitions from: :construction_demolition_form,
+                      to: :service_provided_form
+
+          transitions from: :cbd_type_form,
+                      to: :waste_types_form,
+                      if: :waste_is_main_service?
+
+          transitions from: :cbd_type_form,
+                      to: :construction_demolition_form
+
+          # End smart answers
+
+          transitions from: :registration_number_form,
+                      to: :cbd_type_form
+
+          transitions from: :company_name_form,
+                      to: :cbd_type_form,
+                      if: :skip_registration_number?
+
+          transitions from: :company_name_form,
+                      to: :registration_number_form
+
+          # Registered address
+
+          transitions from: :company_postcode_form,
+                      to: :company_name_form
+
+          transitions from: :company_address_form,
+                      to: :company_postcode_form
+
+          transitions from: :company_address_manual_form,
+                      to: :company_name_form,
+                      if: :overseas?
+
+          transitions from: :company_address_manual_form,
+                      to: :company_postcode_form
+
+          transitions from: :main_people_form,
+                      to: :company_address_manual_form,
+                      if: :registered_address_was_manually_entered?
+
+          transitions from: :main_people_form,
+                      to: :company_address_form
+
+          # End registered address
+
+          transitions from: :declare_convictions_form,
+                      to: :main_people_form
+
+          transitions from: :conviction_details_form,
+                      to: :declare_convictions_form
+
+          transitions from: :contact_name_form,
+                      to: :conviction_details_form,
+                      if: :declared_convictions?
+
+          transitions from: :contact_name_form,
+                      to: :declare_convictions_form
+
+          transitions from: :contact_phone_form,
+                      to: :contact_name_form
+
+          transitions from: :contact_email_form,
+                      to: :contact_phone_form
+
+          # Contact address
+
+          transitions from: :contact_postcode_form,
+                      to: :contact_email_form
+
+          transitions from: :contact_address_form,
+                      to: :contact_postcode_form
+
+          transitions from: :contact_address_manual_form,
+                      to: :contact_email_form,
+                      if: :overseas?
+
+          transitions from: :contact_address_manual_form,
+                      to: :contact_postcode_form
+
+          transitions from: :check_your_answers_form,
+                      to: :contact_address_manual_form,
+                      if: :contact_address_was_manually_entered?
+
+          transitions from: :check_your_answers_form,
+                      to: :contact_address_form
+
+          # End contact address
+
+          transitions from: :declaration_form,
+                      to: :check_your_answers_form
+
+          transitions from: :cards_form,
+                      to: :declaration_form
+
+          transitions from: :payment_summary_form,
+                      to: :cards_form
+
+          # TODO: Remove this ones once we implement lower-tier journey
+          # Exit routes from renewals process
+
+          transitions from: :cannot_renew_lower_tier_form,
+                      to: :business_type_form,
+                      if: :switch_to_lower_tier_based_on_business_type?
+
+          transitions from: :cannot_renew_lower_tier_form,
+                      to: :construction_demolition_form,
+                      if: :only_carries_own_waste?
+
+          transitions from: :cannot_renew_lower_tier_form,
+                      to: :waste_types_form,
+                      if: :waste_is_main_service?
+
+          transitions from: :cannot_renew_lower_tier_form,
+                      to: :construction_demolition_form
+        end
+
+        event :skip_to_manual_address do
+          transitions from: :company_postcode_form,
+                      to: :company_address_manual_form
+
+          transitions from: :company_address_form,
+                      to: :company_address_manual_form
+
+          transitions from: :contact_postcode_form,
+                      to: :contact_address_manual_form
+
+          transitions from: :contact_address_form,
+                      to: :contact_address_manual_form
         end
       end
 
@@ -49,6 +445,68 @@ module WasteCarriersEngine
       def should_renew?
         temp_start_option == WasteCarriersEngine::StartForm::RENEW
       end
+
+      def skip_registration_number?
+        !company_no_required?
+      end
+
+      # Charity registrations should be lower tier
+      def switch_to_lower_tier_based_on_business_type?
+        charity?
+      end
+
+      def switch_to_lower_tier_based_on_smart_answers?
+        SmartAnswersCheckerService.new(self).lower_tier?
+      end
+
+      def only_carries_own_waste?
+        # TODO: Make this a boolean
+        other_businesses == "no"
+      end
+
+      def waste_is_main_service?
+        # TODO: Make this a boolean
+        is_main_service == "yes"
+      end
+
+      def registered_address_was_manually_entered?
+        return unless registered_address
+
+        registered_address.manually_entered?
+      end
+
+      def skip_to_manual_address?
+        temp_os_places_error
+      end
+
+      def contact_address_was_manually_entered?
+        return unless contact_address
+
+        contact_address.manually_entered?
+      end
+
+      def should_register_in_northern_ireland?
+        location == "northern_ireland"
+      end
+
+      def should_register_in_scotland?
+        location == "scotland"
+      end
+
+      def should_register_in_wales?
+        location == "wales"
+      end
+
+      def declared_convictions?
+        # TODO: Make this a boolean
+        declared_convictions == "yes"
+      end
+
+      def paying_by_card?
+        temp_payment_method == "card"
+      end
     end
+    # rubocop:enable Metrics/BlockLength
   end
+  # rubocop:enable Metrics/ModuleLength
 end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/business_type_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/business_type_form_spec.rb
@@ -13,10 +13,10 @@ module WasteCarriersEngine
             subject { build(:new_registration, workflow_state: "business_type_form", business_type: "charity") }
 
             # TODO: Fix when implementing lower tier flow
-            include_examples "can transition next to", next_state: "cannot_renew_lower_tier_form"
+            include_examples "has next transition", next_state: "cannot_renew_lower_tier_form"
           end
 
-          include_examples "can transition next to", next_state: "other_businesses_form"
+          include_examples "has next transition", next_state: "other_businesses_form"
         end
 
         context "on back" do
@@ -25,25 +25,25 @@ module WasteCarriersEngine
           context "when the location is northern_ireland" do
             let(:location) { "northern_ireland" }
 
-            include_examples "can transition back to", previous_state: "register_in_northern_ireland_form"
+            include_examples "has back transition", previous_state: "register_in_northern_ireland_form"
           end
 
           context "when the location is scotland" do
             let(:location) { "scotland" }
 
-            include_examples "can transition back to", previous_state: "register_in_scotland_form"
+            include_examples "has back transition", previous_state: "register_in_scotland_form"
           end
 
           context "when the location is wales" do
             let(:location) { "wales" }
 
-            include_examples "can transition back to", previous_state: "register_in_wales_form"
+            include_examples "has back transition", previous_state: "register_in_wales_form"
           end
 
           context "when the location is in england" do
             let(:location) { "england" }
 
-            include_examples "can transition back to", previous_state: "location_form"
+            include_examples "has back transition", previous_state: "location_form"
           end
         end
       end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/business_type_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/business_type_form_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "business_type_form") }
+
+    describe "#workflow_state" do
+      context ":business_type_form state transitions" do
+        context "on next" do
+          context "when the business type is a lower tier specific type" do
+            subject { build(:new_registration, workflow_state: "business_type_form", business_type: "charity") }
+
+            # TODO: Fix when implementing lower tier flow
+            include_examples "can transition next to", next_state: "cannot_renew_lower_tier_form"
+          end
+
+          include_examples "can transition next to", next_state: "other_businesses_form"
+        end
+
+        context "on back" do
+          subject { build(:new_registration, workflow_state: "business_type_form", location: location) }
+
+          context "when the location is northern_ireland" do
+            let(:location) { "northern_ireland" }
+
+            include_examples "can transition back to", previous_state: "register_in_northern_ireland_form"
+          end
+
+          context "when the location is scotland" do
+            let(:location) { "scotland" }
+
+            include_examples "can transition back to", previous_state: "register_in_scotland_form"
+          end
+
+          context "when the location is wales" do
+            let(:location) { "wales" }
+
+            include_examples "can transition back to", previous_state: "register_in_wales_form"
+          end
+
+          context "when the location is in england" do
+            let(:location) { "england" }
+
+            include_examples "can transition back to", previous_state: "location_form"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/cards_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/cards_form_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "cards_form") }
+
+    describe "#workflow_state" do
+      context ":cards_form state transitions" do
+        context "on next" do
+          include_examples "can transition next to", next_state: "payment_summary_form"
+        end
+
+        context "on back" do
+          include_examples "can transition back to", previous_state: "declaration_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/cards_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/cards_form_spec.rb
@@ -9,11 +9,11 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":cards_form state transitions" do
         context "on next" do
-          include_examples "can transition next to", next_state: "payment_summary_form"
+          include_examples "has next transition", next_state: "payment_summary_form"
         end
 
         context "on back" do
-          include_examples "can transition back to", previous_state: "declaration_form"
+          include_examples "has back transition", previous_state: "declaration_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/cbd_type_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/cbd_type_form_spec.rb
@@ -12,20 +12,20 @@ module WasteCarriersEngine
           context "when a company registration number is required" do
             subject { build(:new_registration, workflow_state: "cbd_type_form", business_type: "limitedCompany") }
 
-            include_examples "can transition next to", next_state: "registration_number_form"
+            include_examples "has next transition", next_state: "registration_number_form"
           end
 
-          include_examples "can transition next to", next_state: "company_name_form"
+          include_examples "has next transition", next_state: "company_name_form"
         end
 
         context "on back" do
           context "when the waste is the main business of the company" do
             subject { build(:new_registration, workflow_state: "cbd_type_form", is_main_service: "yes") }
 
-            include_examples "can transition back to", previous_state: "waste_types_form"
+            include_examples "has back transition", previous_state: "waste_types_form"
           end
 
-          include_examples "can transition back to", previous_state: "construction_demolition_form"
+          include_examples "has back transition", previous_state: "construction_demolition_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/cbd_type_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/cbd_type_form_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "cbd_type_form") }
+
+    describe "#workflow_state" do
+      context ":cbd_type_form state transitions" do
+        context "on next" do
+          context "when a company registration number is required" do
+            subject { build(:new_registration, workflow_state: "cbd_type_form", business_type: "limitedCompany") }
+
+            include_examples "can transition next to", next_state: "registration_number_form"
+          end
+
+          include_examples "can transition next to", next_state: "company_name_form"
+        end
+
+        context "on back" do
+          context "when the waste is the main business of the company" do
+            subject { build(:new_registration, workflow_state: "cbd_type_form", is_main_service: "yes") }
+
+            include_examples "can transition back to", previous_state: "waste_types_form"
+          end
+
+          include_examples "can transition back to", previous_state: "construction_demolition_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/check_your_answers_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/check_your_answers_form_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "check_your_answers_form") }
+
+    describe "#workflow_state" do
+      context ":check_your_answers_form state transitions" do
+        context "on next" do
+          include_examples "can transition next to", next_state: "declaration_form"
+        end
+
+        context "on back" do
+          context "when the contact address was manually entered" do
+            let(:contact_address) { build(:address, :contact, :manual_uk) }
+            subject { build(:new_registration, workflow_state: "check_your_answers_form", contact_address: contact_address) }
+
+            include_examples "can transition back to", previous_state: "contact_address_manual_form"
+          end
+
+          include_examples "can transition back to", previous_state: "contact_address_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/check_your_answers_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/check_your_answers_form_spec.rb
@@ -9,7 +9,7 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":check_your_answers_form state transitions" do
         context "on next" do
-          include_examples "can transition next to", next_state: "declaration_form"
+          include_examples "has next transition", next_state: "declaration_form"
         end
 
         context "on back" do
@@ -17,10 +17,10 @@ module WasteCarriersEngine
             let(:contact_address) { build(:address, :contact, :manual_uk) }
             subject { build(:new_registration, workflow_state: "check_your_answers_form", contact_address: contact_address) }
 
-            include_examples "can transition back to", previous_state: "contact_address_manual_form"
+            include_examples "has back transition", previous_state: "contact_address_manual_form"
           end
 
-          include_examples "can transition back to", previous_state: "contact_address_form"
+          include_examples "has back transition", previous_state: "contact_address_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/company_address_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/company_address_form_spec.rb
@@ -8,19 +8,5 @@ module WasteCarriersEngine
                     next_state_if_not_skipping_to_manual: :main_people_form,
                     address_type: "company",
                     factory: :new_registration
-
-    subject { build(:new_registration, workflow_state: "company_address_form") }
-
-    describe "#workflow_state" do
-      context ":company_address_form state transitions" do
-        context "on skip_to_manual_address" do
-          it "transitions to :company_address_manual_form" do
-            subject.skip_to_manual_address!
-
-            expect(subject.workflow_state).to eq("company_address_manual_form")
-          end
-        end
-      end
-    end
   end
 end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/company_address_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/company_address_form_spec.rb
@@ -4,24 +4,15 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe NewRegistration do
+    it_behaves_like "an address lookup transition",
+                    next_state_if_not_skipping_to_manual: :main_people_form,
+                    address_type: "company",
+                    factory: :new_registration
+
     subject { build(:new_registration, workflow_state: "company_address_form") }
 
     describe "#workflow_state" do
       context ":company_address_form state transitions" do
-        context "on next" do
-          context "when the user skip to a manual address" do
-            subject { build(:new_registration, workflow_state: "company_address_form", temp_os_places_error: "foo") }
-
-            include_examples "can transition next to", next_state: "company_address_manual_form"
-          end
-
-          include_examples "can transition next to", next_state: "main_people_form"
-        end
-
-        context "on back" do
-          include_examples "can transition back to", previous_state: "company_postcode_form"
-        end
-
         context "on skip_to_manual_address" do
           it "transitions to :company_address_manual_form" do
             subject.skip_to_manual_address!

--- a/spec/models/waste_carriers_engine/new_registration_workflow/company_address_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/company_address_form_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "company_address_form") }
+
+    describe "#workflow_state" do
+      context ":company_address_form state transitions" do
+        context "on next" do
+          context "when the user skip to a manual address" do
+            subject { build(:new_registration, workflow_state: "company_address_form", temp_os_places_error: "foo") }
+
+            include_examples "can transition next to", next_state: "company_address_manual_form"
+          end
+
+          include_examples "can transition next to", next_state: "main_people_form"
+        end
+
+        context "on back" do
+          include_examples "can transition back to", previous_state: "company_postcode_form"
+        end
+
+        context "on skip_to_manual_address" do
+          it "transitions to :company_address_manual_form" do
+            subject.skip_to_manual_address!
+
+            expect(subject.workflow_state).to eq("company_address_manual_form")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/company_address_manual_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/company_address_manual_form_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "company_address_manual_form") }
+
+    describe "#workflow_state" do
+      context ":company_address_manual_form state transitions" do
+        context "on next" do
+          include_examples "can transition next to", next_state: "main_people_form"
+        end
+
+        context "on back" do
+          context "when the business is based overseas" do
+            subject { build(:new_registration, workflow_state: "company_address_manual_form", location: "overseas") }
+
+            include_examples "can transition back to", previous_state: "company_name_form"
+          end
+
+          include_examples "can transition back to", previous_state: "company_postcode_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/company_address_manual_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/company_address_manual_form_spec.rb
@@ -4,24 +4,12 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe NewRegistration do
-    subject { build(:new_registration, workflow_state: "company_address_manual_form") }
-
     describe "#workflow_state" do
-      context ":company_address_manual_form state transitions" do
-        context "on next" do
-          include_examples "can transition next to", next_state: "main_people_form"
-        end
-
-        context "on back" do
-          context "when the business is based overseas" do
-            subject { build(:new_registration, workflow_state: "company_address_manual_form", location: "overseas") }
-
-            include_examples "can transition back to", previous_state: "company_name_form"
-          end
-
-          include_examples "can transition back to", previous_state: "company_postcode_form"
-        end
-      end
+      it_behaves_like "a manual address transition",
+                      previous_state_if_overseas: :company_name_form,
+                      next_state: :main_people_form,
+                      address_type: "company",
+                      factory: :new_registration
     end
   end
 end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/company_name_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/company_name_form_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "company_name_form") }
+
+    describe "#workflow_state" do
+      context ":company_name_form state transitions" do
+        context "on next" do
+          context "when the business is based overseas" do
+            subject { build(:new_registration, workflow_state: "company_name_form", location: "overseas") }
+
+            include_examples "can transition next to", next_state: "company_address_manual_form"
+          end
+
+          include_examples "can transition next to", next_state: "company_postcode_form"
+        end
+
+        context "on back" do
+          context "when the business requires a registration number" do
+            subject { build(:new_registration, workflow_state: "company_name_form", business_type: "limitedCompany") }
+
+            include_examples "can transition back to", previous_state: "registration_number_form"
+          end
+
+          include_examples "can transition back to", previous_state: "cbd_type_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/company_name_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/company_name_form_spec.rb
@@ -12,20 +12,20 @@ module WasteCarriersEngine
           context "when the business is based overseas" do
             subject { build(:new_registration, workflow_state: "company_name_form", location: "overseas") }
 
-            include_examples "can transition next to", next_state: "company_address_manual_form"
+            include_examples "has next transition", next_state: "company_address_manual_form"
           end
 
-          include_examples "can transition next to", next_state: "company_postcode_form"
+          include_examples "has next transition", next_state: "company_postcode_form"
         end
 
         context "on back" do
           context "when the business requires a registration number" do
             subject { build(:new_registration, workflow_state: "company_name_form", business_type: "limitedCompany") }
 
-            include_examples "can transition back to", previous_state: "registration_number_form"
+            include_examples "has back transition", previous_state: "registration_number_form"
           end
 
-          include_examples "can transition back to", previous_state: "cbd_type_form"
+          include_examples "has back transition", previous_state: "cbd_type_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/company_postcode_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/company_postcode_form_spec.rb
@@ -9,18 +9,6 @@ module WasteCarriersEngine
                       previous_state: :company_name_form,
                       address_type: "company",
                       factory: :new_registration
-
-      context ":company_postcode_form state transitions" do
-        context "on skip_to_manual_address" do
-          subject { build(:new_registration, workflow_state: "company_postcode_form") }
-
-          it "transitions to :company_address_manual_form" do
-            subject.skip_to_manual_address!
-
-            expect(subject.workflow_state).to eq("company_address_manual_form")
-          end
-        end
-      end
     end
   end
 end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/company_postcode_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/company_postcode_form_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "company_postcode_form") }
+
+    describe "#workflow_state" do
+      context ":company_postcode_form state transitions" do
+        context "on next" do
+          context "when the user skip to a manual address" do
+            subject { build(:new_registration, workflow_state: "company_postcode_form", temp_os_places_error: "foo") }
+
+            include_examples "can transition next to", next_state: "company_address_manual_form"
+          end
+
+          include_examples "can transition next to", next_state: "company_address_form"
+        end
+
+        context "on back" do
+          include_examples "can transition back to", previous_state: "company_name_form"
+        end
+
+        context "on skip_to_manual_address" do
+          it "transitions to :company_address_manual_form" do
+            subject.skip_to_manual_address!
+
+            expect(subject.workflow_state).to eq("company_address_manual_form")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/company_postcode_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/company_postcode_form_spec.rb
@@ -4,25 +4,16 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe NewRegistration do
-    subject { build(:new_registration, workflow_state: "company_postcode_form") }
-
     describe "#workflow_state" do
+      it_behaves_like "a postcode transition",
+                      previous_state: :company_name_form,
+                      address_type: "company",
+                      factory: :new_registration
+
       context ":company_postcode_form state transitions" do
-        context "on next" do
-          context "when the user skip to a manual address" do
-            subject { build(:new_registration, workflow_state: "company_postcode_form", temp_os_places_error: "foo") }
-
-            include_examples "can transition next to", next_state: "company_address_manual_form"
-          end
-
-          include_examples "can transition next to", next_state: "company_address_form"
-        end
-
-        context "on back" do
-          include_examples "can transition back to", previous_state: "company_name_form"
-        end
-
         context "on skip_to_manual_address" do
+          subject { build(:new_registration, workflow_state: "company_postcode_form") }
+
           it "transitions to :company_address_manual_form" do
             subject.skip_to_manual_address!
 

--- a/spec/models/waste_carriers_engine/new_registration_workflow/construction_demolition_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/construction_demolition_form_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "construction_demolition_form") }
+
+    describe "#workflow_state" do
+      context ":construction_demolition_form state transitions" do
+        context "on next" do
+          let(:smart_answer_checker_service) { double(:smart_answer_checker_service, lower_tier?: lower_tier) }
+
+          before do
+            allow(SmartAnswersCheckerService).to receive(:new).and_return(smart_answer_checker_service)
+          end
+
+          context "when the result of smart answers is lower-tier" do
+            let(:lower_tier) { true }
+
+            # TODO: Fix me when implement lower-tier journey
+            include_examples "can transition next to", next_state: "cannot_renew_lower_tier_form"
+          end
+
+          context "when the result of smart answers is upper-tier" do
+            let(:lower_tier) { false }
+
+            include_examples "can transition next to", next_state: "cbd_type_form"
+          end
+        end
+
+        context "on back" do
+          context "when the company only carries its own waste" do
+            subject { build(:new_registration, workflow_state: "construction_demolition_form", other_businesses: "no") }
+
+            include_examples "can transition back to", previous_state: "other_businesses_form"
+          end
+
+          include_examples "can transition back to", previous_state: "service_provided_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/construction_demolition_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/construction_demolition_form_spec.rb
@@ -19,13 +19,13 @@ module WasteCarriersEngine
             let(:lower_tier) { true }
 
             # TODO: Fix me when implement lower-tier journey
-            include_examples "can transition next to", next_state: "cannot_renew_lower_tier_form"
+            include_examples "has next transition", next_state: "cannot_renew_lower_tier_form"
           end
 
           context "when the result of smart answers is upper-tier" do
             let(:lower_tier) { false }
 
-            include_examples "can transition next to", next_state: "cbd_type_form"
+            include_examples "has next transition", next_state: "cbd_type_form"
           end
         end
 
@@ -33,10 +33,10 @@ module WasteCarriersEngine
           context "when the company only carries its own waste" do
             subject { build(:new_registration, workflow_state: "construction_demolition_form", other_businesses: "no") }
 
-            include_examples "can transition back to", previous_state: "other_businesses_form"
+            include_examples "has back transition", previous_state: "other_businesses_form"
           end
 
-          include_examples "can transition back to", previous_state: "service_provided_form"
+          include_examples "has back transition", previous_state: "service_provided_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/contact_address_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/contact_address_form_spec.rb
@@ -4,24 +4,15 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe NewRegistration do
+    it_behaves_like "an address lookup transition",
+                    next_state_if_not_skipping_to_manual: :check_your_answers_form,
+                    address_type: "contact",
+                    factory: :new_registration
+
     subject { build(:new_registration, workflow_state: "contact_address_form") }
 
     describe "#workflow_state" do
       context ":contact_address_form state transitions" do
-        context "on next" do
-          context "when the user skip to a manual address" do
-            subject { build(:new_registration, workflow_state: "contact_address_form", temp_os_places_error: "foo") }
-
-            include_examples "can transition next to", next_state: "contact_address_manual_form"
-          end
-
-          include_examples "can transition next to", next_state: "check_your_answers_form"
-        end
-
-        context "on back" do
-          include_examples "can transition back to", previous_state: "contact_postcode_form"
-        end
-
         context "on skip_to_manual_address" do
           it "transitions to :contact_address_manual_form" do
             subject.skip_to_manual_address!

--- a/spec/models/waste_carriers_engine/new_registration_workflow/contact_address_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/contact_address_form_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "contact_address_form") }
+
+    describe "#workflow_state" do
+      context ":contact_address_form state transitions" do
+        context "on next" do
+          context "when the user skip to a manual address" do
+            subject { build(:new_registration, workflow_state: "contact_address_form", temp_os_places_error: "foo") }
+
+            include_examples "can transition next to", next_state: "contact_address_manual_form"
+          end
+
+          include_examples "can transition next to", next_state: "check_your_answers_form"
+        end
+
+        context "on back" do
+          include_examples "can transition back to", previous_state: "contact_postcode_form"
+        end
+
+        context "on skip_to_manual_address" do
+          it "transitions to :contact_address_manual_form" do
+            subject.skip_to_manual_address!
+
+            expect(subject.workflow_state).to eq("contact_address_manual_form")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/contact_address_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/contact_address_form_spec.rb
@@ -8,19 +8,5 @@ module WasteCarriersEngine
                     next_state_if_not_skipping_to_manual: :check_your_answers_form,
                     address_type: "contact",
                     factory: :new_registration
-
-    subject { build(:new_registration, workflow_state: "contact_address_form") }
-
-    describe "#workflow_state" do
-      context ":contact_address_form state transitions" do
-        context "on skip_to_manual_address" do
-          it "transitions to :contact_address_manual_form" do
-            subject.skip_to_manual_address!
-
-            expect(subject.workflow_state).to eq("contact_address_manual_form")
-          end
-        end
-      end
-    end
   end
 end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/contact_address_manual_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/contact_address_manual_form_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "contact_address_manual_form") }
+
+    describe "#workflow_state" do
+      context ":contact_address_manual_form state transitions" do
+        context "on next" do
+          include_examples "can transition next to", next_state: "check_your_answers_form"
+        end
+
+        context "on back" do
+          context "when the business is based overseas" do
+            subject { build(:new_registration, workflow_state: "contact_address_manual_form", location: "overseas") }
+
+            include_examples "can transition back to", previous_state: "contact_email_form"
+          end
+
+          include_examples "can transition back to", previous_state: "contact_postcode_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/contact_address_manual_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/contact_address_manual_form_spec.rb
@@ -4,24 +4,12 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe NewRegistration do
-    subject { build(:new_registration, workflow_state: "contact_address_manual_form") }
-
     describe "#workflow_state" do
-      context ":contact_address_manual_form state transitions" do
-        context "on next" do
-          include_examples "can transition next to", next_state: "check_your_answers_form"
-        end
-
-        context "on back" do
-          context "when the business is based overseas" do
-            subject { build(:new_registration, workflow_state: "contact_address_manual_form", location: "overseas") }
-
-            include_examples "can transition back to", previous_state: "contact_email_form"
-          end
-
-          include_examples "can transition back to", previous_state: "contact_postcode_form"
-        end
-      end
+      it_behaves_like "a manual address transition",
+                      previous_state_if_overseas: :contact_email_form,
+                      next_state: :check_your_answers_form,
+                      address_type: "contact",
+                      factory: :new_registration
     end
   end
 end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/contact_email_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/contact_email_form_spec.rb
@@ -12,14 +12,14 @@ module WasteCarriersEngine
           context "when the business is based overseas" do
             subject { build(:new_registration, workflow_state: "contact_email_form", location: "overseas") }
 
-            include_examples "can transition next to", next_state: "contact_address_manual_form"
+            include_examples "has next transition", next_state: "contact_address_manual_form"
           end
 
-          include_examples "can transition next to", next_state: "contact_postcode_form"
+          include_examples "has next transition", next_state: "contact_postcode_form"
         end
 
         context "on back" do
-          include_examples "can transition back to", previous_state: "contact_phone_form"
+          include_examples "has back transition", previous_state: "contact_phone_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/contact_email_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/contact_email_form_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "contact_email_form") }
+
+    describe "#workflow_state" do
+      context ":contact_email_form state transitions" do
+        context "on next" do
+          context "when the business is based overseas" do
+            subject { build(:new_registration, workflow_state: "contact_email_form", location: "overseas") }
+
+            include_examples "can transition next to", next_state: "contact_address_manual_form"
+          end
+
+          include_examples "can transition next to", next_state: "contact_postcode_form"
+        end
+
+        context "on back" do
+          include_examples "can transition back to", previous_state: "contact_phone_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/contact_name_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/contact_name_form_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "contact_name_form") }
+
+    describe "#workflow_state" do
+      context ":contact_name_form state transitions" do
+        context "on next" do
+          include_examples "can transition next to", next_state: "contact_phone_form"
+        end
+
+        context "on back" do
+          context "When the user has convictions to declare" do
+            subject { build(:new_registration, workflow_state: "contact_name_form", declared_convictions: "yes") }
+
+            include_examples "can transition back to", previous_state: "conviction_details_form"
+          end
+
+          include_examples "can transition back to", previous_state: "declare_convictions_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/contact_name_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/contact_name_form_spec.rb
@@ -9,17 +9,17 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":contact_name_form state transitions" do
         context "on next" do
-          include_examples "can transition next to", next_state: "contact_phone_form"
+          include_examples "has next transition", next_state: "contact_phone_form"
         end
 
         context "on back" do
           context "When the user has convictions to declare" do
             subject { build(:new_registration, workflow_state: "contact_name_form", declared_convictions: "yes") }
 
-            include_examples "can transition back to", previous_state: "conviction_details_form"
+            include_examples "has back transition", previous_state: "conviction_details_form"
           end
 
-          include_examples "can transition back to", previous_state: "declare_convictions_form"
+          include_examples "has back transition", previous_state: "declare_convictions_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/contact_phone_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/contact_phone_form_spec.rb
@@ -9,11 +9,11 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":contact_phone_form state transitions" do
         context "on next" do
-          include_examples "can transition next to", next_state: "contact_email_form"
+          include_examples "has next transition", next_state: "contact_email_form"
         end
 
         context "on back" do
-          include_examples "can transition back to", previous_state: "contact_name_form"
+          include_examples "has back transition", previous_state: "contact_name_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/contact_phone_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/contact_phone_form_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "contact_phone_form") }
+
+    describe "#workflow_state" do
+      context ":contact_phone_form state transitions" do
+        context "on next" do
+          include_examples "can transition next to", next_state: "contact_email_form"
+        end
+
+        context "on back" do
+          include_examples "can transition back to", previous_state: "contact_name_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/contact_postcode_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/contact_postcode_form_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "contact_postcode_form") }
+
+    describe "#workflow_state" do
+      context ":contact_postcode_form state transitions" do
+        context "on next" do
+          context "when the user skip to a manual address" do
+            subject { build(:new_registration, workflow_state: "contact_postcode_form", temp_os_places_error: "foo") }
+
+            include_examples "can transition next to", next_state: "contact_address_manual_form"
+          end
+
+          include_examples "can transition next to", next_state: "contact_address_form"
+        end
+
+        context "on back" do
+          include_examples "can transition back to", previous_state: "contact_email_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/contact_postcode_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/contact_postcode_form_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 module WasteCarriersEngine
   RSpec.describe NewRegistration do
     it_behaves_like "a postcode transition",
-                      previous_state: :contact_email_form,
-                      address_type: "contact",
-                      factory: :new_registration
+                    previous_state: :contact_email_form,
+                    address_type: "contact",
+                    factory: :new_registration
   end
 end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/contact_postcode_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/contact_postcode_form_spec.rb
@@ -4,24 +4,9 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe NewRegistration do
-    subject { build(:new_registration, workflow_state: "contact_postcode_form") }
-
-    describe "#workflow_state" do
-      context ":contact_postcode_form state transitions" do
-        context "on next" do
-          context "when the user skip to a manual address" do
-            subject { build(:new_registration, workflow_state: "contact_postcode_form", temp_os_places_error: "foo") }
-
-            include_examples "can transition next to", next_state: "contact_address_manual_form"
-          end
-
-          include_examples "can transition next to", next_state: "contact_address_form"
-        end
-
-        context "on back" do
-          include_examples "can transition back to", previous_state: "contact_email_form"
-        end
-      end
-    end
+    it_behaves_like "a postcode transition",
+                      previous_state: :contact_email_form,
+                      address_type: "contact",
+                      factory: :new_registration
   end
 end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/conviction_details_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/conviction_details_form_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "conviction_details_form") }
+
+    describe "#workflow_state" do
+      context ":conviction_details_form state transitions" do
+        context "on next" do
+          include_examples "can transition next to", next_state: "contact_name_form"
+        end
+
+        context "on back" do
+          include_examples "can transition back to", previous_state: "declare_convictions_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/conviction_details_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/conviction_details_form_spec.rb
@@ -9,11 +9,11 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":conviction_details_form state transitions" do
         context "on next" do
-          include_examples "can transition next to", next_state: "contact_name_form"
+          include_examples "has next transition", next_state: "contact_name_form"
         end
 
         context "on back" do
-          include_examples "can transition back to", previous_state: "declare_convictions_form"
+          include_examples "has back transition", previous_state: "declare_convictions_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/declaration_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/declaration_form_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "declaration_form") }
+
+    describe "#workflow_state" do
+      context ":declaration_form state transitions" do
+        context "on next" do
+          include_examples "can transition next to", next_state: "cards_form"
+        end
+
+        context "on back" do
+          include_examples "can transition back to", previous_state: "check_your_answers_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/declaration_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/declaration_form_spec.rb
@@ -9,11 +9,11 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":declaration_form state transitions" do
         context "on next" do
-          include_examples "can transition next to", next_state: "cards_form"
+          include_examples "has next transition", next_state: "cards_form"
         end
 
         context "on back" do
-          include_examples "can transition back to", previous_state: "check_your_answers_form"
+          include_examples "has back transition", previous_state: "check_your_answers_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/declare_convictions_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/declare_convictions_form_spec.rb
@@ -12,14 +12,14 @@ module WasteCarriersEngine
           context "if the users has convictions to declare" do
             subject { build(:new_registration, workflow_state: "declare_convictions_form", declared_convictions: "yes") }
 
-            include_examples "can transition next to", next_state: "conviction_details_form"
+            include_examples "has next transition", next_state: "conviction_details_form"
           end
 
-          include_examples "can transition next to", next_state: "contact_name_form"
+          include_examples "has next transition", next_state: "contact_name_form"
         end
 
         context "on back" do
-          include_examples "can transition back to", previous_state: "main_people_form"
+          include_examples "has back transition", previous_state: "main_people_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/declare_convictions_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/declare_convictions_form_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "declare_convictions_form") }
+
+    describe "#workflow_state" do
+      context ":declare_convictions_form state transitions" do
+        context "on next" do
+          context "if the users has convictions to declare" do
+            subject { build(:new_registration, workflow_state: "declare_convictions_form", declared_convictions: "yes") }
+
+            include_examples "can transition next to", next_state: "conviction_details_form"
+          end
+
+          include_examples "can transition next to", next_state: "contact_name_form"
+        end
+
+        context "on back" do
+          include_examples "can transition back to", previous_state: "main_people_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/location_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/location_form_spec.rb
@@ -4,16 +4,46 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe NewRegistration do
-    subject(:new_registration) { build(:new_registration, workflow_state: "location_form") }
+    subject { build(:new_registration, workflow_state: "location_form") }
 
     describe "#workflow_state" do
       context ":location_form state transitions" do
-        context "on back" do
-          it "can transition from a :location_form state to a :start_form" do
-            new_registration.back
+        context "on next" do
+          subject { build(:new_registration, workflow_state: "location_form", location: location) }
 
-            expect(new_registration.workflow_state).to eq("start_form")
+          context "when the location is northern_ireland" do
+            let(:location) { "northern_ireland" }
+
+            include_examples "can transition next to", next_state: "register_in_northern_ireland_form"
           end
+
+          context "when the location is scotland" do
+            let(:location) { "scotland" }
+
+            include_examples "can transition next to", next_state: "register_in_scotland_form"
+          end
+
+          context "when the location is wales" do
+            let(:location) { "wales" }
+
+            include_examples "can transition next to", next_state: "register_in_wales_form"
+          end
+
+          context "when the location is not in the UK" do
+            let(:location) { "overseas" }
+
+            include_examples "can transition next to", next_state: "other_businesses_form"
+          end
+
+          context "when the location is in england" do
+            let(:location) { "england" }
+
+            include_examples "can transition next to", next_state: "business_type_form"
+          end
+        end
+
+        context "on back" do
+          include_examples "can transition back to", previous_state: "start_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/location_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/location_form_spec.rb
@@ -14,36 +14,36 @@ module WasteCarriersEngine
           context "when the location is northern_ireland" do
             let(:location) { "northern_ireland" }
 
-            include_examples "can transition next to", next_state: "register_in_northern_ireland_form"
+            include_examples "has next transition", next_state: "register_in_northern_ireland_form"
           end
 
           context "when the location is scotland" do
             let(:location) { "scotland" }
 
-            include_examples "can transition next to", next_state: "register_in_scotland_form"
+            include_examples "has next transition", next_state: "register_in_scotland_form"
           end
 
           context "when the location is wales" do
             let(:location) { "wales" }
 
-            include_examples "can transition next to", next_state: "register_in_wales_form"
+            include_examples "has next transition", next_state: "register_in_wales_form"
           end
 
           context "when the location is not in the UK" do
             let(:location) { "overseas" }
 
-            include_examples "can transition next to", next_state: "other_businesses_form"
+            include_examples "has next transition", next_state: "other_businesses_form"
           end
 
           context "when the location is in england" do
             let(:location) { "england" }
 
-            include_examples "can transition next to", next_state: "business_type_form"
+            include_examples "has next transition", next_state: "business_type_form"
           end
         end
 
         context "on back" do
-          include_examples "can transition back to", previous_state: "start_form"
+          include_examples "has back transition", previous_state: "start_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/main_people_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/main_people_form_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "main_people_form") }
+
+    describe "#workflow_state" do
+      context ":main_people_form state transitions" do
+        context "on next" do
+          include_examples "can transition next to", next_state: "declare_convictions_form"
+        end
+
+        context "on back" do
+          context "when the registered address was manually entered" do
+            let(:registered_address) { build(:address, :registered, :manual_foreign) }
+            subject { build(:new_registration, workflow_state: "main_people_form", registered_address: registered_address) }
+
+            include_examples "can transition back to", previous_state: "company_address_manual_form"
+          end
+
+          include_examples "can transition back to", previous_state: "company_address_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/main_people_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/main_people_form_spec.rb
@@ -9,7 +9,7 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":main_people_form state transitions" do
         context "on next" do
-          include_examples "can transition next to", next_state: "declare_convictions_form"
+          include_examples "has next transition", next_state: "declare_convictions_form"
         end
 
         context "on back" do
@@ -17,10 +17,10 @@ module WasteCarriersEngine
             let(:registered_address) { build(:address, :registered, :manual_foreign) }
             subject { build(:new_registration, workflow_state: "main_people_form", registered_address: registered_address) }
 
-            include_examples "can transition back to", previous_state: "company_address_manual_form"
+            include_examples "has back transition", previous_state: "company_address_manual_form"
           end
 
-          include_examples "can transition back to", previous_state: "company_address_form"
+          include_examples "has back transition", previous_state: "company_address_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/other_businesses_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/other_businesses_form_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "other_businesses_form") }
+
+    describe "#workflow_state" do
+      context ":other_businesses_form state transitions" do
+        context "on next" do
+          context "when they only carries their own waste" do
+            subject { build(:new_registration, workflow_state: "other_businesses_form", other_businesses: "no") }
+
+            include_examples "can transition next to", next_state: "construction_demolition_form"
+          end
+
+          context "when they carries other's waste too" do
+            include_examples "can transition next to", next_state: "service_provided_form"
+          end
+        end
+
+        context "on back" do
+          context "if the company is based overseas" do
+            subject { build(:new_registration, workflow_state: "other_businesses_form", location: "overseas") }
+
+            include_examples "can transition back to", previous_state: "location_form"
+          end
+
+          include_examples "can transition back to", previous_state: "business_type_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/other_businesses_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/other_businesses_form_spec.rb
@@ -12,11 +12,11 @@ module WasteCarriersEngine
           context "when they only carries their own waste" do
             subject { build(:new_registration, workflow_state: "other_businesses_form", other_businesses: "no") }
 
-            include_examples "can transition next to", next_state: "construction_demolition_form"
+            include_examples "has next transition", next_state: "construction_demolition_form"
           end
 
           context "when they carries other's waste too" do
-            include_examples "can transition next to", next_state: "service_provided_form"
+            include_examples "has next transition", next_state: "service_provided_form"
           end
         end
 
@@ -24,10 +24,10 @@ module WasteCarriersEngine
           context "if the company is based overseas" do
             subject { build(:new_registration, workflow_state: "other_businesses_form", location: "overseas") }
 
-            include_examples "can transition back to", previous_state: "location_form"
+            include_examples "has back transition", previous_state: "location_form"
           end
 
-          include_examples "can transition back to", previous_state: "business_type_form"
+          include_examples "has back transition", previous_state: "business_type_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/payment_summary_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/payment_summary_form_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "payment_summary_form") }
+
+    describe "#workflow_state" do
+      context ":payment_summary_form state transitions" do
+        context "on next" do
+          context "when the user choose to pay by card" do
+            subject { build(:new_registration, workflow_state: "payment_summary_form", temp_payment_method: "card") }
+
+            include_examples "can transition next to", next_state: "worldpay_form"
+          end
+
+          include_examples "can transition next to", next_state: "bank_transfer_form"
+        end
+
+        context "on back" do
+          include_examples "can transition back to", previous_state: "cards_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/payment_summary_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/payment_summary_form_spec.rb
@@ -12,14 +12,14 @@ module WasteCarriersEngine
           context "when the user choose to pay by card" do
             subject { build(:new_registration, workflow_state: "payment_summary_form", temp_payment_method: "card") }
 
-            include_examples "can transition next to", next_state: "worldpay_form"
+            include_examples "has next transition", next_state: "worldpay_form"
           end
 
-          include_examples "can transition next to", next_state: "bank_transfer_form"
+          include_examples "has next transition", next_state: "bank_transfer_form"
         end
 
         context "on back" do
-          include_examples "can transition back to", previous_state: "cards_form"
+          include_examples "has back transition", previous_state: "cards_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/register_in_northern_ireland_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/register_in_northern_ireland_form_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "register_in_northern_ireland_form") }
+
+    describe "#workflow_state" do
+      context ":register_in_northern_ireland_form state transitions" do
+        context "on next" do
+          include_examples "can transition next to", next_state: "business_type_form"
+        end
+
+        context "on back" do
+          include_examples "can transition back to", previous_state: "location_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/register_in_northern_ireland_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/register_in_northern_ireland_form_spec.rb
@@ -9,11 +9,11 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":register_in_northern_ireland_form state transitions" do
         context "on next" do
-          include_examples "can transition next to", next_state: "business_type_form"
+          include_examples "has next transition", next_state: "business_type_form"
         end
 
         context "on back" do
-          include_examples "can transition back to", previous_state: "location_form"
+          include_examples "has back transition", previous_state: "location_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/register_in_scotland_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/register_in_scotland_form_spec.rb
@@ -9,11 +9,11 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":register_in_scotland_form state transitions" do
         context "on next" do
-          include_examples "can transition next to", next_state: "business_type_form"
+          include_examples "has next transition", next_state: "business_type_form"
         end
 
         context "on back" do
-          include_examples "can transition back to", previous_state: "location_form"
+          include_examples "has back transition", previous_state: "location_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/register_in_scotland_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/register_in_scotland_form_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "register_in_scotland_form") }
+
+    describe "#workflow_state" do
+      context ":register_in_scotland_form state transitions" do
+        context "on next" do
+          include_examples "can transition next to", next_state: "business_type_form"
+        end
+
+        context "on back" do
+          include_examples "can transition back to", previous_state: "location_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/register_in_wales_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/register_in_wales_form_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "register_in_wales_form") }
+
+    describe "#workflow_state" do
+      context ":register_in_wales_form state transitions" do
+        context "on next" do
+          include_examples "can transition next to", next_state: "business_type_form"
+        end
+
+        context "on back" do
+          include_examples "can transition back to", previous_state: "location_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/register_in_wales_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/register_in_wales_form_spec.rb
@@ -9,11 +9,11 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":register_in_wales_form state transitions" do
         context "on next" do
-          include_examples "can transition next to", next_state: "business_type_form"
+          include_examples "has next transition", next_state: "business_type_form"
         end
 
         context "on back" do
-          include_examples "can transition back to", previous_state: "location_form"
+          include_examples "has back transition", previous_state: "location_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/registration_number_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/registration_number_form_spec.rb
@@ -9,11 +9,11 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":registration_number_form state transitions" do
         context "on next" do
-          include_examples "can transition next to", next_state: "company_name_form"
+          include_examples "has next transition", next_state: "company_name_form"
         end
 
         context "on back" do
-          include_examples "can transition back to", previous_state: "cbd_type_form"
+          include_examples "has back transition", previous_state: "cbd_type_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/registration_number_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/registration_number_form_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "registration_number_form") }
+
+    describe "#workflow_state" do
+      context ":registration_number_form state transitions" do
+        context "on next" do
+          include_examples "can transition next to", next_state: "company_name_form"
+        end
+
+        context "on back" do
+          include_examples "can transition back to", previous_state: "cbd_type_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/renew_registration_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/renew_registration_form_spec.rb
@@ -9,7 +9,7 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":renew_registration_form state transitions" do
         context "on back" do
-          include_examples "can transition back to", previous_state: "start_form"
+          include_examples "has back transition", previous_state: "start_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/renew_registration_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/renew_registration_form_spec.rb
@@ -4,16 +4,12 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe NewRegistration do
-    subject(:new_registration) { build(:new_registration, workflow_state: "renew_registration_form") }
+    subject { build(:new_registration, workflow_state: "renew_registration_form") }
 
     describe "#workflow_state" do
       context ":renew_registration_form state transitions" do
         context "on back" do
-          it "can transition from a :renew_registration_form state to a :start_form" do
-            new_registration.back
-
-            expect(new_registration.workflow_state).to eq("start_form")
-          end
+          include_examples "can transition back to", previous_state: "start_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/service_provided_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/service_provided_form_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "service_provided_form") }
+
+    describe "#workflow_state" do
+      context ":service_provided_form state transitions" do
+        context "on next" do
+          context "when waste is their main service" do
+            subject { build(:new_registration, workflow_state: "service_provided_form", is_main_service: "yes") }
+
+            include_examples "can transition next to", next_state: "waste_types_form"
+          end
+
+          context "when waste is not their main service" do
+            include_examples "can transition next to", next_state: "construction_demolition_form"
+          end
+        end
+
+        context "on back" do
+          include_examples "can transition back to", previous_state: "other_businesses_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/service_provided_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/service_provided_form_spec.rb
@@ -12,16 +12,16 @@ module WasteCarriersEngine
           context "when waste is their main service" do
             subject { build(:new_registration, workflow_state: "service_provided_form", is_main_service: "yes") }
 
-            include_examples "can transition next to", next_state: "waste_types_form"
+            include_examples "has next transition", next_state: "waste_types_form"
           end
 
           context "when waste is not their main service" do
-            include_examples "can transition next to", next_state: "construction_demolition_form"
+            include_examples "has next transition", next_state: "construction_demolition_form"
           end
         end
 
         context "on back" do
-          include_examples "can transition back to", previous_state: "other_businesses_form"
+          include_examples "has back transition", previous_state: "other_businesses_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/start_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/start_form_spec.rb
@@ -12,21 +12,13 @@ module WasteCarriersEngine
           context "when the temp_start_option is `renew`" do
             let(:temp_start_option) { WasteCarriersEngine::StartForm::RENEW }
 
-            it "can transition from a :start_form state to a :renew_registration_form" do
-              new_registration.next
-
-              expect(new_registration.workflow_state).to eq("renew_registration_form")
-            end
+            include_examples "can transition next to", next_state: "renew_registration_form"
           end
 
           context "when the temp_start_option is `new`" do
             let(:temp_start_option) { WasteCarriersEngine::StartForm::NEW }
 
-            it "can transition from a :start_form state to a :location_form" do
-              new_registration.next
-
-              expect(new_registration.workflow_state).to eq("location_form")
-            end
+            include_examples "can transition next to", next_state: "location_form"
           end
         end
       end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/start_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/start_form_spec.rb
@@ -12,13 +12,13 @@ module WasteCarriersEngine
           context "when the temp_start_option is `renew`" do
             let(:temp_start_option) { WasteCarriersEngine::StartForm::RENEW }
 
-            include_examples "can transition next to", next_state: "renew_registration_form"
+            include_examples "has next transition", next_state: "renew_registration_form"
           end
 
           context "when the temp_start_option is `new`" do
             let(:temp_start_option) { WasteCarriersEngine::StartForm::NEW }
 
-            include_examples "can transition next to", next_state: "location_form"
+            include_examples "has next transition", next_state: "location_form"
           end
         end
       end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/waste_types_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/waste_types_form_spec.rb
@@ -19,18 +19,18 @@ module WasteCarriersEngine
             let(:lower_tier) { true }
 
             # TODO: Fix me when implement lower-tier journey
-            include_examples "can transition next to", next_state: "cannot_renew_lower_tier_form"
+            include_examples "has next transition", next_state: "cannot_renew_lower_tier_form"
           end
 
           context "when the result of smart answers is upper-tier" do
             let(:lower_tier) { false }
 
-            include_examples "can transition next to", next_state: "cbd_type_form"
+            include_examples "has next transition", next_state: "cbd_type_form"
           end
         end
 
         context "on back" do
-          include_examples "can transition back to", previous_state: "service_provided_form"
+          include_examples "has back transition", previous_state: "service_provided_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/waste_types_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/waste_types_form_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "waste_types_form") }
+
+    describe "#workflow_state" do
+      context ":waste_types_form state transitions" do
+        context "on next" do
+          let(:smart_answer_checker_service) { double(:smart_answer_checker_service, lower_tier?: lower_tier) }
+
+          before do
+            allow(SmartAnswersCheckerService).to receive(:new).and_return(smart_answer_checker_service)
+          end
+
+          context "when the result of smart answers is lower-tier" do
+            let(:lower_tier) { true }
+
+            # TODO: Fix me when implement lower-tier journey
+            include_examples "can transition next to", next_state: "cannot_renew_lower_tier_form"
+          end
+
+          context "when the result of smart answers is upper-tier" do
+            let(:lower_tier) { false }
+
+            include_examples "can transition next to", next_state: "cbd_type_form"
+          end
+        end
+
+        context "on back" do
+          include_examples "can transition back to", previous_state: "service_provided_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/waste_carriers_engine/business_type_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/business_type_forms_spec.rb
@@ -6,11 +6,24 @@ module WasteCarriersEngine
   RSpec.describe "BusinessTypeForms", type: :request do
     include_examples "GET flexible form", "business_type_form"
 
-    include_examples "POST renewal form",
-                     "business_type_form",
-                     valid_params: { business_type: "limitedCompany" },
-                     invalid_params: { business_type: "foo" },
-                     test_attribute: :business_type
+    describe "POST business_type_form_path" do
+      include_examples "POST renewal form",
+                       "business_type_form",
+                       valid_params: { business_type: "limitedCompany" },
+                       invalid_params: { business_type: "foo" },
+                       test_attribute: :business_type
+
+      context "When the transient_registration is a new registration" do
+        let(:transient_registration) do
+          create(:new_registration, workflow_state: "business_type_form")
+        end
+
+        include_examples "POST form",
+                         "business_type_form",
+                         valid_params: { business_type: "limitedCompany" },
+                         invalid_params: { business_type: "foo" }
+      end
+    end
 
     describe "GET back_business_type_forms_path" do
       context "when a valid user is signed in" do

--- a/spec/requests/waste_carriers_engine/cards_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/cards_forms_spec.rb
@@ -6,11 +6,24 @@ module WasteCarriersEngine
   RSpec.describe "CardsForms", type: :request do
     include_examples "GET locked-in form", "cards_form"
 
-    include_examples "POST renewal form",
-                     "cards_form",
-                     valid_params: { temp_cards: 2 },
-                     invalid_params: { temp_cards: 999_999 },
-                     test_attribute: :temp_cards
+    describe "POST cards_form_path" do
+      include_examples "POST renewal form",
+                       "cards_form",
+                       valid_params: { temp_cards: 2 },
+                       invalid_params: { temp_cards: 999_999 },
+                       test_attribute: :temp_cards
+
+      context "When the transient_registration is a new registration" do
+        let(:transient_registration) do
+          create(:new_registration, workflow_state: "cards_form")
+        end
+
+        include_examples "POST form",
+                         "cards_form",
+                         valid_params: { temp_cards: 2 },
+                         invalid_params: { temp_cards: 999_999 }
+      end
+    end
 
     describe "GET back_cards_forms_path" do
       context "when a valid user is signed in" do

--- a/spec/requests/waste_carriers_engine/cbd_type_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/cbd_type_forms_spec.rb
@@ -6,11 +6,24 @@ module WasteCarriersEngine
   RSpec.describe "CbdTypeForms", type: :request do
     include_examples "GET flexible form", "cbd_type_form"
 
-    include_examples "POST renewal form",
-                     "cbd_type_form",
-                     valid_params: { registration_type: "broker_dealer" },
-                     invalid_params: { registration_type: "foo" },
-                     test_attribute: :registration_type
+    describe "POST cbd_type_form_path" do
+      include_examples "POST renewal form",
+                       "cbd_type_form",
+                       valid_params: { registration_type: "broker_dealer" },
+                       invalid_params: { registration_type: "foo" },
+                       test_attribute: :registration_type
+
+      context "When the transient_registration is a new registration" do
+        let(:transient_registration) do
+          create(:new_registration, workflow_state: "cbd_type_form")
+        end
+
+        include_examples "POST form",
+                         "cbd_type_form",
+                         valid_params: { registration_type: "broker_dealer" },
+                         invalid_params: { registration_type: "foo" }
+      end
+    end
 
     describe "GET back_cbd_type_forms_path" do
       context "when a valid user is signed in" do

--- a/spec/requests/waste_carriers_engine/company_name_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/company_name_forms_spec.rb
@@ -6,11 +6,24 @@ module WasteCarriersEngine
   RSpec.describe "CompanyNameForms", type: :request do
     include_examples "GET flexible form", "company_name_form"
 
-    include_examples "POST renewal form",
-                     "company_name_form",
-                     valid_params: { company_name: "WasteCo Ltd" },
-                     invalid_params: { company_name: "" },
-                     test_attribute: :company_name
+    describe "POST company_name_form_path" do
+      include_examples "POST renewal form",
+                       "company_name_form",
+                       valid_params: { company_name: "WasteCo Ltd" },
+                       invalid_params: { company_name: "" },
+                       test_attribute: :company_name
+
+      context "When the transient_registration is a new registration" do
+        let(:transient_registration) do
+          create(:new_registration, workflow_state: "company_name_form")
+        end
+
+        include_examples "POST form",
+                         "company_name_form",
+                         valid_params: { company_name: "WasteCo Ltd" },
+                         invalid_params: { company_name: "" }
+      end
+    end
 
     describe "GET back_company_name_forms_path" do
       context "when a valid user is signed in" do

--- a/spec/requests/waste_carriers_engine/construction_demolition_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/construction_demolition_forms_spec.rb
@@ -6,11 +6,24 @@ module WasteCarriersEngine
   RSpec.describe "ConstructionDemolitionForms", type: :request do
     include_examples "GET flexible form", "construction_demolition_form"
 
-    include_examples "POST renewal form",
-                     "construction_demolition_form",
-                     valid_params: { construction_waste: "yes" },
-                     invalid_params: { construction_waste: "foo" },
-                     test_attribute: :construction_waste
+    describe "POST construction_demolition_form_path" do
+      include_examples "POST renewal form",
+                       "construction_demolition_form",
+                       valid_params: { construction_waste: "yes" },
+                       invalid_params: { construction_waste: "foo" },
+                       test_attribute: :construction_waste
+
+      context "When the transient_registration is a new registration" do
+        let(:transient_registration) do
+          create(:new_registration, workflow_state: "construction_demolition_form")
+        end
+
+        include_examples "POST form",
+                         "construction_demolition_form",
+                         valid_params: { construction_waste: "yes" },
+                         invalid_params: { construction_waste: "foo" }
+      end
+    end
 
     describe "GET back_construction_demolition_forms_path" do
       context "when a valid user is signed in" do

--- a/spec/requests/waste_carriers_engine/contact_email_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/contact_email_forms_spec.rb
@@ -6,13 +6,24 @@ module WasteCarriersEngine
   RSpec.describe "ContactEmailForms", type: :request do
     include_examples "GET flexible form", "contact_email_form"
 
-    include_examples "POST renewal form",
-                     "contact_email_form",
-                     valid_params: { contact_email: "bar.baz@example.com",
-                                     confirmed_email: "bar.baz@example.com" },
-                     invalid_params: { contact_email: "bar",
-                                       confirmed_email: "baz" },
-                     test_attribute: :contact_email
+    describe "POST contact_email_form_path" do
+      include_examples "POST renewal form",
+                       "contact_email_form",
+                       valid_params: { contact_email: "bar.baz@example.com", confirmed_email: "bar.baz@example.com" },
+                       invalid_params: { contact_email: "bar", confirmed_email: "baz" },
+                       test_attribute: :contact_email
+
+      context "When the transient_registration is a new registration" do
+        let(:transient_registration) do
+          create(:new_registration, workflow_state: "contact_email_form")
+        end
+
+        include_examples "POST form",
+                         "contact_email_form",
+                         valid_params: { contact_email: "bar.baz@example.com", confirmed_email: "bar.baz@example.com" },
+                         invalid_params: { contact_email: "bar", confirmed_email: "baz" }
+      end
+    end
 
     describe "GET back_contact_email_forms_path" do
       context "when a valid user is signed in" do

--- a/spec/requests/waste_carriers_engine/contact_name_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/contact_name_forms_spec.rb
@@ -6,13 +6,24 @@ module WasteCarriersEngine
   RSpec.describe "ContactNameForms", type: :request do
     include_examples "GET flexible form", "contact_name_form"
 
-    include_examples "POST renewal form",
-                     "contact_name_form",
-                     valid_params: { first_name: "Foo",
-                                     last_name: "Bar" },
-                     invalid_params: { first_name: "",
-                                       last_name: "" },
-                     test_attribute: :contact_name
+    describe "POST contact_name_form_path" do
+      include_examples "POST renewal form",
+                       "contact_name_form",
+                       valid_params: { first_name: "Foo", last_name: "Bar" },
+                       invalid_params: { first_name: "", last_name: "" },
+                       test_attribute: :contact_name
+
+      context "When the transient_registration is a new registration" do
+        let(:transient_registration) do
+          create(:new_registration, workflow_state: "contact_name_form")
+        end
+
+        include_examples "POST form",
+                         "contact_name_form",
+                         valid_params: { first_name: "Foo", last_name: "Bar" },
+                         invalid_params: { first_name: "", last_name: "" }
+      end
+    end
 
     describe "GET back_contact_name_forms_path" do
       context "when a valid user is signed in" do

--- a/spec/requests/waste_carriers_engine/contact_phone_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/contact_phone_forms_spec.rb
@@ -6,11 +6,24 @@ module WasteCarriersEngine
   RSpec.describe "ContactPhoneForms", type: :request do
     include_examples "GET flexible form", "contact_phone_form"
 
-    include_examples "POST renewal form",
-                     "contact_phone_form",
-                     valid_params: { phone_number: "01234 567890" },
-                     invalid_params: { phone_number: "foo" },
-                     test_attribute: :phone_number
+    describe "POST contact_phone_form_path" do
+      include_examples "POST renewal form",
+                       "contact_phone_form",
+                       valid_params: { phone_number: "01234 567890" },
+                       invalid_params: { phone_number: "foo" },
+                       test_attribute: :phone_number
+
+      context "When the transient_registration is a new registration" do
+        let(:transient_registration) do
+          create(:new_registration, workflow_state: "contact_phone_form")
+        end
+
+        include_examples "POST form",
+                         "contact_phone_form",
+                         valid_params: { phone_number: "01234 567890" },
+                         invalid_params: { phone_number: "foo" }
+      end
+    end
 
     describe "GET back_contact_phone_forms_path" do
       context "when a valid user is signed in" do

--- a/spec/requests/waste_carriers_engine/declaration_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/declaration_forms_spec.rb
@@ -10,11 +10,24 @@ module WasteCarriersEngine
 
     include_examples "GET locked-in form", "declaration_form"
 
-    include_examples "POST renewal form",
-                     "declaration_form",
-                     valid_params: { declaration: 1 },
-                     invalid_params: { declaration: "foo" },
-                     test_attribute: :declaration
+    describe "POST declaration_form_path" do
+      include_examples "POST renewal form",
+                       "declaration_form",
+                       valid_params: { declaration: 1 },
+                       invalid_params: { declaration: "foo" },
+                       test_attribute: :declaration
+
+      context "When the transient_registration is a new registration" do
+        let(:transient_registration) do
+          create(:new_registration, workflow_state: "declaration_form")
+        end
+
+        include_examples "POST form",
+                         "declaration_form",
+                         valid_params: { declaration: 1 },
+                         invalid_params: { declaration: "foo" }
+      end
+    end
 
     describe "POST declaration_forms_path" do
       context "when a valid user is signed in" do

--- a/spec/requests/waste_carriers_engine/declare_convictions_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/declare_convictions_forms_spec.rb
@@ -6,11 +6,24 @@ module WasteCarriersEngine
   RSpec.describe "DeclareConvictionsForms", type: :request do
     include_examples "GET flexible form", "declare_convictions_form"
 
-    include_examples "POST renewal form",
-                     "declare_convictions_form",
-                     valid_params: { declared_convictions: "yes" },
-                     invalid_params: { declared_convictions: "foo" },
-                     test_attribute: :declared_convictions
+    describe "POST declare_convictions_form_path" do
+      include_examples "POST renewal form",
+                       "declare_convictions_form",
+                       valid_params: { declared_convictions: "yes" },
+                       invalid_params: { declared_convictions: "foo" },
+                       test_attribute: :declared_convictions
+
+      context "When the transient_registration is a new registration" do
+        let(:transient_registration) do
+          create(:new_registration, workflow_state: "declare_convictions_form")
+        end
+
+        include_examples "POST form",
+                         "declare_convictions_form",
+                         valid_params: { declared_convictions: "yes" },
+                         invalid_params: { declared_convictions: "foo" }
+      end
+    end
 
     describe "GET back_declare_convictions_forms_path" do
       context "when a valid user is signed in" do

--- a/spec/requests/waste_carriers_engine/location_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/location_forms_spec.rb
@@ -6,11 +6,24 @@ module WasteCarriersEngine
   RSpec.describe "LocationForms", type: :request do
     include_examples "GET flexible form", "location_form"
 
-    include_examples "POST renewal form",
-                     "location_form",
-                     valid_params: { location: "england" },
-                     invalid_params: { location: "foo" },
-                     test_attribute: :location
+    describe "POST location_form_path" do
+      include_examples "POST renewal form",
+                       "location_form",
+                       valid_params: { location: "england" },
+                       invalid_params: { location: "foo" },
+                       test_attribute: :location
+
+      context "When the transient_registration is a new registration" do
+        let(:transient_registration) do
+          create(:new_registration, workflow_state: "location_form")
+        end
+
+        include_examples "POST form",
+                         "location_form",
+                         valid_params: { location: "england" },
+                         invalid_params: { location: "foo" }
+      end
+    end
 
     describe "GET back_location_forms_path" do
       context "when a valid user is signed in" do

--- a/spec/requests/waste_carriers_engine/other_businesses_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/other_businesses_forms_spec.rb
@@ -6,11 +6,24 @@ module WasteCarriersEngine
   RSpec.describe "OtherBusinessesForms", type: :request do
     include_examples "GET flexible form", "other_businesses_form"
 
-    include_examples "POST renewal form",
-                     "other_businesses_form",
-                     valid_params: { other_businesses: "yes" },
-                     invalid_params: { other_businesses: "foo" },
-                     test_attribute: :other_businesses
+    describe "POST other_businesses_form_path" do
+      include_examples "POST renewal form",
+                       "other_businesses_form",
+                       valid_params: { other_businesses: "yes" },
+                       invalid_params: { other_businesses: "foo" },
+                       test_attribute: :other_businesses
+
+      context "When the transient_registration is a new registration" do
+        let(:transient_registration) do
+          create(:new_registration, workflow_state: "other_businesses_form")
+        end
+
+        include_examples "POST form",
+                         "other_businesses_form",
+                         valid_params: { other_businesses: "yes" },
+                         invalid_params: { other_businesses: "foo" }
+      end
+    end
 
     describe "GET back_other_businesses_forms_path" do
       context "when a valid user is signed in" do

--- a/spec/requests/waste_carriers_engine/payment_summary_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/payment_summary_forms_spec.rb
@@ -6,11 +6,24 @@ module WasteCarriersEngine
   RSpec.describe "PaymentSummaryForms", type: :request do
     include_examples "GET locked-in form", "payment_summary_form"
 
-    include_examples "POST renewal form",
-                     "payment_summary_form",
-                     valid_params: { temp_payment_method: "card" },
-                     invalid_params: { temp_payment_method: "foo" },
-                     test_attribute: :temp_payment_method
+    describe "POST payment_summary_form_path" do
+      include_examples "POST renewal form",
+                       "payment_summary_form",
+                       valid_params: { temp_payment_method: "card" },
+                       invalid_params: { temp_payment_method: "foo" },
+                       test_attribute: :temp_payment_method
+
+      context "When the transient_registration is a new registration" do
+        let(:transient_registration) do
+          create(:new_registration, workflow_state: "payment_summary_form")
+        end
+
+        include_examples "POST form",
+                         "payment_summary_form",
+                         valid_params: { temp_payment_method: "card" },
+                         invalid_params: { temp_payment_method: "foo" }
+      end
+    end
 
     describe "GET back_payment_summary_forms_path" do
       context "when a valid user is signed in" do

--- a/spec/requests/waste_carriers_engine/service_provided_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/service_provided_forms_spec.rb
@@ -6,11 +6,24 @@ module WasteCarriersEngine
   RSpec.describe "ServiceProvidedForms", type: :request do
     include_examples "GET flexible form", "service_provided_form"
 
-    include_examples "POST renewal form",
-                     "service_provided_form",
-                     valid_params: { is_main_service: "yes" },
-                     invalid_params: { is_main_service: "foo" },
-                     test_attribute: :is_main_service
+    describe "POST service_provided_form_path" do
+      include_examples "POST renewal form",
+                       "service_provided_form",
+                       valid_params: { is_main_service: "yes" },
+                       invalid_params: { is_main_service: "foo" },
+                       test_attribute: :is_main_service
+
+      context "When the transient_registration is a new registration" do
+        let(:transient_registration) do
+          create(:new_registration, workflow_state: "service_provided_form")
+        end
+
+        include_examples "POST form",
+                         "service_provided_form",
+                         valid_params: { is_main_service: "yes" },
+                         invalid_params: { is_main_service: "foo" }
+      end
+    end
 
     describe "GET back_service_provided_forms_path" do
       context "when a valid user is signed in" do

--- a/spec/requests/waste_carriers_engine/waste_types_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/waste_types_forms_spec.rb
@@ -6,11 +6,24 @@ module WasteCarriersEngine
   RSpec.describe "WasteTypesForms", type: :request do
     include_examples "GET flexible form", "waste_types_form"
 
-    include_examples "POST renewal form",
-                     "waste_types_form",
-                     valid_params: { only_amf: "yes" },
-                     invalid_params: { only_amf: "foo" },
-                     test_attribute: :only_amf
+    describe "POST waste_types_form_path" do
+      include_examples "POST renewal form",
+                       "waste_types_form",
+                       valid_params: { only_amf: "yes" },
+                       invalid_params: { only_amf: "foo" },
+                       test_attribute: :only_amf
+
+      context "When the transient_registration is a new registration" do
+        let(:transient_registration) do
+          create(:new_registration, workflow_state: "waste_types_form")
+        end
+
+        include_examples "POST form",
+                         "waste_types_form",
+                         valid_params: { only_amf: "yes" },
+                         invalid_params: { only_amf: "foo" }
+      end
+    end
 
     describe "GET back_waste_types_forms_path" do
       context "when a valid user is signed in" do

--- a/spec/support/shared_examples/post_form.rb
+++ b/spec/support/shared_examples/post_form.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# When a user submits a form, that form must match the expected workflow_state.
+# We don't adjust the state to match what the user is doing like we do for viewing forms.
+
+# We expect to receive the name of the form (for example, location_form), and a set of options.
+# Options can include valid params, invalid params, and an attribute to test persistence.
+RSpec.shared_examples "POST form" do |form, options|
+  let(:valid_params) { options[:valid_params] }
+  let(:invalid_params) { options[:invalid_params] }
+
+  context "when the params are valid" do
+    it "updates the transient registration's workflow_state and returns a 302 http status" do
+      state_before_request = transient_registration.workflow_state
+
+      post_form_with_params(form, transient_registration.token, valid_params)
+
+      transient_registration.reload
+
+      expect(transient_registration.workflow_state).to_not eq(state_before_request)
+      expect(response).to have_http_status(302)
+    end
+  end
+
+  context "when the params are invalid" do
+    it "does not update the transient registration's workflow_state, returns a 200 response and show the form again" do
+      state_before_request = transient_registration.workflow_state
+
+      post_form_with_params(form, transient_registration.token, invalid_params)
+
+      transient_registration.reload
+
+      expect(transient_registration.workflow_state).to eq(state_before_request)
+      expect(response).to have_http_status(200)
+      expect(response).to render_template("#{form}s/new")
+    end
+  end
+end

--- a/spec/support/shared_examples/post_renewal_form.rb
+++ b/spec/support/shared_examples/post_renewal_form.rb
@@ -48,6 +48,8 @@ RSpec.shared_examples "POST renewal form" do |form, options|
         end
 
         context "when the params are valid" do
+          # NOTE: Keep me and put in shared POST.
+          # Fix so we test all persisted data. Data comes from options.
           it "updates the transient registration" do
             # If we've specified the value we want to get after updating, use that
             # Otherwise, expect the value submitted in params
@@ -83,6 +85,7 @@ RSpec.shared_examples "POST renewal form" do |form, options|
         end
 
         context "when the params are empty" do
+          # NOTE: Kill it
           it "does not throw an error" do
             # rubocop:disable Style/BlockDelimiters
             expect {
@@ -108,6 +111,7 @@ RSpec.shared_examples "POST renewal form" do |form, options|
         end
       end
 
+      # Externalise is own shared scenario
       context "when the workflow_state does not match the requested form" do
         before do
           # We need to pick a different but also valid state for the transient_registration

--- a/spec/support/shared_examples/post_renewal_form.rb
+++ b/spec/support/shared_examples/post_renewal_form.rb
@@ -20,7 +20,7 @@ RSpec.shared_examples "POST renewal form" do |form, options|
     end
 
     context "when no transient registration is found" do
-      it "redirects to the incalid page" do
+      it "redirects to the invalid page" do
         post_form_with_params(form, "foo")
 
         expect(response).to redirect_to(page_path("invalid"))

--- a/spec/support/shared_examples/workflow_states/a_manual_address_transition.rb
+++ b/spec/support/shared_examples/workflow_states/a_manual_address_transition.rb
@@ -3,12 +3,11 @@
 RSpec.shared_examples "a manual address transition" do |previous_state_if_overseas:, next_state:, address_type:, factory:|
   describe "#workflow_state" do
     current_state = "#{address_type}_address_manual_form".to_sym
-    subject(:subject) { create(factory, workflow_state: current_state) }
+    subject { build(factory, workflow_state: current_state, location: location) }
 
     context "when subject.overseas? is false" do
       previous_state_if_uk = "#{address_type}_postcode_form".to_sym
-
-      before(:each) { subject.location = "england" }
+      let(:location) { "england" }
 
       it "can only transition to either #{previous_state_if_uk} or #{next_state}" do
         permitted_states = Helpers::WorkflowStates.permitted_states(subject)
@@ -26,7 +25,7 @@ RSpec.shared_examples "a manual address transition" do |previous_state_if_overse
     end
 
     context "when subject.overseas? is true" do
-      before(:each) { subject.location = "overseas" }
+      let(:location) { "overseas" }
 
       it "can only transition to #{previous_state_if_overseas} or #{next_state}" do
         permitted_states = Helpers::WorkflowStates.permitted_states(subject)

--- a/spec/support/shared_examples/workflow_states/a_simple_monodirectional_transition.rb
+++ b/spec/support/shared_examples/workflow_states/a_simple_monodirectional_transition.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
+# TODO: Kill this and use `has back transition` and `has next transition` instead
 RSpec.shared_examples "a simple monodirectional transition" do |previous_and_next_state:, current_state:, factory:|
   context "when a subject's state is #{current_state}" do
-    subject(:subject) { create(factory, workflow_state: current_state) }
-
-    it "can only transition to #{previous_and_next_state}" do
-      permitted_states = Helpers::WorkflowStates.permitted_states(subject)
-      expect(permitted_states).to match_array([previous_and_next_state])
-    end
+    subject(:subject) { build(factory) }
 
     it "changes to #{previous_and_next_state} after the 'next' event" do
       expect(subject).to transition_from(current_state).to(previous_and_next_state).on_event(:next)

--- a/spec/support/shared_examples/workflow_states/an_address_lookup_transition.rb
+++ b/spec/support/shared_examples/workflow_states/an_address_lookup_transition.rb
@@ -12,12 +12,6 @@ RSpec.shared_examples "an address lookup transition" do |next_state_if_not_skipp
 
       before(:each) { subject.temp_os_places_error = nil }
 
-      it "can only transition to either #{previous_state}, #{next_state}, or #{alt_state}" do
-        permitted_states = Helpers::WorkflowStates.permitted_states(subject)
-
-        expect(permitted_states).to match_array([previous_state, next_state, alt_state])
-      end
-
       it "changes to #{next_state} after the 'next' event" do
         expect(subject).to transition_from(current_state).to(next_state).on_event(:next)
       end
@@ -38,12 +32,6 @@ RSpec.shared_examples "an address lookup transition" do |next_state_if_not_skipp
       next_state = "#{address_type}_address_manual_form".to_sym
 
       before(:each) { subject.temp_os_places_error = true }
-
-      it "can only transition to either #{previous_state} or #{next_state}" do
-        permitted_states = Helpers::WorkflowStates.permitted_states(subject)
-
-        expect(permitted_states).to match_array([previous_state, next_state])
-      end
 
       it "changes to #{next_state} after the 'next' event" do
         expect(subject).to transition_from(current_state).to(next_state).on_event(:next)

--- a/spec/support/shared_examples/workflow_states/can_transition_back_to.rb
+++ b/spec/support/shared_examples/workflow_states/can_transition_back_to.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.shared_examples "can transition back to" do |previous_state:|
-  it "can transition back to #{previous_state}" do
-    subject.back
-
-    expect(subject.workflow_state).to eq(previous_state)
-  end
-end

--- a/spec/support/shared_examples/workflow_states/can_transition_back_to.rb
+++ b/spec/support/shared_examples/workflow_states/can_transition_back_to.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "can transition back to" do |previous_state:|
+  it "can transition back to #{previous_state}" do
+    subject.back
+
+    expect(subject.workflow_state).to eq(previous_state)
+  end
+end

--- a/spec/support/shared_examples/workflow_states/can_transition_next_to.rb
+++ b/spec/support/shared_examples/workflow_states/can_transition_next_to.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "can transition next to" do |next_state:|
+  it "can transition next to #{next_state}" do
+    subject.next
+
+    expect(subject.workflow_state).to eq(next_state)
+  end
+end

--- a/spec/support/shared_examples/workflow_states/can_transition_next_to.rb
+++ b/spec/support/shared_examples/workflow_states/can_transition_next_to.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.shared_examples "can transition next to" do |next_state:|
-  it "can transition next to #{next_state}" do
-    subject.next
-
-    expect(subject.workflow_state).to eq(next_state)
-  end
-end

--- a/spec/support/shared_examples/workflow_states/has_back_transition.rb
+++ b/spec/support/shared_examples/workflow_states/has_back_transition.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "has back transition" do |previous_state:|
+  it "can transition to #{previous_state}" do
+    current_state = subject.workflow_state
+
+    expect(subject).to transition_from(current_state).to(previous_state).on_event(:back)
+  end
+end

--- a/spec/support/shared_examples/workflow_states/has_next_transition.rb
+++ b/spec/support/shared_examples/workflow_states/has_next_transition.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "has next transition" do |next_state:|
+  it "can transition to #{next_state}" do
+    current_state = subject.workflow_state
+
+    expect(subject).to transition_from(current_state).to(next_state).on_event(:next)
+  end
+end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-915

This PR includes the code necessary to create an upper-tier workflow for new registrations.
The majority of the work is on the test suite, while the rest of the work is on the state machine and the used forms are all already been built and shared with Edit and Renewals.
