### PR TITLE
Fixes to check your answers validations and texts

### DIFF
--- a/app/forms/waste_carriers_engine/check_your_answers_form.rb
+++ b/app/forms/waste_carriers_engine/check_your_answers_form.rb
@@ -92,7 +92,7 @@ module WasteCarriersEngine
     end
 
     def company_no_required?
-      transient_registration.company_no_required?
+      transient_registration.company_no_required? && transient_registration.upper_tier?
     end
   end
 end

--- a/app/forms/waste_carriers_engine/check_your_answers_form.rb
+++ b/app/forms/waste_carriers_engine/check_your_answers_form.rb
@@ -9,7 +9,7 @@ module WasteCarriersEngine
     delegate :first_name, :last_name, :location, :main_people, :phone_number, to: :transient_registration
     delegate :registration_type, :relevant_people, :tier, to: :transient_registration
     delegate :registered_address, :declared_convictions, to: :transient_registration
-    delegate :lower_tier?, :upper_tier?, to: :transient_registration
+    delegate :lower_tier?, :upper_tier?, :company_no_required?, to: :transient_registration
 
     # This has to be before the validations are called, otherwise it fails.
     def self.custom_error_messages(attribute, *errors)
@@ -89,10 +89,6 @@ module WasteCarriersEngine
 
       errors.add(:company_no, :changed)
       false
-    end
-
-    def company_no_required?
-      transient_registration.company_no_required? && transient_registration.upper_tier?
     end
   end
 end

--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -112,6 +112,7 @@ module WasteCarriersEngine
       # Some business types should not have a company_no
       def company_no_required?
         return false if overseas?
+        return false if upper_tier?
 
         %w[limitedCompany limitedLiabilityPartnership].include?(business_type)
       end

--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -112,7 +112,7 @@ module WasteCarriersEngine
       # Some business types should not have a company_no
       def company_no_required?
         return false if overseas?
-        return false if upper_tier?
+        return false if lower_tier?
 
         %w[limitedCompany limitedLiabilityPartnership].include?(business_type)
       end

--- a/config/locales/forms/check_your_answers_forms/en.yml
+++ b/config/locales/forms/check_your_answers_forms/en.yml
@@ -60,8 +60,8 @@ en:
           "yes": "you deal with waste from other businesses or households"
           "no": "you do not deal with waste from other businesses or households"
         main_service:
-          "yes": "you produce the waste as part of a service you provide"
-          "no": "you just collect or move waste created by your customers"
+          "yes": "you just collect or move waste created by your customers"
+          "no": "you produce the waste as part of a service you provide"
         only_amf: "you only deal with agricultural waste, animal by-products or waste from mines or quarries"
         construction_waste:
           "yes": "you deal with construction or demolition waste"
@@ -76,7 +76,7 @@ en:
             carrier_broker_dealer: "a carrier, broker and dealer (you carry waste yourselves and arrange for others to carry it)"
         date_of_birth: "Date of birth: %{dob}"
         declared_convictions:
-          "yes": "You told us there are no relevant people with convictions in your business or organisation."
+          "yes": "You told us there are relevant people with convictions in your business or organisation."
           "no": "You told us there are no relevant people with convictions in your business or organisation."
         next_button: Continue
   activemodel:

--- a/config/locales/forms/check_your_answers_forms/en.yml
+++ b/config/locales/forms/check_your_answers_forms/en.yml
@@ -4,9 +4,9 @@ en:
       new:
         title: "Check your answers"
         error_heading: "Something is wrong"
-        error_description_1: "We're missing some of the information we need to renew your registration:"
+        error_description_1: "We're missing some of the information we need to complete this application:"
         error_description_2: "Please go back and make sure all the required questions have been answered."
-        heading: "Check your answers before renewing your registration"
+        heading: "Check your answers"
         subheadings:
           you_told_us: "You told us:"
           registration: "Registration"


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-929

This addresses some issues on the validations we make to the check your answers page, for which we are validating a company number for lower tiers. It also addresses some text fixes so that we don't mention renewals and the text is applicable to the different types of resources