### PR TITLE
Add locking to MongoId documents

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ gem "jquery-rails"
 
 # Use MongoDB as the database
 gem "mongoid", "~> 5.2"
+# Implement document-level locking
+gem "mongoid-locker"
 
 # Use CanCanCan for user roles and permissions
 # Version 2.0 doesn't support Mongoid, so we're locked to an earlier one

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,8 @@ GEM
       mongo (>= 2.4.1, < 3.0.0)
       origin (~> 2.3)
       tzinfo (>= 0.3.37)
+    mongoid-locker (2.0.0)
+      mongoid (>= 5.0, < 8)
     multi_json (1.14.1)
     multipart-post (2.1.1)
     netrc (0.11.0)
@@ -338,6 +340,7 @@ DEPENDENCIES
   jquery-rails
   loofah (>= 2.2.1)
   mongoid (~> 5.2)
+  mongoid-locker
   pry-byebug
   rails-html-sanitizer (>= 1.0.4)
   rails_12factor

--- a/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
@@ -17,23 +17,43 @@ module WasteCarriersEngine
     def create; end
 
     def success
-      respond_to_acceptable_payment(:success)
+      find_or_initialize_transient_registration(params[:token])
+
+      @transient_registration.with_lock do
+        respond_to_acceptable_payment(:success)
+      end
     end
 
     def pending
-      respond_to_acceptable_payment(:pending)
+      find_or_initialize_transient_registration(params[:token])
+
+      @transient_registration.with_lock do
+        respond_to_acceptable_payment(:pending)
+      end
     end
 
     def failure
-      respond_to_unsuccessful_payment(:failure)
+      find_or_initialize_transient_registration(params[:token])
+
+      @transient_registration.with_lock do
+        respond_to_unsuccessful_payment(:failure)
+      end
     end
 
     def cancel
-      respond_to_unsuccessful_payment(:cancel)
+      find_or_initialize_transient_registration(params[:token])
+
+      @transient_registration.with_lock do
+        respond_to_unsuccessful_payment(:cancel)
+      end
     end
 
     def error
-      respond_to_unsuccessful_payment(:error)
+      find_or_initialize_transient_registration(params[:token])
+
+      @transient_registration.with_lock do
+        respond_to_unsuccessful_payment(:error)
+      end
     end
 
     private
@@ -46,7 +66,7 @@ module WasteCarriersEngine
     end
 
     def respond_to_acceptable_payment(action)
-      return unless valid_transient_registration?(params[:token])
+      return unless valid_transient_registration?
 
       if response_is_valid?(action, params)
         log_and_send_worldpay_response(true, action)
@@ -60,7 +80,7 @@ module WasteCarriersEngine
     end
 
     def respond_to_unsuccessful_payment(action)
-      return unless valid_transient_registration?(params[:token])
+      return unless valid_transient_registration?
 
       if response_is_valid?(action, params)
         log_and_send_worldpay_response(true, action)
@@ -73,8 +93,7 @@ module WasteCarriersEngine
       go_back
     end
 
-    def valid_transient_registration?(token)
-      find_or_initialize_transient_registration(token)
+    def valid_transient_registration?
       setup_checks_pass?
     end
 

--- a/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ClassLength
 module WasteCarriersEngine
   class WorldpayFormsController < FormsController
     def new
@@ -145,3 +146,4 @@ module WasteCarriersEngine
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/models/concerns/waste_carriers_engine/can_use_lock.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_lock.rb
@@ -16,7 +16,13 @@ module WasteCarriersEngine
       field :locking_name, type: String
       field :locked_at, type: Time
 
-      index({ _id: 1, locking_name: 1 }, name: 'mongoid_locker_index', sparse: true, unique: true, expire_after_seconds: 20)
+      index(
+        { _id: 1, locking_name: 1 },
+        name: "mongoid_locker_index",
+        sparse: true,
+        unique: true,
+        expire_after_seconds: 20
+      )
     end
   end
 end

--- a/app/models/concerns/waste_carriers_engine/can_use_lock.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_lock.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# Warning: Do not extend it in TransientRegistration.
+# The Mongoid::Locker gem has trouble dealing with STI and it will cause errors.
 module WasteCarriersEngine
   module CanUseLock
     extend ActiveSupport::Concern

--- a/app/models/concerns/waste_carriers_engine/can_use_lock.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_lock.rb
@@ -5,9 +5,12 @@ module WasteCarriersEngine
     extend ActiveSupport::Concern
 
     include Mongoid::Document
-    include Mongoid::Locker
 
     included do
