### PR TITLE
Add translations for charity business type

### DIFF
--- a/config/locales/forms/check_your_answers_forms/en.yml
+++ b/config/locales/forms/check_your_answers_forms/en.yml
@@ -25,6 +25,7 @@ en:
           localAuthority_html: "you are a <span class=\"strong\">local authority or public body</span>"
           partnership_html: "you are a <span class=\"strong\">partnership</span>"
           soleTrader_html: "you are a <span class=\"strong\">individual or sole trader</span>"
+          charity_html: "you are a <span class=\"strong\">charity or trust</span>"
         subheading_2: Registration type
         registration_type:
           carrier_dealer_html: "Your registration type is <span class=\"strong\">carrier and dealer</span> (you carry the waste yourselves)"
@@ -37,6 +38,7 @@ en:
           overseas: Business or organisation name
           partnership: Partnership name
           soleTrader: Business or organisation name
+          charity: Charity or trust name
         subheading_4: Companies House number
         subheading_5:
           limitedCompany: Company address
@@ -45,6 +47,7 @@ en:
           overseas: Business or organisation address
           partnership: Partnership address
           soleTrader: Business or organisation address
+          charity: Charity or trust address
         subheading_6:
           limitedCompany:
             one: Director
@@ -64,6 +67,9 @@ en:
           soleTrader:
             one: Business or organisation owner
             other: Business or organisation owners
+          charity:
+            one: Charity or trust owner
+            other: Charity or trust owners
         subheading_7: Relevant convictions
         declared_convictions:
           "yes": You told us you have relevant people with convictions in your business or organisation.

--- a/config/locales/forms/company_address_forms/en.yml
+++ b/config/locales/forms/company_address_forms/en.yml
@@ -9,6 +9,7 @@ en:
           limitedLiabilityPartnership: What's the address of the limited liability partnership?
           partnership: What's the address of the partnership?
           soleTrader: What's the address of the business?
+          charity: What's the address of the charity or trust?
         postcode_label: Postcode
         postcode_change_link: "Change postcode"
         manual_address_link: "I cannot find the address in the list"

--- a/config/locales/forms/company_address_manual_forms/en.yml
+++ b/config/locales/forms/company_address_manual_forms/en.yml
@@ -10,6 +10,7 @@ en:
           partnership: What's the address of the partnership?
           soleTrader: What's the address of the business?
           overseas: What's the address of the business or organisation?
+          charity: What's the address of the charity or trust?
         os_places_error_heading: Our address finder is not working
         os_places_error_text: Please enter the address below.
         preset_postcode_label: Postcode

--- a/config/locales/forms/company_name_forms/en.yml
+++ b/config/locales/forms/company_name_forms/en.yml
@@ -10,6 +10,7 @@ en:
           overseas: What's the name of the business or organisation?
           partnership: What's the name of the partnership?
           soleTrader: What's the name of the business?
+          charity: What's the name of the charity or trust?
         company_name_label:
           localAuthority: Local authority or public body name
           limitedCompany: Company trading name
@@ -17,6 +18,7 @@ en:
           overseas: Trading name
           partnership: Partnership trading name
           soleTrader: Business trading name
+          charity: Charity or trust registered name
         error_heading: Something is wrong
         next_button: Continue
   activemodel:

--- a/config/locales/forms/company_postcode_forms/en.yml
+++ b/config/locales/forms/company_postcode_forms/en.yml
@@ -9,6 +9,7 @@ en:
           limitedLiabilityPartnership: What's the address of the limited liability partnership?
           partnership: What's the address of the partnership?
           soleTrader: What's the address of the business?
+          charity: What's the address of the charity or trust?
         temp_company_postcode_label: Please enter a UK postcode
         temp_company_postcode_hint: For example, BS1 5AH
         error_heading: A problem to fix

--- a/config/locales/forms/edit_forms/en.yml
+++ b/config/locales/forms/edit_forms/en.yml
@@ -59,6 +59,7 @@ en:
             overseas: Overseas
             publicBody: Public body
             authority: Local or regulatory authority
+            charity: Charity or trust
           main_people:
             localAuthority: chief executive
             limitedCompany: director
@@ -66,6 +67,7 @@ en:
             overseas: business owner
             partnership: partner
             soleTrader: business owner
+            charity: charity or trust owner
           location:
             england: England
             wales: Wales


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-836

Since now we have the ability to run through a journey for `charity` business_types, we realised that we need to fix our dynamically generated translations for this type of business.