### PR TITLE
Add presenter for order details

### DIFF
--- a/app/presenters/waste_carriers_engine/order_and_total_presenter.rb
+++ b/app/presenters/waste_carriers_engine/order_and_total_presenter.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class OrderAndTotalPresenter < BasePresenter
+    LOCALES_KEY = ".waste_carriers_engine.shared.order_and_total"
+
+    def order_items
+      items = []
+
+      transient_registration.finance_details.orders.first.order_items.each do |item|
+        items << add_order_item(item)
+      end
+
+      items
+    end
+
+    def total_cost
+      transient_registration.finance_details.balance
+    end
+
+    private
+
+    def add_order_item(item)
+      formatted_item = {}
+
+      formatted_item[:cost] = item.amount
+      formatted_item[:description] = description_for(item)
+
+      formatted_item
+    end
+
+    def description_for(item)
+      case item.type
+      when OrderItem::TYPES[:renew]
+        description_for_renew
+      when OrderItem::TYPES[:edit]
+        description_for_type_change
+      when OrderItem::TYPES[:copy_cards]
+        description_for_copy_cards
+      when OrderItem::TYPES[:charge_adjust]
+        description_for_charge_adjust
+      else
+        raise ArgumentError, "No description for #{item.type}"
+      end
+    end
+
+    def description_for_renew
+      I18n.t("#{LOCALES_KEY}.item_descriptions.renew")
+    end
+
+    def description_for_type_change
+      if renewal?
+        I18n.t("#{LOCALES_KEY}.item_descriptions.type_change.renewal")
+      else
+        I18n.t("#{LOCALES_KEY}.item_descriptions.type_change.edit")
+      end
+    end
+
+    def description_for_copy_cards
+      I18n.t("#{LOCALES_KEY}.item_descriptions.copy_cards", count: transient_registration.temp_cards)
+    end
+
+    def description_for_charge_adjust
+      I18n.t("#{LOCALES_KEY}.item_descriptions.charge_adjust")
+    end
+
+    def renewal?
+      transient_registration.is_a?(RenewingRegistration)
+    end
+  end
+end

--- a/app/presenters/waste_carriers_engine/order_and_total_presenter.rb
+++ b/app/presenters/waste_carriers_engine/order_and_total_presenter.rb
@@ -23,7 +23,7 @@ module WasteCarriersEngine
     def add_order_item(item)
       formatted_item = {}
 
-      formatted_item[:cost] = item.amount
+      formatted_item[:amount] = item.amount
       formatted_item[:description] = description_for(item)
 
       formatted_item

--- a/config/locales/shared/order_and_total.en.yml
+++ b/config/locales/shared/order_and_total.en.yml
@@ -1,0 +1,15 @@
+en:
+  waste_carriers_engine:
+    shared:
+      order_and_total:
+        legend: "Order details"
+        item_descriptions:
+          renew: "Renewal of registration"
+          type_change:
+            renewal: "Additional charge for changing registration type"
+            edit: "Charge for changing registration type"
+          copy_cards:
+            one: "1 registration card total cost"
+            other: "%{count} registration cards total cost"
+          charge_adjust: "Charge adjust"
+        total_cost: "Total charge"

--- a/spec/presenters/waste_carriers_engine/order_and_total_presenter_spec.rb
+++ b/spec/presenters/waste_carriers_engine/order_and_total_presenter_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe OrderAndTotalPresenter do
+    subject { described_class.new(form, view) }
+
+    let(:form) { double(:form, transient_registration: transient_registration) }
+    let(:transient_registration) do
+      double(:transient_registration,
+             finance_details: finance_details,
+             temp_cards: temp_cards)
+    end
+    let(:temp_cards) { 2 }
+
+    let(:finance_details) { double(:finance_details, balance: balance, orders: orders) }
+    let(:balance) { 0 }
+    let(:orders) { [order] }
+    let(:order) { double(:order, order_items: order_items) }
+
+    let(:order_items) { [] }
+    let(:renewal_order_item) { double(:order_item, type: OrderItem::TYPES[:renew], amount: 10_500) }
+    let(:edit_order_item) { double(:order_item, type: OrderItem::TYPES[:edit], amount: 4_000) }
+    let(:copy_cards_order_item) { double(:order_item, type: OrderItem::TYPES[:copy_cards], amount: 1_000) }
+    let(:charge_adjust_order_item) { double(:order_item, type: OrderItem::TYPES[:charge_adjust], amount: 500) }
+
+    describe "#order_items" do
+      let(:order_items) { [edit_order_item, copy_cards_order_item, charge_adjust_order_item] }
+
+      it "returns a correctly-formatted list with descriptions and values" do
+        expected_list = [
+          {
+            description: "Charge for changing registration type",
+            cost: 4_000
+          },
+          {
+            description: "2 registration cards total cost",
+            cost: 1_000
+          },
+          {
+            description: "Charge adjust",
+            cost: 500
+          }
+        ]
+        expect(subject.order_items).to eq(expected_list)
+      end
+
+      context "when the transient registration is a renewal" do
+        let(:order_items) { [renewal_order_item, edit_order_item, copy_cards_order_item, charge_adjust_order_item] }
+
+        before { allow(transient_registration).to receive(:is_a?).with(RenewingRegistration).and_return(true) }
+
+        it "returns a correctly-formatted list with the renewal description and values" do
+          expected_list = [
+            {
+              description: "Renewal of registration",
+              cost: 10_500
+            },
+            {
+              description: "Additional charge for changing registration type",
+              cost: 4_000
+            },
+            {
+              description: "2 registration cards total cost",
+              cost: 1_000
+            },
+            {
+              description: "Charge adjust",
+              cost: 500
+            }
+          ]
+          expect(subject.order_items).to eq(expected_list)
+        end
+      end
+    end
+
+    describe "#total_cost" do
+      it "returns the balance" do
+        expect(subject.total_cost).to eq(balance)
+      end
+    end
+  end
+end

--- a/spec/presenters/waste_carriers_engine/order_and_total_presenter_spec.rb
+++ b/spec/presenters/waste_carriers_engine/order_and_total_presenter_spec.rb
@@ -32,15 +32,15 @@ module WasteCarriersEngine
         expected_list = [
           {
             description: "Charge for changing registration type",
-            cost: 4_000
+            amount: 4_000
           },
           {
             description: "2 registration cards total cost",
-            cost: 1_000
+            amount: 1_000
           },
           {
             description: "Charge adjust",
-            cost: 500
+            amount: 500
           }
         ]
         expect(subject.order_items).to eq(expected_list)
@@ -55,19 +55,19 @@ module WasteCarriersEngine
           expected_list = [
             {
               description: "Renewal of registration",
-              cost: 10_500
+              amount: 10_500
             },
             {
               description: "Additional charge for changing registration type",
-              cost: 4_000
+              amount: 4_000
             },
             {
               description: "2 registration cards total cost",
-              cost: 1_000
+              amount: 1_000
             },
             {
               description: "Charge adjust",
-              cost: 500
+              amount: 500
             }
           ]
           expect(subject.order_items).to eq(expected_list)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-833

This is part of a set of multiple PRs to configure payment when a carrier type changes during editing.

This presenter will be used to display the individual charges of an order, as well as the total cost.

The aim is to standardise our various payment pages as much as we can.