+      # Including mongoId::Locker outside of this will generate errors when using the lock.
+      # Reason unknow for now.
+      include Mongoid::Locker
+
       field :locking_name, type: String
       field :locked_at, type: Time
 

--- a/app/models/concerns/waste_carriers_engine/can_use_lock.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_lock.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  module CanUseLock
+    extend ActiveSupport::Concern
+
+    include Mongoid::Document
+    include Mongoid::Locker
+
+    included do
+      field :locking_name, type: String
+      field :locked_at, type: Time
+
+      index({ _id: 1, locking_name: 1 }, name: 'mongoid_locker_index', sparse: true, unique: true, expire_after_seconds: 20)
+    end
+  end
+end

--- a/app/models/waste_carriers_engine/new_registration.rb
+++ b/app/models/waste_carriers_engine/new_registration.rb
@@ -3,6 +3,7 @@
 module WasteCarriersEngine
   class NewRegistration < TransientRegistration
     include CanUseNewRegistrationWorkflow
+    include CanUseLock
 
     field :temp_start_option, type: String
   end

--- a/app/models/waste_carriers_engine/past_registration.rb
+++ b/app/models/waste_carriers_engine/past_registration.rb
@@ -19,7 +19,7 @@ module WasteCarriersEngine
 
       past_registration.registration = registration
 
-      attributes = registration.attributes.except("_id", "past_registrations")
+      attributes = registration.attributes.except("_id", "past_registrations", "locking_name", "locked_at")
       past_registration.assign_attributes(attributes)
 
       past_registration.save!

--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -7,6 +7,7 @@ module WasteCarriersEngine
     include CanFilterConvictionStatus
     include CanHaveRegistrationAttributes
     include CanGenerateRegIdentifier
+    include CanUseLock
 
     store_in collection: "registrations"
 

--- a/app/models/waste_carriers_engine/renewing_registration.rb
+++ b/app/models/waste_carriers_engine/renewing_registration.rb
@@ -4,6 +4,7 @@ module WasteCarriersEngine
   class RenewingRegistration < TransientRegistration
     include CanCopyDataFromRegistration
     include CanUseRenewingRegistrationWorkflow
+    include CanUseLock
 
     validate :no_renewal_in_progress?, on: :create
     validates :reg_identifier, "waste_carriers_engine/reg_identifier": true

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -10,7 +10,6 @@ module WasteCarriersEngine
     include CanHaveSecureToken
     include CanSetCreatedAt
     include CanStripWhitespace
-    include CanUseLock
 
     store_in collection: "transient_registrations"
 

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -10,6 +10,7 @@ module WasteCarriersEngine
     include CanHaveSecureToken
     include CanSetCreatedAt
     include CanStripWhitespace
+    include CanUseLock
 
     store_in collection: "transient_registrations"
 

--- a/app/services/waste_carriers_engine/registration_completion_service.rb
+++ b/app/services/waste_carriers_engine/registration_completion_service.rb
@@ -8,7 +8,9 @@ module WasteCarriersEngine
     def run(registration:)
       @registration = registration
 
-      activate_registration if can_be_completed?
+      registration.with_lock do
+        activate_registration if can_be_completed?
+      end
 
       send_confirmation_email
     end

--- a/app/services/waste_carriers_engine/renewal_completion_service.rb
+++ b/app/services/waste_carriers_engine/renewal_completion_service.rb
@@ -30,10 +30,10 @@ module WasteCarriersEngine
     end
 
     def complete_renewal
-      transient_registration.with_lock do
-        registration.with_lock do
-          raise_completion_error unless can_be_completed?
+      raise_completion_error unless can_be_completed?
 
+      registration.with_lock do
+        transient_registration.with_lock do
           copy_names_to_contact_address
           create_past_registration
           update_registration
@@ -117,7 +117,9 @@ module WasteCarriersEngine
                                                                     "temp_payment_method",
                                                                     "temp_tier_check",
                                                                     "_type",
-                                                                    "workflow_state")
+                                                                    "workflow_state",
+                                                                    "locking_name",
+                                                                    "locked_at")
 
       remove_unused_attributes(registration_attributes, renewal_attributes)
 

--- a/app/services/waste_carriers_engine/renewal_completion_service.rb
+++ b/app/services/waste_carriers_engine/renewal_completion_service.rb
@@ -30,13 +30,17 @@ module WasteCarriersEngine
     end
 
     def complete_renewal
-      raise_completion_error unless can_be_completed?
+      transient_registration.with_lock do
+        registration.with_lock do
+          raise_completion_error unless can_be_completed?
 
