### PR TITLE
Fix matching comp. reg. no's with lowercase chars

### DIFF
--- a/app/models/waste_carriers_engine/renewing_registration.rb
+++ b/app/models/waste_carriers_engine/renewing_registration.rb
@@ -73,6 +73,12 @@ module WasteCarriersEngine
       # registration.
       old_company_no = registration.company_no.to_s.strip
 
+      # It was previously possible to save a company_no with lowercase letters e.g. ni123456. This is no longer
+      # possible because the check against Comapnies House fails when we search with lowercase registration numbers. The
+      # value has to be made uppercase. So to avoid the renewal being blocked because it thinks the numbers don't match
+      # we upcase the old_company_no
+      old_company_no.upcase!
+
       # It was previously valid to have company_nos with less than 8 digits
       # The form prepends 0s to make up the length, so we should do this for the old number to match
       old_company_no = "0#{old_company_no}" while old_company_no.length < 8

--- a/spec/models/waste_carriers_engine/renewing_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_spec.rb
@@ -357,6 +357,53 @@ module WasteCarriersEngine
       end
     end
 
+    describe "#company_no_changed?" do
+      context "when the renewal is for an business type that doesn't require a company number" do
+        before(:each) { renewing_registration.business_type = "soleTrader" }
+
+        it "returns false" do
+          expect(renewing_registration.company_no_changed?).to eq(false)
+        end
+      end
+
+      context "when the renewal is for an business type that does require a company number" do
+        context "but the original registration was for a partnership" do
+          before(:each) { renewing_registration.registration.business_type = "partnership" }
+
+          it "returns false" do
+            expect(renewing_registration.company_no_changed?).to eq(false)
+          end
+        end
+
+        context "and the original registration has spaces in the company number" do
+          before(:each) { renewing_registration.registration.company_no = "  09360070  " }
+
+          it "returns false" do
+            expect(renewing_registration.company_no_changed?).to eq(false)
+          end
+        end
+
+        context "and the original registration has lowercase characters in the company number" do
+          before(:each) do
+            renewing_registration.registration.company_no = "ni123456"
+            renewing_registration.company_no = "NI123456"
+          end
+
+          it "returns false" do
+            expect(renewing_registration.company_no_changed?).to eq(false)
+          end
+        end
+
+        context "and the company numbers don't match" do
+          before(:each) { renewing_registration.company_no = "NI123456" }
+
+          it "returns true" do
+            expect(renewing_registration.company_no_changed?).to eq(true)
+          end
+        end
+      end
+    end
+
     describe "#pending_manual_conviction_check?" do
       context "when the renewal is not in a completed workflow_state" do
         it "returns false" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-942

We had a report from NCCC of a renewal that got stuck at the Companies house number page. Even though the registration number is the same as the one on the original registration, the renewal journey kept directing the user to the 'This registration cannot be renewed' page.

Upon investigation it turned out to be because the number in the registration had lowercase characters, and the number in the renewal had uppercase. We were able to reproduce the issue using the following steps.

- `registration` is completed using old service and has a registration number of `ni123456`
- user starts renewal. `ni123456` is copied to the `transient_registration`
- user gets to the company registration number screen and sees `ni123456`
- user clicks submit but gets a *Companies House couldn't find a company with this number validation error*
- user corrects the number to be `NI123456`. This is valid and recognised by the lookup so the value is persisted to the `transient_registration`
- our workflow engine runs its `require_new_registration_based_on_company_no?` test
- it compares `ni123456` to `NI123456` and returns `true`
- user directed to the *You cannot renew page*

The companies house check won’t accept the registration number being lowercase. And the check to see if the number has changed isn’t ignoring case so thinks it has.

Hence this change. Here we are just updating the underpinning logic in `require_new_registration_based_on_company_no` to handle differences in case.