### PR TITLE
Make EditCompletionService deal with new finance info

### DIFF
--- a/app/services/waste_carriers_engine/edit_completion_service.rb
+++ b/app/services/waste_carriers_engine/edit_completion_service.rb
@@ -2,9 +2,12 @@
 
 module WasteCarriersEngine
   class EditCompletionService < BaseService
+    attr_reader :transient_registration
+
+    delegate :registration, to: :transient_registration
+
     def run(edit_registration:)
-      @edit_registration = edit_registration
-      @registration = @edit_registration.registration
+      @transient_registration = edit_registration
 
       copy_names_to_contact_address
       create_past_registration
@@ -15,39 +18,39 @@ module WasteCarriersEngine
     private
 
     def copy_names_to_contact_address
-      @edit_registration.contact_address.first_name = @edit_registration.first_name
-      @edit_registration.contact_address.last_name = @edit_registration.last_name
+      @transient_registration.contact_address.first_name = @transient_registration.first_name
+      @transient_registration.contact_address.last_name = @transient_registration.last_name
     end
 
     def create_past_registration
-      PastRegistration.build_past_registration(@registration, :edit)
+      PastRegistration.build_past_registration(registration, :edit)
     end
 
     def copy_data_to_registration
       copy_attributes
-      @registration.save!
+      registration.save!
     end
 
     def delete_transient_registration
-      @edit_registration.delete
+      @transient_registration.delete
     end
 
     def copy_attributes
-      copyable_attributes = @edit_registration.attributes.except("_id",
-                                                                 "token",
-                                                                 "account_email",
-                                                                 "created_at",
-                                                                 "financeDetails",
-                                                                 "temp_cards",
-                                                                 "temp_company_postcode",
-                                                                 "temp_contact_postcode",
-                                                                 "temp_os_places_error",
-                                                                 "temp_payment_method",
-                                                                 "temp_tier_check",
-                                                                 "_type",
-                                                                 "workflow_state")
+      copyable_attributes = @transient_registration.attributes.except("_id",
+                                                                      "token",
+                                                                      "account_email",
+                                                                      "created_at",
+                                                                      "financeDetails",
+                                                                      "temp_cards",
+                                                                      "temp_company_postcode",
+                                                                      "temp_contact_postcode",
+                                                                      "temp_os_places_error",
+                                                                      "temp_payment_method",
+                                                                      "temp_tier_check",
+                                                                      "_type",
+                                                                      "workflow_state")
 
-      @registration.write_attributes(copyable_attributes)
+      registration.write_attributes(copyable_attributes)
     end
   end
 end

--- a/app/services/waste_carriers_engine/edit_completion_service.rb
+++ b/app/services/waste_carriers_engine/edit_completion_service.rb
@@ -20,8 +20,8 @@ module WasteCarriersEngine
     private
 
     def copy_names_to_contact_address
-      @transient_registration.contact_address.first_name = @transient_registration.first_name
-      @transient_registration.contact_address.last_name = @transient_registration.last_name
+      transient_registration.contact_address.first_name = transient_registration.first_name
+      transient_registration.contact_address.last_name = transient_registration.last_name
     end
 
     def create_past_registration
@@ -35,23 +35,23 @@ module WasteCarriersEngine
     end
 
     def delete_transient_registration
-      @transient_registration.delete
+      transient_registration.delete
     end
 
     def copy_attributes
-      copyable_attributes = @transient_registration.attributes.except("_id",
-                                                                      "token",
-                                                                      "account_email",
-                                                                      "created_at",
-                                                                      "financeDetails",
-                                                                      "temp_cards",
-                                                                      "temp_company_postcode",
-                                                                      "temp_contact_postcode",
-                                                                      "temp_os_places_error",
-                                                                      "temp_payment_method",
-                                                                      "temp_tier_check",
-                                                                      "_type",
-                                                                      "workflow_state")
+      copyable_attributes = transient_registration.attributes.except("_id",
+                                                                     "token",
+                                                                     "account_email",
+                                                                     "created_at",
+                                                                     "financeDetails",
+                                                                     "temp_cards",
+                                                                     "temp_company_postcode",
+                                                                     "temp_contact_postcode",
+                                                                     "temp_os_places_error",
+                                                                     "temp_payment_method",
+                                                                     "temp_tier_check",
+                                                                     "_type",
+                                                                     "workflow_state")
 
       registration.write_attributes(copyable_attributes)
     end

--- a/app/services/waste_carriers_engine/edit_completion_service.rb
+++ b/app/services/waste_carriers_engine/edit_completion_service.rb
@@ -2,6 +2,8 @@
 
 module WasteCarriersEngine
   class EditCompletionService < BaseService
+    include CanMergeFinanceDetails
+
     attr_reader :transient_registration
 
     delegate :registration, to: :transient_registration
@@ -28,6 +30,7 @@ module WasteCarriersEngine
 
     def copy_data_to_registration
       copy_attributes
+      merge_finance_details
       registration.save!
     end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-833

This is part of a set of multiple PRs to configure payment when a carrier type changes during editing.

The EditCompletionService currently disregards any finance_details on the transient object. However, if the user is required to pay for an edit, a new finance_details will be created. We need to be able to merge any new orders and payments onto the original registration.

The OrderCopyCardsCompletionService already deals with this, so we just need to make some tweaks the EditCompletionService to follow that example.