### PR TITLE
Set up order models for type change during edit

### DIFF
--- a/app/models/waste_carriers_engine/order.rb
+++ b/app/models/waste_carriers_engine/order.rb
@@ -90,7 +90,11 @@ module WasteCarriersEngine
     end
 
     def generate_description
-      self.description = order_items.map(&:description).join(", plus ")
+      self.description = order_items.map(&:description)
+                                    .join(", plus ")
+
+      # Upcase the first letter. (TODO: Use .upcase_first when we switch to Rails 5)
+      description[0] = description[0].capitalize
     end
 
     def update_after_worldpay(status)

--- a/app/models/waste_carriers_engine/order.rb
+++ b/app/models/waste_carriers_engine/order.rb
@@ -38,7 +38,7 @@ module WasteCarriersEngine
       # TODO: Review whether card_count.present? is still necessary - this was a fix put in to deal with WC-498
       order[:order_items] << OrderItem.new_copy_cards_item(card_count) if card_count.present? && card_count.positive?
 
-      order.generate_description
+      order.set_description
 
       order[:total_amount] = order[:order_items].sum { |item| item[:amount] }
 
@@ -89,18 +89,25 @@ module WasteCarriersEngine
       Time.now.to_i.to_s
     end
 
-    def generate_description
-      self.description = order_items.map(&:description)
-                                    .join(", plus ")
-
-      # Upcase the first letter. (TODO: Use .upcase_first when we switch to Rails 5)
-      description[0] = description[0].capitalize
+    def set_description
+      self.description = generate_description
     end
 
     def update_after_worldpay(status)
       self.world_pay_status = status
       self.date_last_updated = Time.current
       save!
+    end
+
+    private
+
+    def generate_description
+      description = order_items.map(&:description)
+                               .join(", plus ")
+
+      description[0] = description[0].capitalize
+
+      description
     end
   end
 end

--- a/app/models/waste_carriers_engine/order.rb
+++ b/app/models/waste_carriers_engine/order.rb
@@ -32,7 +32,9 @@ module WasteCarriersEngine
       card_count = transient_registration.temp_cards
 
       order[:order_items] = [OrderItem.new_renewal_item]
-      order[:order_items] << OrderItem.new_type_change_item if transient_registration.registration_type_changed?
+      if transient_registration.registration_type_changed?
+        order[:order_items] << OrderItem.new_type_change_item(:renewal)
+      end
       # TODO: Review whether card_count.present? is still necessary - this was a fix put in to deal with WC-498
       order[:order_items] << OrderItem.new_copy_cards_item(card_count) if card_count.present? && card_count.positive?
 

--- a/app/models/waste_carriers_engine/order.rb
+++ b/app/models/waste_carriers_engine/order.rb
@@ -32,9 +32,7 @@ module WasteCarriersEngine
       card_count = transient_registration.temp_cards
 
       order[:order_items] = [OrderItem.new_renewal_item]
-      if transient_registration.registration_type_changed?
-        order[:order_items] << OrderItem.new_type_change_item(:renewal)
-      end
+      order[:order_items] << OrderItem.new_type_change_item if transient_registration.registration_type_changed?
       # TODO: Review whether card_count.present? is still necessary - this was a fix put in to deal with WC-498
       order[:order_items] << OrderItem.new_copy_cards_item(card_count) if card_count.present? && card_count.positive?
 

--- a/app/models/waste_carriers_engine/order_item.rb
+++ b/app/models/waste_carriers_engine/order_item.rb
@@ -6,6 +6,8 @@ module WasteCarriersEngine
 
     embedded_in :order, class_name: "WasteCarriersEngine::Order"
 
