### PR TITLE
Fix Mongoid::Locker dependency

### DIFF
--- a/lib/waste_carriers_engine/engine.rb
+++ b/lib/waste_carriers_engine/engine.rb
@@ -2,6 +2,7 @@
 
 require "aasm"
 require "mongoid"
+require "mongoid/locker"
 require "high_voltage"
 require "defra_ruby/alert"
 require "defra_ruby_email"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-858
https://github.com/DEFRA/waste-carriers-engine/pull/715

PR #715 added [Mongoid-locker](https://github.com/mongoid/mongoid-locker), a new dependency we are using to allow us to 'lock' documents when we are making updates to them. The hope is this will solve some edge behaviour we see when multiple requests are made regards the same registration at the same time.

However it seems the apps when using this version of the engine now error with

```bash
NameError:
  uninitialized constant Mongoid::Locker
 ./vendor/bundle/ruby/2.4.0/bundler/gems/waste-carriers-engine-7cf8f8f87ee9/app/models/concerns/waste_carriers_engine/can_use_lock.rb:14:in `block in <module:CanUseLock>'
```

We believe its just because as we are adding the gem in the engine, we need to add a require there as well. This change does that and aims to resolve the error in the apps.