### PR TITLE
Refactor payment summary to work with New registrations

### DIFF
--- a/app/controllers/waste_carriers_engine/check_your_answers_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/check_your_answers_forms_controller.rb
@@ -5,7 +5,7 @@ module WasteCarriersEngine
     def new
       return unless super(CheckYourAnswersForm, "check_your_answers_form")
 
-      @presenter = CheckYourAnswersFormPresenter.new(@transient_registration)
+      @presenter = ResourceTypeFormPresenter.new(@transient_registration)
     end
 
     def create

--- a/app/controllers/waste_carriers_engine/payment_summary_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/payment_summary_forms_controller.rb
@@ -3,10 +3,14 @@
 module WasteCarriersEngine
   class PaymentSummaryFormsController < FormsController
     def new
-      super(PaymentSummaryForm, "payment_summary_form")
+      return unless super(PaymentSummaryForm, "payment_summary_form")
+
+      @presenter = ResourceTypeFormPresenter.new(@transient_registration)
     end
 
     def create
+      @presenter = ResourceTypeFormPresenter.new(@transient_registration)
+
       super(PaymentSummaryForm, "payment_summary_form")
     end
 

--- a/app/forms/waste_carriers_engine/payment_summary_form.rb
+++ b/app/forms/waste_carriers_engine/payment_summary_form.rb
@@ -15,7 +15,6 @@ module WasteCarriersEngine
     def initialize(transient_registration)
       super
 
-      self.type_change = transient_registration.registration_type_changed?
       self.registration_cards = transient_registration.temp_cards || 0
       self.registration_card_charge = transient_registration.total_registration_card_charge
       self.total_charge = transient_registration.total_to_pay

--- a/app/models/waste_carriers_engine/new_registration.rb
+++ b/app/models/waste_carriers_engine/new_registration.rb
@@ -6,5 +6,11 @@ module WasteCarriersEngine
     include CanUseLock
 
     field :temp_start_option, type: String
+
+    private
+
+    def registration_type_base_charges
+      [Rails.configuration.new_registration_charge]
+    end
   end
 end

--- a/app/models/waste_carriers_engine/renewing_registration.rb
+++ b/app/models/waste_carriers_engine/renewing_registration.rb
@@ -140,5 +140,12 @@ module WasteCarriersEngine
 
       errors.add(:reg_identifier, :renewal_in_progress)
     end
+
+    def registration_type_base_charges
+      charges = [Rails.configuration.renewal_charge]
+      charges << Rails.configuration.type_change_charge if registration_type_changed?
+
+      charges
+    end
   end
 end

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -28,11 +28,10 @@ module WasteCarriersEngine
     scope :pending_payment, -> { submitted.where(:"financeDetails.balance".gt => 0) }
     scope :pending_approval, -> { submitted.where("conviction_sign_offs.0.confirmed": "no") }
 
-    # TODO: Move to renewal registration
     def total_to_pay
-      charges = [Rails.configuration.renewal_charge]
-      charges << Rails.configuration.type_change_charge if registration_type_changed?
+      charges = registration_type_base_charges
       charges << total_registration_card_charge
+
       charges.sum
     end
 
@@ -62,6 +61,12 @@ module WasteCarriersEngine
       metaData.route = Rails.configuration.metadata_route
 
       save
+    end
+
+    private
+
+    def registration_type_base_charges
+      [] # default. Override on STI objects where necessary.
     end
   end
 end

--- a/app/presenters/waste_carriers_engine/resource_type_form_presenter.rb
+++ b/app/presenters/waste_carriers_engine/resource_type_form_presenter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module WasteCarriersEngine
-  class CheckYourAnswersFormPresenter < BasePresenter
+  class ResourceTypeFormPresenter < BasePresenter
     def new_registration?
       __getobj__.is_a?(WasteCarriersEngine::NewRegistration)
     end

--- a/app/views/waste_carriers_engine/payment_summary_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/payment_summary_forms/new.html.erb
@@ -19,18 +19,24 @@
     <div class="form-group">
       <table>
         <tbody>
-          <tr>
-            <td><%= t(".renewal_fee") %></td>
-            <td>£<%= display_pence_as_pounds(Rails.configuration.renewal_charge) %></td>
-          </tr>
-
-          <% if @payment_summary_form.type_change %>
+          <% if @presenter.renewal? %>
             <tr>
-              <td><%= t(".cbd_fee") %></td>
-              <td>£<%= display_pence_as_pounds(Rails.configuration.type_change_charge) %></td>
+              <td><%= t(".renewal_fee") %></td>
+              <td>£<%= display_pence_as_pounds(Rails.configuration.renewal_charge) %></td>
+            </tr>
+
+            <% if @transient_registration.registration_type_changed? %>
+              <tr>
+                <td><%= t(".cbd_fee") %></td>
+                <td>£<%= display_pence_as_pounds(Rails.configuration.type_change_charge) %></td>
+              </tr>
+            <% end %>
+          <% else %>
+            <tr>
+              <td><%= t(".registration_fee") %></td>
+              <td>£<%= display_pence_as_pounds(Rails.configuration.new_registration_charge) %></td>
             </tr>
           <% end %>
