### PR TITLE
Remove business owner screen from Lower Tier journey

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
@@ -181,16 +181,20 @@ module WasteCarriersEngine
                       if: :skip_to_manual_address?
 
           transitions from: :company_address_form,
+                      to: :contact_name_form,
+                      if: :lower_tier?
+
+          transitions from: :company_address_form,
                       to: :main_people_form
+
+          transitions from: :company_address_manual_form,
+                      to: :contact_name_form,
+                      if: :lower_tier?
 
           transitions from: :company_address_manual_form,
                       to: :main_people_form
 
           # End registered address
-
-          transitions from: :main_people_form,
-                      to: :contact_name_form,
-                      if: :lower_tier?
 
           transitions from: :main_people_form,
                       to: :declare_convictions_form
@@ -383,7 +387,11 @@ module WasteCarriersEngine
                       to: :declare_convictions_form
 
           transitions from: :contact_name_form,
-                      to: :main_people_form,
+                      to: :company_address_manual_form,
+                      if: %i[lower_tier? registered_address_was_manually_entered?]
+
+          transitions from: :contact_name_form,
+                      to: :company_address_form,
                       if: :lower_tier?
 
           transitions from: :contact_name_form,

--- a/spec/models/waste_carriers_engine/new_registration_workflow/company_address_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/company_address_form_spec.rb
@@ -8,5 +8,17 @@ module WasteCarriersEngine
                     next_state_if_not_skipping_to_manual: :main_people_form,
                     address_type: "company",
                     factory: :new_registration
+
+    describe "#workflow_state" do
+      context ":company_address_form state transitions" do
+        context "on next" do
+          context "when the registration is a lower tier" do
+            subject { build(:new_registration, :lower, workflow_state: "company_address_form") }
+
+            include_examples "has next transition", next_state: "contact_name_form"
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/company_address_manual_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/company_address_manual_form_spec.rb
@@ -10,6 +10,18 @@ module WasteCarriersEngine
                       next_state: :main_people_form,
                       address_type: "company",
                       factory: :new_registration
+
+      describe "#workflow_state" do
+        context ":company_address_manual_form state transitions" do
+          context "on next" do
+            context "when the registration is a lower tier" do
+              subject { build(:new_registration, :lower, workflow_state: "company_address_manual_form") }
+
+              include_examples "has next transition", next_state: "contact_name_form"
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/contact_name_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/contact_name_form_spec.rb
@@ -22,7 +22,14 @@ module WasteCarriersEngine
           context "When the registration is a lower tier" do
             subject { build(:new_registration, :lower, workflow_state: "contact_name_form") }
 
-            include_examples "has back transition", previous_state: "main_people_form"
+            context "when the registered address was manually entered" do
+              let(:registered_address) { build(:address, :registered, :manual_foreign) }
+              subject { build(:new_registration, :lower, workflow_state: "contact_name_form", registered_address: registered_address) }
+
+              include_examples "has back transition", previous_state: "company_address_manual_form"
+            end
+
+            include_examples "has back transition", previous_state: "company_address_form"
           end
 
           include_examples "has back transition", previous_state: "declare_convictions_form"

--- a/spec/models/waste_carriers_engine/new_registration_workflow/main_people_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/main_people_form_spec.rb
@@ -9,12 +9,6 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":main_people_form state transitions" do
         context "on next" do
-          context "when the registration is a lower tier" do
-            subject { build(:new_registration, :lower, workflow_state: "main_people_form") }
-
-            include_examples "has next transition", next_state: "contact_name_form"
-          end
-
           include_examples "has next transition", next_state: "declare_convictions_form"
         end
 


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-836

We discovered today that the wireframe was wrong in the fact that we should capture the business owner details for lower tier registrations. After having a conversation with Anrew and Emi we agreed that the old system is correct and that the wireframe needed fixing so that we don't ask about Business owner details on the lower tier registration journey.