### PR TITLE
Move checks on registration type changes to concern

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_check_if_registration_type_changed.rb
+++ b/app/models/concerns/waste_carriers_engine/can_check_if_registration_type_changed.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  module CanCheckIfRegistrationTypeChanged
+    extend ActiveSupport::Concern
+
+    included do
+      # Check if the user has changed the registration type, as this incurs an additional 40GBP charge
+      def registration_type_changed?
+        # Don't compare registration types if the new one hasn't been set
+        return false unless registration_type
+
+        registration.registration_type != registration_type
+      end
+    end
+  end
+end

--- a/app/models/waste_carriers_engine/edit_registration.rb
+++ b/app/models/waste_carriers_engine/edit_registration.rb
@@ -2,6 +2,7 @@
 
 module WasteCarriersEngine
   class EditRegistration < TransientRegistration
+    include CanCheckIfRegistrationTypeChanged
     include CanCopyDataFromRegistration
     include CanUseEditRegistrationWorkflow
     include CanUseLock

--- a/app/models/waste_carriers_engine/renewing_registration.rb
+++ b/app/models/waste_carriers_engine/renewing_registration.rb
@@ -2,6 +2,7 @@
 
 module WasteCarriersEngine
   class RenewingRegistration < TransientRegistration
+    include CanCheckIfRegistrationTypeChanged
     include CanCopyDataFromRegistration
     include CanUseRenewingRegistrationWorkflow
     include CanUseLock
@@ -26,14 +27,6 @@ module WasteCarriersEngine
                                copy_cards],
       remove_invalid_attributes: true
     }.freeze
-
-    # Check if the user has changed the registration type, as this incurs an additional 40GBP charge
-    def registration_type_changed?
-      # Don't compare registration types if the new one hasn't been set
-      return false unless registration_type
-
-      registration.registration_type != registration_type
-    end
 
     def registration
       @_registration ||= Registration.find_by(reg_identifier: reg_identifier)

--- a/spec/models/waste_carriers_engine/edit_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/edit_registration_spec.rb
@@ -6,6 +6,8 @@ module WasteCarriersEngine
   RSpec.describe EditRegistration, type: :model do
     subject(:edit_registration) { build(:edit_registration) }
 
+    it_should_behave_like "Can check if registration type changed"
+
     context "default status" do
       context "when an EditRegistration is created" do
         it "has the state of :edit_form" do

--- a/spec/models/waste_carriers_engine/renewing_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_spec.rb
@@ -6,6 +6,8 @@ module WasteCarriersEngine
   RSpec.describe RenewingRegistration, type: :model do
     subject(:renewing_registration) { build(:renewing_registration, :has_required_data) }
 
+    it_should_behave_like "Can check if registration type changed"
+
     describe "scopes" do
       it_should_behave_like "TransientRegistration named scopes"
     end
@@ -120,24 +122,6 @@ module WasteCarriersEngine
     describe "status" do
       it_should_behave_like "Can check registration status",
                             factory: :renewing_registration
-    end
-
-    describe "#registration_type_changed?" do
-      context "when a RenewingRegistration is created" do
-        it "should return false" do
-          expect(renewing_registration.registration_type_changed?).to eq(false)
-        end
-
-        context "when the registration_type is updated" do
-          before(:each) do
-            renewing_registration.registration_type = "broker_dealer"
-          end
-
-          it "should return true" do
-            expect(renewing_registration.registration_type_changed?).to eq(true)
-          end
-        end
-      end
     end
 
     describe "#renewal_application_submitted?" do

--- a/spec/support/shared_examples/can_check_if_registration_type_changed.rb
+++ b/spec/support/shared_examples/can_check_if_registration_type_changed.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "Can check if registration type changed" do
+  describe "#registration_type_changed?" do
+    context "when the resource is created" do
+      it "should return false" do
+        expect(subject.registration_type_changed?).to eq(false)
+      end
+
+      context "when the registration_type is updated" do
+        before(:each) do
+          subject.registration_type = "broker_dealer"
+        end
+
+        it "should return true" do
+          expect(subject.registration_type_changed?).to eq(true)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-833

This is part of a set of multiple PRs to configure payment when a carrier type changes during editing.

Renewals already had a check to see if a registration type had been changed from the original registration. We'll need to use this for edits as well, so it makes sense to move this check to a new shared concern.