### PR TITLE
Add fetch_presenters hook to FormsController

### DIFF
--- a/app/controllers/waste_carriers_engine/edit_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/edit_forms_controller.rb
@@ -5,9 +5,7 @@ module WasteCarriersEngine
     prepend_before_action :authenticate_user!
 
     def new
-      return unless super(EditForm, "edit_form")
-
-      @presenter = EditFormPresenter.new(@edit_form, view_context)
+      super(EditForm, "edit_form")
     end
 
     def create
@@ -67,6 +65,10 @@ module WasteCarriersEngine
 
       @transient_registration.send("#{transition}!".to_sym)
       redirect_to_correct_form
+    end
+
+    def fetch_presenters
+      @presenter = EditFormPresenter.new(@edit_form, view_context)
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/forms_controller.rb
@@ -9,12 +9,20 @@ module WasteCarriersEngine
 
     # Expects a form class name (eg BusinessTypeForm) and a snake_case name for the form (eg business_type_form)
     def new(form_class, form)
-      set_up_form(form_class, form, params[:token], true)
+      return false unless set_up_form(form_class, form, params[:token], true)
+
+      fetch_presenters
+
+      # Return 'true' by default so the `return unless super(...)` bits in
+      # subclassed controllers don't fail.
+      true
     end
 
     # Expects a form class name (eg BusinessTypeForm) and a snake_case name for the form (eg business_type_form)
     def create(form_class, form)
       return false unless set_up_form(form_class, form, params[:token])
+
+      fetch_presenters
 
       submit_form(instance_variable_get("@#{form}"), transient_registration_attributes)
     end
@@ -127,6 +135,11 @@ module WasteCarriersEngine
       response.headers["Cache-Control"] = "no-cache, no-store, max-age=0, must-revalidate"
       response.headers["Pragma"] = "no-cache"
       response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
+    end
+
+    def fetch_presenters
+      # A little hook to set up presenters used by the forms. Intended to be
+      # overwritten in subclasses when a presenter is required.
     end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-833

Added to enable us to properly use presenters in the edit payment workflow.

This will let us override this method as needed in subclassed forms so we can create presenters at the right time.

Previously we just stuck presenters in the `new` action of the individual controllers. However, if the form failed to submit (for example, a validation error occurred) then the engine would try to `render :new` as part of the `create` action. But in this case the presenter would not be created and so the page would not render properly.

The downside of this is that the `new` method in FormsController no longer returns the result of `set_up_form` - instead it returned the content of `fetch_presenters`, which is `nil` by default. So any actions in subclassed controllers which relied on lines like `return unless super(FormClass, "form_class")` returning true were no longer being called, as the `unless` no longer passed. Setting `new` to return `true` by default fixes this.

However longterm the FormsController just needs some proper refactoring as it's a big ol mess.