+    LOCALES_KEY = ".waste_carriers_engine.order_items.descriptions"
+
     TYPES = HashWithIndifferentAccess.new(
       renew: "RENEW",
       edit: "EDIT",
@@ -25,7 +27,7 @@ module WasteCarriersEngine
       order_item = OrderItem.base_order_item
 
       order_item.amount = Rails.configuration.renewal_charge
-      order_item.description = "Renewal of registration"
+      order_item.description = I18n.t("#{LOCALES_KEY}.renewal_item")
       order_item.type = TYPES[:renew]
       order_item.quantity = 1
 
@@ -40,7 +42,7 @@ module WasteCarriersEngine
       order_item = OrderItem.base_order_item
 
       order_item.amount = Rails.configuration.type_change_charge
-      order_item.description = "changing carrier type during renewal"
+      order_item.description = I18n.t("#{LOCALES_KEY}.type_change_item.renewal")
       order_item.type = TYPES[:edit]
       order_item.quantity = 1
 
@@ -52,8 +54,7 @@ module WasteCarriersEngine
 
       order_item.amount = cards * Rails.configuration.card_charge
 
-      order_item.description = "#{cards} registration cards"
-      order_item.description = "1 registration card" if cards == 1
+      order_item.description = I18n.t("#{LOCALES_KEY}.copy_cards_item", count: cards)
       order_item.quantity = cards
 
       order_item.type = TYPES[:copy_cards]

--- a/app/models/waste_carriers_engine/order_item.rb
+++ b/app/models/waste_carriers_engine/order_item.rb
@@ -38,11 +38,11 @@ module WasteCarriersEngine
       new(type: TYPES[:charge_adjust])
     end
 
-    def self.new_type_change_item(journey)
+    def self.new_type_change_item
       order_item = OrderItem.base_order_item
 
       order_item.amount = Rails.configuration.type_change_charge
-      order_item.description = I18n.t("#{LOCALES_KEY}.type_change_item.#{journey}")
+      order_item.description = I18n.t("#{LOCALES_KEY}.type_change_item")
       order_item.type = TYPES[:edit]
       order_item.quantity = 1
 

--- a/app/models/waste_carriers_engine/order_item.rb
+++ b/app/models/waste_carriers_engine/order_item.rb
@@ -38,11 +38,11 @@ module WasteCarriersEngine
       new(type: TYPES[:charge_adjust])
     end
 
-    def self.new_type_change_item
+    def self.new_type_change_item(journey)
       order_item = OrderItem.base_order_item
 
       order_item.amount = Rails.configuration.type_change_charge
-      order_item.description = I18n.t("#{LOCALES_KEY}.type_change_item.renewal")
+      order_item.description = I18n.t("#{LOCALES_KEY}.type_change_item.#{journey}")
       order_item.type = TYPES[:edit]
       order_item.quantity = 1
 

--- a/app/services/waste_carriers_engine/order_additional_cards_service.rb
+++ b/app/services/waste_carriers_engine/order_additional_cards_service.rb
@@ -22,7 +22,7 @@ module WasteCarriersEngine
 
       order[:order_items] = [new_item]
 
-      order.generate_description
+      order.set_description
 
       order[:total_amount] = new_item[:amount]
 

--- a/config/locales/order_items.en.yml
+++ b/config/locales/order_items.en.yml
@@ -1,0 +1,11 @@
+en:
+  waste_carriers_engine:
+    order_items:
+      descriptions:
+        renewal_item: "renewal of registration"
+        type_change_item:
+          renewal: "changing carrier type during renewal"
+          edit: "changing carrier type during edit"
+        copy_cards_item:
+          one: "1 registration card"
+          other: "%{count} registration cards"

--- a/config/locales/order_items.en.yml
+++ b/config/locales/order_items.en.yml
@@ -3,9 +3,7 @@ en:
     order_items:
       descriptions:
         renewal_item: "renewal of registration"
-        type_change_item:
-          renewal: "changing carrier type during renewal"
-          edit: "changing carrier type during edit"
+        type_change_item: "changing carrier type"
         copy_cards_item:
           one: "1 registration card"
           other: "%{count} registration cards"

--- a/spec/models/waste_carriers_engine/order_item_spec.rb
+++ b/spec/models/waste_carriers_engine/order_item_spec.rb
@@ -41,7 +41,8 @@ module WasteCarriersEngine
     end
 
     describe "new_type_change_item" do
-      let(:order_item) { described_class.new_type_change_item }
+      let(:journey) {}
+      let(:order_item) { described_class.new_type_change_item(journey) }
 
       it "should have a type of 'EDIT'" do
         expect(order_item.type).to eq(described_class::TYPES[:edit])
@@ -55,8 +56,20 @@ module WasteCarriersEngine
         expect(order_item.amount).to eq(2_500)
       end
 
-      it "should set the correct description" do
-        expect(order_item.description).to eq("changing carrier type during renewal")
+      context "when the journey is :renewal" do
+        let(:journey) { :renewal }
+
+        it "should set the correct description" do
+          expect(order_item.description).to eq("changing carrier type during renewal")
+        end
+      end
+
+      context "when the journey is :edit" do
+        let(:journey) { :edit }
+
+        it "should set the correct description" do
+          expect(order_item.description).to eq("changing carrier type during edit")
+        end
       end
     end
 

--- a/spec/models/waste_carriers_engine/order_item_spec.rb
+++ b/spec/models/waste_carriers_engine/order_item_spec.rb
@@ -36,7 +36,7 @@ module WasteCarriersEngine
       end
 
       it "should set the correct description" do
-        expect(order_item.description).to eq("Renewal of registration")
+        expect(order_item.description).to eq("renewal of registration")
       end
     end
 

--- a/spec/models/waste_carriers_engine/order_item_spec.rb
+++ b/spec/models/waste_carriers_engine/order_item_spec.rb
@@ -41,8 +41,7 @@ module WasteCarriersEngine
     end
 
     describe "new_type_change_item" do
-      let(:journey) {}
-      let(:order_item) { described_class.new_type_change_item(journey) }
+      let(:order_item) { described_class.new_type_change_item }
 
       it "should have a type of 'EDIT'" do
         expect(order_item.type).to eq(described_class::TYPES[:edit])
@@ -56,20 +55,8 @@ module WasteCarriersEngine
         expect(order_item.amount).to eq(2_500)
       end
 
-      context "when the journey is :renewal" do
-        let(:journey) { :renewal }
-
-        it "should set the correct description" do
-          expect(order_item.description).to eq("changing carrier type during renewal")
-        end
-      end
-
-      context "when the journey is :edit" do
-        let(:journey) { :edit }
-
-        it "should set the correct description" do
-          expect(order_item.description).to eq("changing carrier type during edit")
-        end
+      it "should set the correct description" do
+        expect(order_item.description).to eq("changing carrier type")
       end
     end
 

--- a/spec/models/waste_carriers_engine/order_spec.rb
+++ b/spec/models/waste_carriers_engine/order_spec.rb
@@ -78,7 +78,7 @@ module WasteCarriersEngine
         end
 
         it "should have the correct description" do
-          expect(order.description).to eq("Renewal of registration, plus changing carrier type during renewal")
+          expect(order.description).to eq("Renewal of registration, plus changing carrier type")
         end
       end
 

--- a/spec/services/waste_carriers_engine/order_additional_cards_service_spec.rb
+++ b/spec/services/waste_carriers_engine/order_additional_cards_service_spec.rb
@@ -18,7 +18,7 @@ module WasteCarriersEngine
         expect(finance_details).to receive(:transient_registration=).with(transient_registration)
         expect(Order).to receive(:new_order_for).with(user).and_return(order)
         expect(OrderItem).to receive(:new_copy_cards_item).with(2).and_return(order_item)
-        expect(order).to receive(:generate_description)
+        expect(order).to receive(:set_description)
         expect(order).to receive(:[]=).with(:order_items, [order_item])
         expect(order_item).to receive(:[]).with(:amount).and_return(10)
         expect(order).to receive(:[]=).with(:total_amount, 10)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-833

This is part of a set of multiple PRs to configure payment when a carrier type changes during editing.

This PR covers setting up the order models to be usable with the edit journey, rather than assume they are only used for renewals.