### PR TITLE
Build finance_details object for edit journey

### DIFF
--- a/app/models/waste_carriers_engine/order_copy_cards_registration.rb
+++ b/app/models/waste_carriers_engine/order_copy_cards_registration.rb
@@ -14,7 +14,7 @@ module WasteCarriersEngine
     end
 
     def prepare_for_payment(mode, user)
-      OrderAdditionalCardsService.run(
+      BuildOrderCopyCardsFinanceDetailsService.run(
         cards_count: temp_cards,
         user: user,
         transient_registration: self,

--- a/app/services/waste_carriers_engine/build_edit_finance_details_service.rb
+++ b/app/services/waste_carriers_engine/build_edit_finance_details_service.rb
@@ -18,7 +18,7 @@ module WasteCarriersEngine
 
     def set_up_edit_order(user, payment_method, transient_registration)
       order = Order.new_order_for(user)
-      new_item = OrderItem.new_type_change_item(:edit) if transient_registration.registration_type_changed?
+      new_item = OrderItem.new_type_change_item if transient_registration.registration_type_changed?
 
       order[:order_items] = [new_item]
 

--- a/app/services/waste_carriers_engine/build_edit_finance_details_service.rb
+++ b/app/services/waste_carriers_engine/build_edit_finance_details_service.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class BuildEditFinanceDetailsService < BaseService
+    def run(user:, transient_registration:, payment_method:)
+      finance_details = FinanceDetails.new
+      finance_details.transient_registration = transient_registration
+      order = set_up_edit_order(user, payment_method, transient_registration)
+
+      finance_details[:orders] ||= []
+      finance_details[:orders] << order
+
+      finance_details.update_balance
+      finance_details.save!
+    end
+
+    private
+
+    def set_up_edit_order(user, payment_method, transient_registration)
+      order = Order.new_order_for(user)
+      new_item = OrderItem.new_type_change_item(:edit) if transient_registration.registration_type_changed?
+
+      order[:order_items] = [new_item]
+
+      order.generate_description
+
+      order[:total_amount] = new_item[:amount]
+
+      order.add_bank_transfer_attributes if payment_method == :bank_transfer
+      order.add_worldpay_attributes if payment_method == :worldpay
+
+      order
+    end
+  end
+end

--- a/app/services/waste_carriers_engine/build_order_copy_cards_finance_details_service.rb
+++ b/app/services/waste_carriers_engine/build_order_copy_cards_finance_details_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module WasteCarriersEngine
-  class OrderAdditionalCardsService < BaseService
+  class BuildOrderCopyCardsFinanceDetailsService < BaseService
     def run(cards_count:, user:, transient_registration:, payment_method:)
       finance_details = FinanceDetails.new
       finance_details.transient_registration = transient_registration

--- a/spec/services/waste_carriers_engine/build_edit_finance_details_service_spec.rb
+++ b/spec/services/waste_carriers_engine/build_edit_finance_details_service_spec.rb
@@ -18,7 +18,7 @@ module WasteCarriersEngine
         expect(finance_details).to receive(:transient_registration=).with(transient_registration)
         expect(Order).to receive(:new_order_for).with(user).and_return(order)
         expect(transient_registration).to receive(:registration_type_changed?).and_return(true)
-        expect(OrderItem).to receive(:new_type_change_item).and_return(order_item)
+        expect(OrderItem).to receive(:new_type_change_item).with(:edit).and_return(order_item)
         expect(order).to receive(:generate_description)
         expect(order).to receive(:[]=).with(:order_items, [order_item])
         expect(order_item).to receive(:[]).with(:amount).and_return(40)

--- a/spec/services/waste_carriers_engine/build_edit_finance_details_service_spec.rb
+++ b/spec/services/waste_carriers_engine/build_edit_finance_details_service_spec.rb
@@ -18,7 +18,7 @@ module WasteCarriersEngine
         expect(finance_details).to receive(:transient_registration=).with(transient_registration)
         expect(Order).to receive(:new_order_for).with(user).and_return(order)
         expect(transient_registration).to receive(:registration_type_changed?).and_return(true)
-        expect(OrderItem).to receive(:new_type_change_item).with(:edit).and_return(order_item)
+        expect(OrderItem).to receive(:new_type_change_item).and_return(order_item)
         expect(order).to receive(:generate_description)
         expect(order).to receive(:[]=).with(:order_items, [order_item])
         expect(order_item).to receive(:[]).with(:amount).and_return(40)

--- a/spec/services/waste_carriers_engine/build_edit_finance_details_service_spec.rb
+++ b/spec/services/waste_carriers_engine/build_edit_finance_details_service_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe BuildEditFinanceDetailsService do
+    describe ".run" do
+      let(:user) { double(:user) }
+      let(:transient_registration) { double(:transient_registration) }
+      let(:order) { double(:order) }
+
+      before do
+        finance_details = double(:finance_details)
+        order_item = double(:order_item)
+        orders = double(:orders)
+
+        expect(FinanceDetails).to receive(:new).and_return(finance_details)
+        expect(finance_details).to receive(:transient_registration=).with(transient_registration)
+        expect(Order).to receive(:new_order_for).with(user).and_return(order)
+        expect(transient_registration).to receive(:registration_type_changed?).and_return(true)
+        expect(OrderItem).to receive(:new_type_change_item).and_return(order_item)
+        expect(order).to receive(:generate_description)
+        expect(order).to receive(:[]=).with(:order_items, [order_item])
+        expect(order_item).to receive(:[]).with(:amount).and_return(40)
+        expect(order).to receive(:[]=).with(:total_amount, 40)
+
+        expect(finance_details).to receive(:[]).with(:orders).and_return(orders).twice
+        expect(orders).to receive(:<<).with(order)
+        expect(finance_details).to receive(:update_balance)
+        expect(finance_details).to receive(:save!)
+      end
+
+      context "when the payment method is bank transfer" do
+        let(:payment_method) { :bank_transfer }
+
+        it "updates the transient_registration's finance details with a new order for the change fee" do
+          expect(order).to receive(:add_bank_transfer_attributes)
+
+          described_class.run(user: user, transient_registration: transient_registration, payment_method: payment_method)
+        end
+      end
+
+      context "when the payment method is worldpay" do
+        let(:payment_method) { :worldpay }
+
+        it "updates the transient_registration's finance details with a new order for the change fee" do
+          expect(order).to receive(:add_worldpay_attributes)
+
+          described_class.run(user: user, transient_registration: transient_registration, payment_method: payment_method)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/waste_carriers_engine/build_order_copy_cards_finance_details_service_spec.rb
+++ b/spec/services/waste_carriers_engine/build_order_copy_cards_finance_details_service_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 module WasteCarriersEngine
-  RSpec.describe OrderAdditionalCardsService do
+  RSpec.describe BuildOrderCopyCardsFinanceDetailsService do
     describe ".run" do
       let(:user) { double(:user) }
       let(:transient_registration) { double(:transient_registration) }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-833

This is part of a set of multiple PRs to configure payment when a carrier type changes during editing.

This PR sets up a BuildEditFinanceDetailsService class which is used to create finance_details objects for the edit journey. It's pretty similar to OrderAdditionalCardsService so there's probably room for consolidating once we have a consistent way of building this objects (I'm looking at you, renewals).