### PR TITLE
Fix rails bin scripts (rails console)

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -1,9 +1,12 @@
 #!/usr/bin/env ruby
-begin
-  load File.expand_path('../spring', __FILE__)
-rescue LoadError => e
-  raise unless e.message.include?('spring')
-end
-APP_PATH = File.expand_path('../../config/application', __FILE__)
-require_relative '../config/boot'
-require 'rails/commands'
+# This command will automatically be run when you run "rails" with Rails 4 gems installed from the root of your application.
+
+ENGINE_ROOT = File.expand_path('../..', __FILE__)
+ENGINE_PATH = File.expand_path('../../lib/waste_carriers_engine/engine', __FILE__)
+
+# Set up gems listed in the Gemfile.
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+
+require 'rails/all'
+require 'rails/engine/commands'

--- a/spec/dummy/bin/rails
+++ b/spec/dummy/bin/rails
@@ -1,9 +1,4 @@
 #!/usr/bin/env ruby
-begin
-  load File.expand_path('../spring', __FILE__)
-rescue LoadError => e
-  raise unless e.message.include?('spring')
-end
 APP_PATH = File.expand_path('../../config/application', __FILE__)
 require_relative '../config/boot'
 require 'rails/commands'


### PR DESCRIPTION
When trying to access the rails console to do some debugging and investigation I was unable to due to errors. Calling `bundle exec rails console` at the root is actually expected to fail, but not with this error message

```bash
bin/rails:8:in `require_relative': cannot load such file -- /vagrant/waste-carriers-engine/config/boot (LoadError)
	from bin/rails:8:in `<main>'
```

In an engine I would expect it to tell me to try running the command in the dummy app in either your test or spec folder. However when I do `cd spec/dummy/ && bundle exec rails console` I get

```bash
/home/vagrant/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/spring-2.1.0/lib/spring/configuration.rb:31:in `application_root_path': Spring::MissingApplication (Spring::MissingApplication)
	from /home/vagrant/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/spring-2.1.0/lib/spring/application.rb:282:in `loaded_application_features'
	from /home/vagrant/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/spring-2.1.0/lib/spring/application.rb:119:in `ensure in preload'
	from /home/vagrant/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/spring-2.1.0/lib/spring/application.rb:126:in `preload'
	from /home/vagrant/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/spring-2.1.0/lib/spring/application.rb:157:in `serve'
	from /home/vagrant/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/spring-2.1.0/lib/spring/application.rb:145:in `block in run'
	from /home/vagrant/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/spring-2.1.0/lib/spring/application.rb:139:in `loop'
	from /home/vagrant/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/spring-2.1.0/lib/spring/application.rb:139:in `run'
	from /home/vagrant/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/spring-2.1.0/lib/spring/application/boot.rb:19:in `<top (required)>'
	from /home/vagrant/.rbenv/versions/2.4.2/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/vagrant/.rbenv/versions/2.4.2/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from -e:1:in `<main>'
```

The problem we believe is that the files `bin/rails` and `spec/dummy/bin/rails` are currently populated based on when the project was originally generated as an application and not an engine. We subsequently converted to an engine at a later date.

This change updates them to match what you would see if the project had been generated as an engine at the outset.

For reference, here is the output you would expect to see when the files are populated correctly

```bash
bundle exec rails console

Error: Command not recognized
Usage: rails COMMAND [ARGS]

The common Rails commands available for engines are:
 generate    Generate new code (short-cut alias: "g")
 destroy     Undo code generated with "generate" (short-cut alias: "d")

All commands can be run with -h for more information.

If you want to run any commands that need to be run in context
of the application, like `rails server` or `rails console`,
you should do it from application's directory (typically test/dummy).
```

```bash
cd spec/dummy/ && bundle exec rails console

Loading development environment (Rails 4.2.11.1)
irb(main):001:0>
```