### PR TITLE
Set Lower Tier and Upper tier in new registration journey

### DIFF
--- a/spec/factories/new_registration.rb
+++ b/spec/factories/new_registration.rb
@@ -2,5 +2,12 @@
 
 FactoryBot.define do
   factory :new_registration, class: WasteCarriersEngine::NewRegistration do
+    trait :upper do
+      tier { WasteCarriersEngine::NewRegistration::UPPER_TIER }
+    end
+
+    trait :lower do
+      tier { WasteCarriersEngine::NewRegistration::LOWER_TIER }
+    end
   end
 end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/business_type_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/business_type_form_spec.rb
@@ -12,8 +12,11 @@ module WasteCarriersEngine
           context "when the business type is a lower tier specific type" do
             subject { build(:new_registration, workflow_state: "business_type_form", business_type: "charity") }
 
-            # TODO: Fix when implementing lower tier flow
-            include_examples "has next transition", next_state: "cannot_renew_lower_tier_form"
+            include_examples "has next transition", next_state: "company_name_form"
+
+            it "updates the tier of the object to LOWER" do
+              expect { subject.next }.to change { subject.tier }.to(WasteCarriersEngine::NewRegistration::LOWER_TIER)
+            end
           end
 
           include_examples "has next transition", next_state: "other_businesses_form"

--- a/spec/models/waste_carriers_engine/new_registration_workflow/company_name_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/company_name_form_spec.rb
@@ -19,13 +19,31 @@ module WasteCarriersEngine
         end
 
         context "on back" do
-          context "when the business requires a registration number" do
-            subject { build(:new_registration, workflow_state: "company_name_form", business_type: "limitedCompany") }
+          context "when the business does not requires a registration number and the registration is upper tier" do
+            subject { build(:new_registration, :upper, workflow_state: "company_name_form", location: "overseas") }
 
-            include_examples "has back transition", previous_state: "registration_number_form"
+            include_examples "has back transition", previous_state: "cbd_type_form"
           end
 
-          include_examples "has back transition", previous_state: "cbd_type_form"
+          context "when the registration is lower tier" do
+            subject { build(:new_registration, :lower, workflow_state: "company_name_form") }
+
+            include_examples "has back transition", previous_state: "waste_types_form"
+
+            context "when the waste is the company's main service" do
+              subject { build(:new_registration, :lower, workflow_state: "company_name_form", is_main_service: "yes") }
+
+              include_examples "has back transition", previous_state: "construction_demolition_form"
+            end
+          end
+
+          context "when the registration's company is a charity" do
+            subject { build(:new_registration, workflow_state: "company_name_form", business_type: "charity") }
+
+            include_examples "has back transition", previous_state: "business_type_form"
+          end
+
+          include_examples "has back transition", previous_state: "registration_number_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/construction_demolition_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/construction_demolition_form_spec.rb
@@ -18,14 +18,21 @@ module WasteCarriersEngine
           context "when the result of smart answers is lower-tier" do
             let(:lower_tier) { true }
 
-            # TODO: Fix me when implement lower-tier journey
-            include_examples "has next transition", next_state: "cannot_renew_lower_tier_form"
+            include_examples "has next transition", next_state: "company_name_form"
+
+            it "updates the tier of the object to LOWER" do
+              expect { subject.next }.to change { subject.tier }.to(WasteCarriersEngine::NewRegistration::LOWER_TIER)
+            end
           end
 
           context "when the result of smart answers is upper-tier" do
             let(:lower_tier) { false }
 
             include_examples "has next transition", next_state: "cbd_type_form"
+
+            it "updates the tier of the object to UPPER" do
+              expect { subject.next }.to change { subject.tier }.to(WasteCarriersEngine::NewRegistration::UPPER_TIER)
+            end
           end
         end
 

--- a/spec/models/waste_carriers_engine/new_registration_workflow/waste_types_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/waste_types_form_spec.rb
@@ -18,14 +18,21 @@ module WasteCarriersEngine
           context "when the result of smart answers is lower-tier" do
             let(:lower_tier) { true }
 
-            # TODO: Fix me when implement lower-tier journey
-            include_examples "has next transition", next_state: "cannot_renew_lower_tier_form"
+            include_examples "has next transition", next_state: "company_name_form"
+
+            it "updates the tier of the object to LOWER" do
+              expect { subject.next }.to change { subject.tier }.to(WasteCarriersEngine::NewRegistration::LOWER_TIER)
+            end
           end
 
           context "when the result of smart answers is upper-tier" do
             let(:lower_tier) { false }
 
             include_examples "has next transition", next_state: "cbd_type_form"
+
+            it "updates the tier of the object to UPPER" do
+              expect { subject.next }.to change { subject.tier }.to(WasteCarriersEngine::NewRegistration::UPPER_TIER)
+            end
           end
         end
 


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-836

This extend the new registration flow to deal with the correct setting of lower tiers and upper tiers on the registration.
It includes getting rid of the placeholder lower tier screen from the renewal journey, set up the tier in the transient object as per flows and make sure the user can go back, change responses to question and change its tier accordingly. 

A different PR will deal with the rest of the journey for LT where we don't need to go through all the screens