-
           <% if @payment_summary_form.registration_cards > 0 %>
             <tr>
               <td><%= t(".cards_fee", count: @payment_summary_form.registration_cards) %></td>
@@ -52,6 +58,7 @@
 
     <div class="form-group <%= "form-group-error" if @payment_summary_form.errors[:temp_payment_method].any? %>">
       <fieldset id="temp_payment_method">
+        <legend class="visuallyhidden"><%= t(".make_payment_subheading") %></legend>
 
         <% if @payment_summary_form.errors[:temp_payment_method].any? %>
           <span class="error-message"><%= @payment_summary_form.errors[:temp_payment_method].join(", ") %></span>
@@ -60,16 +67,16 @@
         <div class="multiple-choice">
           <%= f.radio_button :temp_payment_method, "card" %>
           <%= f.label :temp_payment_method, value: "card", class: "form-label" do %>
-            <%= t(".options.card") %>
-            <span class='form-hint'><%= t(".hint_pay_by_card") %></span>
+            <%= t(".options.card.label") %>
+            <span class='form-hint'><%= t(".options.card.hint") %></span>
           <% end %>
         </div>
 
         <div class="multiple-choice">
           <%= f.radio_button :temp_payment_method, "bank_transfer" %>
           <%= f.label :temp_payment_method, value: "bank_transfer", class: "form-label" do %>
-            <%= t(".options.bank_transfer") %>
-            <span class='form-hint'><%= t(".hint_pay_by_bank_transfer") %></span>
+            <%= t(".options.bank_transfer.label") %>
+            <span class='form-hint'><%= t(".options.bank_transfer.hint") %></span>
           <% end %>
         </div>
       </fieldset>

--- a/config/locales/forms/payment_summary_forms/en.yml
+++ b/config/locales/forms/payment_summary_forms/en.yml
@@ -6,6 +6,7 @@ en:
         payment_error_heading: A problem with your payment
         heading: Payment summary
         renewal_fee: Renewal of registration
+        registration_fee: Initial registration
         cbd_fee: Additional charge for changing registration type
         cards_fee:
           one: "%{count} registration card"
@@ -14,10 +15,12 @@ en:
         vat_statement: All charges are outside the scope of VAT.
         make_payment_subheading: Make a payment
         options:
-          card: Pay by credit card or debit card
-          bank_transfer: Pay by bank transfer
-        hint_pay_by_card: You will be transferred to the secure Worldpay site for you to enter your credit or debit card details. We accept Mastercard, Maestro and Visa.
-        hint_pay_by_bank_transfer: Paying by bank transfer requires 2 steps. Both must be done to complete your registration.
+          card:
+            label: Pay by credit or debit card
+            hint: You will be transferred to the secure WorldPay site. We accept MasterCard, Maestro and Visa.
+          bank_transfer:
+            label: Pay by bank transfer and then email us to confirm payment
+            hint: We cannot register you until your payment clears.
         next_button: Proceed to payment
   activemodel:
     errors:
@@ -26,7 +29,3 @@ en:
           attributes:
             temp_payment_method:
               inclusion: "You must select a payment method"
-            reg_identifier:
-              invalid_format: "The registration ID is not in a valid format"
-              no_registration: "There is no registration matching this ID"
-              renewal_in_progress: "This renewal is already in progress"

--- a/spec/presenters/waste_carriers_engine/resource_type_form_presenter_spec.rb
+++ b/spec/presenters/waste_carriers_engine/resource_type_form_presenter_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 module WasteCarriersEngine
-  RSpec.describe CheckYourAnswersFormPresenter do
+  RSpec.describe ResourceTypeFormPresenter do
     subject { described_class.new(object) }
 
     describe "#new_registration?" do


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-924

This contains the code to apply the changes and fixes to the payment summary screen as per new wireframe. This affects both registration and renewals.




<details> 
<summary>New Registration</summary>
<img width="527" alt="Screenshot 2020-03-13 at 13 48 36" src="https://user-images.githubusercontent.com/1385397/76628281-64ad3880-6534-11ea-86bc-8afe426003cd.png">
</details>

<details> 
<summary>Renewal</summary>
<img width="528" alt="Screenshot 2020-03-13 at 13 48 30" src="https://user-images.githubusercontent.com/1385397/76628289-670f9280-6534-11ea-9129-8aabc85a7717.png">

</details>