-      copy_names_to_contact_address
-      create_past_registration
-      update_registration
-      delete_transient_registration
-      send_confirmation_email
+          copy_names_to_contact_address
+          create_past_registration
+          update_registration
+          delete_transient_registration
+          send_confirmation_email
+        end
+      end
     end
 
     private

--- a/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
@@ -85,6 +85,17 @@ module WasteCarriersEngine
           end
 
           context "when the params are valid and the balance is paid" do
+            let(:params) do
+              {
+                orderKey: order_key,
+                token: token,
+                paymentAmount: order.total_amount,
+                paymentCurrency: "GBP",
+                paymentStatus: "AUTHORISED",
+                mac: mac
+              }
+            end
+
             it "add a new payment to the registration, redirects to renewal_complete_form, updates the metadata route and is idempotent." do
               allow(Rails.configuration).to receive(:metadata_route).and_return("ASSISTED_DIGITAL")
               expected_payments_count = transient_registration.finance_details.payments.count + 1
@@ -133,8 +144,15 @@ module WasteCarriersEngine
           end
 
           context "when the params are invalid" do
-            before do
-              allow_any_instance_of(WorldpayService).to receive(:valid_success?).and_return(false)
+            let(:params) do
+              {
+                orderKey: order_key,
+                token: token,
+                paymentAmount: order.total_amount,
+                paymentCurrency: "GBP",
+                paymentStatus: "AUTHORISED",
+                mac: "FOO"
+              }
             end
 
             it "redirects to payment_summary_form" do

--- a/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
@@ -58,32 +58,45 @@ module WasteCarriersEngine
             transient_registration.finance_details.orders.first
           end
 
+          let(:order_key) do
+            "#{Rails.configuration.worldpay_admin_code}^#{Rails.configuration.worldpay_merchantcode}^#{order.order_code}"
+          end
+
+          let(:mac) do
+            data = [order_key,
+              order.total_amount,
+              "GBP",
+              "AUTHORISED",
+              Rails.configuration.worldpay_macsecret
+            ]
+
+            Digest::MD5.hexdigest(data.join).to_s
+          end
+
           let(:params) do
             {
-              orderKey: "#{Rails.configuration.worldpay_admin_code}^#{Rails.configuration.worldpay_merchantcode}^#{order.order_code}",
-              token: token
+              orderKey: order_key,
+              token: token,
+              paymentAmount: order.total_amount,
+              paymentCurrency: "GBP",
+              paymentStatus: "AUTHORISED",
+              mac: mac
             }
           end
 
           context "when the params are valid and the balance is paid" do
-            before do
-              allow_any_instance_of(WorldpayService).to receive(:valid_success?).and_return(true)
-              transient_registration.finance_details.update_attributes(balance: 0)
-            end
-
-            it "redirects to renewal_complete_form" do
-              get success_worldpay_forms_path(token), params
-              expect(response).to redirect_to(new_renewal_complete_form_path(token))
-            end
-
-            it "updates the transient registration metadata attributes from application configuration" do
+            it "add a new payment to the registration, redirects to renewal_complete_form, updates the metadata route and is idempotent." do
               allow(Rails.configuration).to receive(:metadata_route).and_return("ASSISTED_DIGITAL")
-
-              expect(transient_registration.reload.metaData.route).to be_nil
+              expected_payments_count = transient_registration.finance_details.payments.count + 1
 
               get success_worldpay_forms_path(token), params
+              get success_worldpay_forms_path(token), params
 
-              expect(transient_registration.reload.metaData.route).to eq("ASSISTED_DIGITAL")
+              transient_registration.reload
+
+              expect(response).to redirect_to(new_renewal_complete_form_path(token))
+              expect(transient_registration.metaData.route).to eq("ASSISTED_DIGITAL")
+              expect(transient_registration.finance_details.payments.count).to eq(expected_payments_count)
             end
 
             context "when it has been flagged for conviction checks" do

--- a/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
@@ -63,7 +63,8 @@ module WasteCarriersEngine
           end
 
           let(:mac) do
-            data = [order_key,
+            data = [
+              order_key,
               order.total_amount,
               "GBP",
               "AUTHORISED",

--- a/spec/services/waste_carriers_engine/renewal_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/renewal_completion_service_spec.rb
@@ -65,6 +65,7 @@ module WasteCarriersEngine
 
         it "copies the registration's route from the transient_registration to the registration" do
           transient_registration.metaData.route = "ASSISTED_DIGITAL_FROM_TRANSIENT_REGISTRATION"
+          transient_registration.save
 
           renewal_completion_service.complete_renewal
 


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-858

Add locking using the https://github.com/mongoid/mongoid-locker gem to our models.
Implement locking in completion service and worldpay payments.