### PR TITLE
Calculate Reg identifier for new registrations on the fly

### DIFF
--- a/app/models/waste_carriers_engine/new_registration.rb
+++ b/app/models/waste_carriers_engine/new_registration.rb
@@ -7,6 +7,14 @@ module WasteCarriersEngine
 
     field :temp_start_option, type: String
 
+    def reg_identifier
+      return unless super.present?
+
+      prefix = lower_tier? ? "CBDL" : "CBDU"
+
+      prefix + super.to_s
+    end
+
     private
 
     def registration_type_base_charges

--- a/spec/forms/waste_carriers_engine/declaration_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/declaration_forms_spec.rb
@@ -23,7 +23,7 @@ module WasteCarriersEngine
           let(:transient_registration) { declaration_form.transient_registration }
 
           it "should assign a reg identifier number to the transient registration object" do
-            expect { declaration_form.submit(valid_params) }.to change { transient_registration.reg_identifier }.to("1")
+            expect { declaration_form.submit(valid_params) }.to change { transient_registration.reload.attributes["regIdentifier"] }.to("1")
           end
         end
       end

--- a/spec/models/waste_carriers_engine/new_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_spec.rb
@@ -9,5 +9,31 @@ module WasteCarriersEngine
     describe "scopes" do
       it_should_behave_like "TransientRegistration named scopes"
     end
+
+    describe "#reg_identifier" do
+      context "if there is no reg_identifier number persisted in the db yet" do
+        it "returns nil" do
+          expect(subject.reg_identifier).to be_nil
+        end
+      end
+
+      context "if there is a reg_identifier number persisted in the db" do
+        context "when the registation is a lower tier" do
+          subject(:new_registration) { build(:new_registration, :lower, reg_identifier: 3) }
+
+          it "returns a CBDL identifier" do
+            expect(subject.reg_identifier).to eq("CBDL3")
+          end
+        end
+
+        context "when the registration is an upper tier" do
+          subject(:new_registration) { build(:new_registration, :upper, reg_identifier: 3) }
+
+          it "returns a CBDU identifier" do
+            expect(subject.reg_identifier).to eq("CBDU3")
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
We have decided that we will assign a unique registration number to a registration when the declaration form is submitted. However, since the user is able to go back in the journey and change its tier up until the very end of the journey, we also decided that would be wise to not persist the `CBDL` VS `CBDU` prefix to the identifier until the transient object becomes an actual registration. With this change, we always generate the number on the fly for NewRegistration objects.