### PR TITLE
Do not update a transient registration unless is persisted

### DIFF
--- a/app/controllers/waste_carriers_engine/forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/forms_controller.rb
@@ -95,6 +95,7 @@ module WasteCarriersEngine
     def set_workflow_state
       return unless state_can_navigate_flexibly?(@transient_registration.workflow_state)
       return unless state_can_navigate_flexibly?(requested_state)
+      return unless @transient_registration.persisted?
 
       @transient_registration.update_attributes(workflow_state: requested_state)
     end


### PR DESCRIPTION
This will avoid saving unecessary objects during GET requests, in-line with what we do on WEX.