### PR TITLE
Switch to SonarCloud from CodeClimate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,21 @@
+dist: trusty
+
+addons:
+  sonarcloud:
+    organization: "defra"
+
+language: ruby
+rvm: 2.4.2
+cache: bundler
+
+# Travis CI uses shallow clone to speed up build times, but a truncated SCM
+# history may cause issues when SonarCloud computes blame data. To avoid this,
+# you can access the full SCM history with `depth: false`
+git:
+  depth: false
+
 env:
   global:
-    - CC_TEST_REPORTER_ID=be55758aa1e0f8d601613fa05cb3d025ce0a8555144b63ac277b5113edbbe3bc
     - WCRS_REGISTRATION_EXPIRES_AFTER=3
     - WCRS_REGISTRATION_RENEWAL_WINDOW=3
     - WCRS_REGISTRATION_GRACE_WINDOW=5
@@ -19,40 +34,22 @@ env:
   matrix:
     secure: Kcymo4dlw9/N7roosBvEvIzhpTSWhvQwzrL6iWowBNsdsQ/H3o+MBQteoL0rYtJVche3sRVhmqXo5YIQ8CUk5oYD8S4oFwWSMODe6XnO/odBsDC3mtzc8YCILVMsnni504KDxxSz7Zl3SZ0JbAyUGNBi1HQ3EuXylvCv3QnDE20UcUvb+OpilqgDzsjFaOb/FKEgUZuXF8TisiCtpU3CR7HFV/Fw37cYvtHK5mUNNTmW88laTvR3l2eel3SRIl8PUUWWyRgtu7h2n4gq3cbV9SIs/AgDEEvGkVhsWgK2l6yPbGtMVWjVihbo71KX0ec0yTxliD8WTvlao6R7Iwagp/jg11evJMYUVx+1GkLGfxzZcVmIOwYdNFcVROPBAB8TVbbd+wdO8W93tVHEnDHQBM6Ol2qxCC0RNWi3ElD2Sg6rx34ECEhlK8tWoyZTHTlWGz32ctt6fNftJOPM0euQhLpr7ZBz7GqfJMYy5+tCm110SmLXvxe5cotoIofJ29U2DkZACa0sSPkQSnco/xA0aYXOL1fPCPFyRwmN8wXBMxZi6SeGtC47Zg5I2e447zinvv+4hsMlwESiwvCMGEGBmBIKuMg5Nqk0o3lPE4bfRiDkAiHOrLAhhUBQxM4sE5wyg81jr172E1gDVgSAU1hkCyRGObqzaDaH/cybOc397ic=
 
-language: ruby
-rvm: 2.4.2
-cache: bundler
-
-# Travis CI clones repositories to a depth of 50 commits, which is only really
-# useful if you are performing git operations.
-# https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth
-git:
-  depth: 3
 services:
   - mongodb
+
 before_install:
   - export TZ=UTC
+  - gem install -v 1.17.3 bundler --no-rdoc --no-ri
   - sudo apt-get install xvfb -y
   - sudo apt-get install ttf-liberation -y
   - sudo apt-get install wkhtmltopdf -y
-  - gem install -v 1.17.2 bundler --no-rdoc --no-ri
+
 before_script:
   # Set up Mongo databases
   - mongo waste-carriers-test --eval 'db.createUser({user:"mongoUser", pwd:"password1234", roles:["readWrite", "dbAdmin", "userAdmin"]})'
   - mongo waste-carriers-users-test --eval 'db.createUser({user:"mongoUser", pwd:"password1234", roles:["readWrite", "dbAdmin", "userAdmin"]})'
-  # Setup to support the CodeClimate test coverage submission
-  # As per CodeClimate's documentation, they suggest only running
-  # ./cc-test-reporter commands on travis-ci push builds only. Hence we wrap all
-  # the codeclimate test coverage related commands in a check that tests if we
-  # are in a pull request or not.
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter; fi
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then chmod +x ./cc-test-reporter; fi
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter before-build; fi
-  # Run rubocop. It's installed as a dependency (hence no install step) as this
-  # allows projects to control the version they are using (rather than getting)
-  # surprise build failures.
-  - bundle exec rubocop
+
 script:
+  - bundle exec rubocop --format=json --out=rubocop-result.json
   - bundle exec rspec
-after_script:
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi
+  - sonar-scanner

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Waste Carriers engine
 
 [![Build Status](https://travis-ci.com/DEFRA/waste-carriers-engine.svg?branch=master)](https://travis-ci.com/DEFRA/waste-carriers-engine)
-[![Maintainability](https://api.codeclimate.com/v1/badges/2fee55bc96a9c8942729/maintainability)](https://codeclimate.com/github/DEFRA/waste-carriers-engine/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/2fee55bc96a9c8942729/test_coverage)](https://codeclimate.com/github/DEFRA/waste-carriers-engine/test_coverage)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_waste-carriers-engine&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=DEFRA_waste-carriers-engine)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_waste-carriers-engine&metric=coverage)](https://sonarcloud.io/dashboard?id=DEFRA_waste-carriers-engine)
 [![security](https://hakiri.io/github/DEFRA/waste-carriers-engine/master.svg)](https://hakiri.io/github/DEFRA/waste-carriers-engine/master)
 
 The 'Register as a waste carrier' service allows businesses, who deal with waste and have to register according to the regulations, to register online. Once registered, businesses can sign in again to edit their registrations if needed.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,29 @@
+# Project key is required. You'll find it in the SonarCloud UI
+sonar.projectKey=DEFRA_waste-carriers-engine
+sonar.organization=defra
+
+# This is the name and version displayed in the SonarCloud UI
+sonar.projectName=waste-carriers-engine
+
+# This will add the same links in the SonarCloud UI
+sonar.links.homepage=https://github.com/DEFRA/waste-carriers-engine
+sonar.links.ci=https://travis-ci.com/DEFRA/waste-carriers-engine
+sonar.links.scm=https://github.com/DEFRA/waste-carriers-engine
+sonar.links.issue=https://github.com/DEFRA/ruby-services-team/issues
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on
+# Windows.
+# Because rails generates a number of files, and SonarCloud has no rails and
+# ruby intelligence we have found we have to specify what should be covered.
+# If we don't SonarCloud will do things like take the raw coverage data from
+# simplecov, compare that to all files ion the repo, and score 0 for all the
+# files we don't actually need to test. This severly deflates our scores and
+# means it is not consistent with our previous reporting tool CodeClimate.
+sonar.sources=./app,./lib
+sonar.tests=./spec
+
+# Encoding of the source code. Default is default system encoding
+sonar.sourceEncoding=UTF-8
+
+sonar.ruby.coverage.reportPath=coverage/.resultset.json
+sonar.ruby.rubocop.reportPaths=rubocop-result.json


### PR DESCRIPTION
https://sonarcloud.io/organizations/defra/projects

We currently use [Code Climate](https://codeclimate.com/) for our code quality checks and test coverage analysis. However a number of Defra projects have used an internal SonarQube instance, and some public ones have been using SonarCloud (the cloud SASS version of SonarQube).

It looks like we're about to formally adopt SonarCloud and all projects will coalesce onto. So to keep on top of things and continue to be an example to others, we are working through our repos and switching them to SonarCloud.

** Notes

The figuring out of how to do this (because it wasn't straight forward!) was done in

- https://github.com/DEFRA/waste-exemptions-front-office/pull/317
- https://github.com/DEFRA/waste-exemptions-front-office/pull/318