### PR TITLE
Hide start new registration behind feature toggle

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,8 @@ WasteCarriersEngine::Engine.routes.draw do
   resources :start_forms,
             only: %i[new create],
             path: "start",
-            path_names: { new: "" }
+            path_names: { new: "" },
+            constraints: ->(_request) { WasteCarriersEngine::FeatureToggle.active?(:new_registration) }
 
   get "transient-registration/:token/destroy",
       to: "transient_registrations#destroy",

--- a/spec/requests/waste_carriers_engine/start_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/start_forms_spec.rb
@@ -4,6 +4,9 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe "StartForms", type: :request do
+    # TODO: Remove once new registration is no longer behind a feature toggle
+    before(:each) { allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:new_registration).and_return(true) }
+
     describe "GET new_start_form_path" do
       it "returns a 200 response and render the new template" do
         get new_start_form_path


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-840

We are currently not yet finished with building new registrations into the service (migrating it from the old code). But there are other features we do want to ship so for now, we will hide the ability to start a new registration behind a feature toggle.