### PR TITLE
Set up workflow for edit payments by bank transfer

### DIFF
--- a/app/controllers/waste_carriers_engine/edit_bank_transfer_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/edit_bank_transfer_forms_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class EditBankTransferFormsController < FormsController
+    def new
+      return unless super(EditBankTransferForm, "edit_bank_transfer_form")
+
+      set_up_finance_details
+    end
+
+    def create
+      super(EditBankTransferForm, "edit_bank_transfer_form")
+    end
+
+    private
+
+    def set_up_finance_details
+      @transient_registration.prepare_for_payment(:bank_transfer, current_user)
+    end
+  end
+end

--- a/app/controllers/waste_carriers_engine/edit_payment_summary_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/edit_payment_summary_forms_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class EditPaymentSummaryFormsController < FormsController
+    def new
+      return unless super(EditPaymentSummaryForm, "edit_payment_summary_form")
+
+      set_up_finance_details
+    end
+
+    def create
+      super(EditPaymentSummaryForm, "edit_payment_summary_form")
+    end
+
+    private
+
+    def transient_registration_attributes
+      params.fetch(:edit_payment_summary_form, {}).permit(:temp_payment_method)
+    end
+
+    def fetch_presenters
+      @order_and_total_presenter = OrderAndTotalPresenter.new(@edit_payment_summary_form, view_context)
+    end
+
+    def set_up_finance_details
+      return if @transient_registration.finance_details.present?
+
+      @transient_registration.prepare_for_payment(:unknown, current_user)
+    end
+  end
+end

--- a/app/forms/waste_carriers_engine/edit_bank_transfer_form.rb
+++ b/app/forms/waste_carriers_engine/edit_bank_transfer_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class EditBankTransferForm < BaseForm
+    def self.can_navigate_flexibly?
+      false
+    end
+  end
+end

--- a/app/forms/waste_carriers_engine/edit_payment_summary_form.rb
+++ b/app/forms/waste_carriers_engine/edit_payment_summary_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class EditPaymentSummaryForm < BaseForm
+    delegate :temp_payment_method, to: :transient_registration
+
+    validates :temp_payment_method, inclusion: { in: %w[card bank_transfer] }
+  end
+end

--- a/app/models/concerns/waste_carriers_engine/can_use_edit_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_edit_registration_workflow.rb
@@ -39,6 +39,8 @@ module WasteCarriersEngine
 
         # Complete an edit
         state :declaration_form
+        state :edit_payment_summary_form
+        state :edit_bank_transfer_form
         state :edit_complete_form
 
         # Cancel an edit
@@ -173,6 +175,17 @@ module WasteCarriersEngine
                       to: :declaration_form
 
           transitions from: :declaration_form,
+                      to: :edit_complete_form,
+                      unless: :registration_type_changed?
+
+          transitions from: :declaration_form,
+                      to: :edit_payment_summary_form,
+                      if: :registration_type_changed?
+
+          transitions from: :edit_payment_summary_form,
+                      to: :edit_bank_transfer_form
+
+          transitions from: :edit_bank_transfer_form,
                       to: :edit_complete_form
 
           # Cancel an edit
@@ -237,6 +250,12 @@ module WasteCarriersEngine
           # Complete an edit
           transitions from: :declaration_form,
                       to: :edit_form
+
+          transitions from: :edit_payment_summary_form,
+                      to: :declaration_form
+
+          transitions from: :edit_bank_transfer_form,
+                      to: :edit_payment_summary_form
 
           # Cancelling the edit process
           transitions from: :confirm_edit_cancelled_form,

--- a/app/models/waste_carriers_engine/edit_registration.rb
+++ b/app/models/waste_carriers_engine/edit_registration.rb
@@ -27,5 +27,13 @@ module WasteCarriersEngine
     def registration
       @_registration ||= Registration.find_by(reg_identifier: reg_identifier)
     end
+
+    def prepare_for_payment(mode, user)
+      BuildEditFinanceDetailsService.run(
+        user: user,
+        transient_registration: self,
+        payment_method: mode
+      )
+    end
   end
 end

--- a/app/services/waste_carriers_engine/build_edit_finance_details_service.rb
+++ b/app/services/waste_carriers_engine/build_edit_finance_details_service.rb
@@ -22,7 +22,7 @@ module WasteCarriersEngine
 
       order[:order_items] = [new_item]
 
-      order.generate_description
+      order.set_description
 
       order[:total_amount] = new_item[:amount]
 

--- a/app/views/waste_carriers_engine/edit_bank_transfer_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/edit_bank_transfer_forms/new.html.erb
@@ -1,0 +1,17 @@
+<%= render("waste_carriers_engine/shared/back", back_path: back_edit_bank_transfer_forms_path(@edit_bank_transfer_form.token)) %>
+
+<div class="text">
+  <%= form_for(@edit_bank_transfer_form) do |f| %>
+    <%= render("waste_carriers_engine/shared/errors", object: @edit_bank_transfer_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= render("waste_carriers_engine/shared/bank_transfer_details",
+        reg_identifier: @edit_bank_transfer_form.reg_identifier,
+        payment_due: @edit_bank_transfer_form.transient_registration.finance_details.balance) %>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/waste_carriers_engine/edit_payment_summary_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/edit_payment_summary_forms/new.html.erb
@@ -1,0 +1,17 @@
+<%= render("waste_carriers_engine/shared/back", back_path: back_edit_payment_summary_forms_path(token: @transient_registration.token)) %>
+
+<div class="text">
+  <%= form_for(@edit_payment_summary_form) do |f| %>
+    <%= render("waste_carriers_engine/shared/errors", object: @edit_payment_summary_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= render("waste_carriers_engine/shared/order_and_total", presenter: @order_and_total_presenter) %>
+
+    <%= render("waste_carriers_engine/shared/payment_summary_options", form: @edit_payment_summary_form, f: f) %>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/waste_carriers_engine/shared/_bank_transfer_details.html.erb
+++ b/app/views/waste_carriers_engine/shared/_bank_transfer_details.html.erb
@@ -1,0 +1,63 @@
+<div class="form-group">
+  <table aria-describedby="uk_payment_legend">
+    <legend id="uk_payment_legend">
+      <h2 class="heading-medium">
+        <%= t(".uk_payment_table.heading") %>
+      </h2>
+    </legend>
+
+    <tbody>
+      <tr>
+        <th scope="row"><%= t(".uk_payment_table.sort_code.label") %></th>
+        <td><%= t(".uk_payment_table.sort_code.value") %></td>
+      </tr>
+      <tr>
+        <th scope="row"><%= t(".uk_payment_table.account_number.label") %></th>
+        <td><%= t(".uk_payment_table.account_number.value") %></td>
+      </tr>
+      <tr>
+        <th scope="row">
+          <%= t(".uk_payment_table.reference_number.label") %>
+          <span class="form-hint"><%= t(".uk_payment_table.reference_number.hint") %></span>
+        </th>
+        <td><%= reg_identifier %></td>
+      </tr>
+      <tr>
+        <th scope="row"><%= t(".uk_payment_table.payment_due.label") %></th>
+        <td>£<%= display_pence_as_pounds(payment_due) %></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<details>
+  <summary>
+    <%= t(".overseas_payments.heading") %>
+  </summary>
+  <div class="panel">
+    <%= t(".overseas_payments.iban") %><br/><br/>
+    <%= t(".overseas_payments.swiftbic") %><br/><br/>
+    <%= t(".overseas_payments.currency") %>
+  </div>
+</details>
+
+<div class="form-group">
+  <table aria-describedby="confirmation_legend">
+    <legend id="confirmation_legend">
+      <h2 class="heading-medium">
+        <%= t(".send_confirmation.heading", reg_identifier: reg_identifier) %>
+      </h2>
+    </legend>
+
+    <tbody>
+      <tr>
+        <th scope="row"><%= t(".send_confirmation.email_us.label") %></th>
+        <td><%= t(".send_confirmation.email_us.value") %></td>
+      </tr>
+      <tr>
+        <th scope="row"><%= t(".send_confirmation.payment_reference.label") %></th>
+        <td><%= reg_identifier %></td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/app/views/waste_carriers_engine/shared/_order_and_total.html.erb
+++ b/app/views/waste_carriers_engine/shared/_order_and_total.html.erb
@@ -1,0 +1,23 @@
+<div class="form-group">
+  <table aria-describedby="order_and_total_legend">
+    <legend id="order_and_total_legend" class="visually-hidden">
+      <%= t(".legend") %>
+    </legend>
+    <tbody>
+      <% presenter.order_items.each do |item| %>
+        <tr>
+          <td><%= item[:description] %></td>
+          <td>£<%= display_pence_as_pounds(item[:amount]) %></td>
+        </tr>
+      <% end %>
+      <tr>
+        <th scope="row">
+          <span class="strong">
+            <%= t(".total_cost") %>
+          </span>
+        </th>
+        <td><span class="strong">£<%= display_pence_as_pounds(presenter.total_cost) %></span></td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/app/views/waste_carriers_engine/shared/_payment_summary_options.html.erb
+++ b/app/views/waste_carriers_engine/shared/_payment_summary_options.html.erb
@@ -1,0 +1,29 @@
+<div class="form-group <%= "form-group-error" if form.errors[:temp_payment_method].any? %>">
+  <fieldset id="temp_payment_method">
+    <legend>
+      <h2 class="bold">
+        <%= t(".payment_method.subheading") %>
+      </h2>
+      <p class="form-hint"><%= t(".payment_method.legend") %></p>
+    </legend>
+    <% if form.errors[:temp_payment_method].any? %>
+      <span class="error-message"><%= form.errors[:temp_payment_method].join(", ") %></span>
+    <% end %>
+
+    <div class="multiple-choice">
+      <%= f.radio_button :temp_payment_method, "card" %>
+      <%= f.label :temp_payment_method, value: "card", class: "form-label" do %>
+        <%= t(".options.card") %>
+        <span class="form-hint"><%= t(".hint_pay_by_card") %></span>
+      <% end %>
+    </div>
+
+    <div class="multiple-choice">
+      <%= f.radio_button :temp_payment_method, "bank_transfer" %>
+      <%= f.label :temp_payment_method, value: "bank_transfer", class: "form-label" do %>
+        <%= t(".options.bank_transfer") %>
+        <span class="form-hint"><%= t(".hint_pay_by_bank_transfer") %></span>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/config/locales/forms/edit_bank_transfer_forms/en.yml
+++ b/config/locales/forms/edit_bank_transfer_forms/en.yml
@@ -1,0 +1,7 @@
+en:
+  waste_carriers_engine:
+    edit_bank_transfer_forms:
+      new:
+        title: Pay by bank transfer
+        heading: Pay by bank transfer
+        next_button: Continue

--- a/config/locales/forms/edit_payment_summary_forms/en.yml
+++ b/config/locales/forms/edit_payment_summary_forms/en.yml
@@ -1,0 +1,22 @@
+en:
+  waste_carriers_engine:
+    edit_payment_summary_forms:
+      new:
+        title: "Edit payment summary"
+        heading: "Payment summary"
+        payment_method:
+          subheading: "Payment method"
+          legend: "Preferred payment is by credit or debit card. Do not offer another payment option unless they are unable to pay by card."
+        options:
+          card: "Credit or debit card - encourage customers to pay by card"
+          bank_transfer: "Alternative payment - discouraged"
+        hint_pay_by_card: "Visa, Mastercard, Maestro only"
+        hint_pay_by_bank_transfer: "For example, bank transfer or cheque. We’ll send the cards when payment arrives. Allow 5 days for the transfer to arrive at the bank."
+        next_button: "Go to payment"
+  activemodel:
+    errors:
+      models:
+        waste_carriers_engine/edit_payment_summary_form:
+          attributes:
+            temp_payment_method:
+              inclusion: "Select card or alternative payment"

--- a/config/locales/forms/shared/bank_transfer_details.en.yml
+++ b/config/locales/forms/shared/bank_transfer_details.en.yml
@@ -1,0 +1,29 @@
+en:
+  waste_carriers_engine:
+    shared:
+      bank_transfer_details:
+        uk_payment_table:
+          heading: "Bank details"
+          sort_code:
+            label: Sort code
+            value: 60-70-80
+          account_number:
+            label: Account number
+            value: "10014411"
+          reference_number:
+            label: Payment reference
+            hint: We cannot complete your registration without this
+          payment_due:
+            label: Payment due
+        overseas_payments:
+          heading: "Overseas payments"
+          iban: "IBAN: GB23 NWBK 607080 10014411"
+          swiftbic: "SWIFTBIC: NWBK GB2L"
+          currency: "Currency: Sterling"
+        send_confirmation:
+          heading: "Email us your registration number %{reg_identifier} to confirm you’ve paid"
+          email_us:
+            label: "Email us"
+            value: "ea_fsc_ar@sscl.gse.gov.uk"
+          payment_reference:
+            label: "Payment reference"

--- a/config/locales/forms/shared/order_and_total.en.yml
+++ b/config/locales/forms/shared/order_and_total.en.yml
@@ -1,0 +1,13 @@
+en:
+  waste_carriers_engine:
+    shared:
+      order_and_total:
+        legend: "Order details"
+        item_descriptions:
+          renew: "Renewal of registration"
+          edit: "Additional charge for changing registration type"
+          copy_cards:
+            one: "1 registration card total cost"
+            other: "%{count} registration cards total cost"
+          charge_adjust: "Charge adjust"
+        total_cost: "Total charge"

--- a/config/locales/forms/shared/payment_summary_options.en.yml
+++ b/config/locales/forms/shared/payment_summary_options.en.yml
@@ -1,0 +1,12 @@
+en:
+  waste_carriers_engine:
+    shared:
+      payment_summary_options:
+        payment_method:
+          subheading: "Payment method"
+          legend: "Preferred payment is by credit or debit card. Do not offer another payment option unless they are unable to pay by card."
+        options:
+          card: "Credit or debit card - encourage customers to pay by card"
+          bank_transfer: "Alternative payment - discouraged"
+        hint_pay_by_card: "Visa, Mastercard, Maestro only"
+        hint_pay_by_bank_transfer: "For example, bank transfer or cheque. We’ll send the cards when payment arrives. Allow 5 days for the transfer to arrive at the bank."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -142,6 +142,16 @@ WasteCarriersEngine::Engine.routes.draw do
                     on: :collection
               end
 
+    resources :edit_bank_transfer_forms,
+              only: %i[new create],
+              path: "edit-bank-transfer",
+              path_names: { new: "" } do
+                get "back",
+                    to: "edit_bank_transfer_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+
     resources :edit_complete_forms,
               only: %i[new create],
               path: "edit-complete",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,6 +132,16 @@ WasteCarriersEngine::Engine.routes.draw do
                     on: :collection
               end
 
+    resources :edit_payment_summary_forms,
+              only: %i[new create],
+              path: "edit-payment",
+              path_names: { new: "" } do
+                get "back",
+                    to: "edit_payment_summary_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+
     resources :edit_complete_forms,
               only: %i[new create],
               path: "edit-complete",

--- a/spec/factories/edit_registration.rb
+++ b/spec/factories/edit_registration.rb
@@ -3,5 +3,15 @@
 FactoryBot.define do
   factory :edit_registration, class: WasteCarriersEngine::EditRegistration do
     initialize_with { new(reg_identifier: create(:registration, :has_required_data, :is_active).reg_identifier) }
+
+    trait :has_finance_details do
+      has_changed_registration_type
+
+      finance_details { build(:finance_details, :has_edit_order) }
+    end
+
+    trait :has_changed_registration_type do
+      registration_type { "carrier_dealer" }
+    end
   end
 end

--- a/spec/factories/finance_details.rb
+++ b/spec/factories/finance_details.rb
@@ -17,6 +17,11 @@ FactoryBot.define do
       after(:build, :create, &:update_balance)
     end
 
+    trait :has_edit_order do
+      orders { [build(:order, :has_type_change_item)] }
+      after(:build, :create, &:update_balance)
+    end
+
     trait :has_order_and_payment do
       orders { [build(:order, :has_required_data)] }
       payments { [build(:payment)] }

--- a/spec/factories/forms/copy_cards_bank_transfer_form.rb
+++ b/spec/factories/forms/copy_cards_bank_transfer_form.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :copy_cards_bank_transfer_form, class: WasteCarriersEngine::CopyCardsBankTransferForm do
     trait :has_required_data do
-      initialize_with { new(create(:order_copy_cards_registration, workflow_state: "bank_transfer_form")) }
+      initialize_with { new(create(:order_copy_cards_registration, workflow_state: "copy_cards_bank_transfer_form")) }
     end
   end
 end

--- a/spec/factories/forms/edit_bank_transfer_form.rb
+++ b/spec/factories/forms/edit_bank_transfer_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :edit_bank_transfer_form, class: WasteCarriersEngine::EditBankTransferForm do
+    trait :has_required_data do
+      initialize_with { new(create(:edit_registration, workflow_state: "edit_bank_transfer_form")) }
+    end
+  end
+end

--- a/spec/factories/forms/edit_payment_summary_form.rb
+++ b/spec/factories/forms/edit_payment_summary_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :edit_payment_summary_form, class: WasteCarriersEngine::EditPaymentSummaryForm do
+    trait :has_required_data do
+      initialize_with { new(create(:edit_registration, workflow_state: "edit_payment_summary_form")) }
+    end
+  end
+end

--- a/spec/factories/order.rb
+++ b/spec/factories/order.rb
@@ -18,5 +18,14 @@ FactoryBot.define do
       end
       total_amount { order_items.sum { |item| item[:amount] } }
     end
+
+    trait :has_type_change_item do
+      date_created { Time.now }
+
+      order_items do
+        [WasteCarriersEngine::OrderItem.new_type_change_item]
+      end
+      total_amount { order_items.sum { |item| item[:amount] } }
+    end
   end
 end

--- a/spec/forms/waste_carriers_engine/edit_bank_transfer_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/edit_bank_transfer_forms_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe EditBankTransferForm, type: :model do
+    describe "#submit" do
+      let(:edit_bank_transfer_form) { build(:edit_bank_transfer_form, :has_required_data) }
+
+      context "when the form is valid" do
+        it "should submit" do
+          expect(edit_bank_transfer_form.submit({})).to eq(true)
+        end
+      end
+
+      context "when the form is not valid" do
+        before do
+          expect(edit_bank_transfer_form).to receive(:valid?).and_return(false)
+        end
+
+        it "should not submit" do
+          expect(edit_bank_transfer_form.submit({})).to eq(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/waste_carriers_engine/edit_payment_summary_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/edit_payment_summary_forms_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe EditPaymentSummaryForm, type: :model do
+    describe "#submit" do
+      let(:edit_payment_summary_form) { build(:edit_payment_summary_form, :has_required_data) }
+
+      context "when the form is valid" do
+        let(:valid_params) do
+          { temp_payment_method: "card" }
+        end
+
+        it "should submit" do
+          expect(edit_payment_summary_form.submit(valid_params)).to eq(true)
+        end
+      end
+
+      context "when the form is not valid" do
+        before do
+          expect(edit_payment_summary_form).to receive(:valid?).and_return(false)
+        end
+
+        it "should not submit" do
+          expect(edit_payment_summary_form.submit({})).to eq(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/edit_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/edit_registration_spec.rb
@@ -70,5 +70,20 @@ module WasteCarriersEngine
         end
       end
     end
+
+    describe "#prepare_for_payment" do
+      it "runs the EditFinanceDetailsBuilderService with the correct params" do
+        mode = "OFFLINE"
+        user = double(:user)
+
+        expect(BuildEditFinanceDetailsService).to receive(:run).with(
+          user: user,
+          transient_registration: subject,
+          payment_method: mode
+        )
+
+        subject.prepare_for_payment(mode, user)
+      end
+    end
   end
 end

--- a/spec/models/waste_carriers_engine/edit_registration_workflow/declaration_form_spec.rb
+++ b/spec/models/waste_carriers_engine/edit_registration_workflow/declaration_form_spec.rb
@@ -4,12 +4,24 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe EditRegistration do
+    subject { build(:edit_registration, workflow_state: "declaration_form") }
+
     describe "#workflow_state" do
-      it_behaves_like "a simple bidirectional transition",
-                      previous_state: :edit_form,
-                      current_state: :declaration_form,
-                      next_state: :edit_complete_form,
-                      factory: :edit_registration
+      context ":declaration_form state transitions" do
+        context "on next" do
+          include_examples "has next transition", next_state: "edit_complete_form"
+
+          context "when the registration has changed business type" do
+            before { subject.registration_type = "carrier_dealer" }
+
+            include_examples "has next transition", next_state: "edit_payment_summary_form"
+          end
+        end
+
+        context "on back" do
+          include_examples "has back transition", previous_state: "edit_form"
+        end
+      end
     end
   end
 end

--- a/spec/models/waste_carriers_engine/edit_registration_workflow/edit_bank_transfer_form_spec.rb
+++ b/spec/models/waste_carriers_engine/edit_registration_workflow/edit_bank_transfer_form_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe EditRegistration do
+    subject { build(:edit_registration, workflow_state: "edit_bank_transfer_form") }
+
+    describe "#workflow_state" do
+      context ":payment_summary_form state transitions" do
+        context "on next" do
+          include_examples "has next transition", next_state: "edit_complete_form"
+        end
+
+        context "on back" do
+          include_examples "has back transition", previous_state: "edit_payment_summary_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/edit_registration_workflow/edit_payment_summary_form_spec.rb
+++ b/spec/models/waste_carriers_engine/edit_registration_workflow/edit_payment_summary_form_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe EditRegistration do
+    subject { build(:edit_registration, workflow_state: "edit_payment_summary_form") }
+
+    describe "#workflow_state" do
+      context ":payment_summary_form state transitions" do
+        context "on next" do
+          include_examples "has next transition", next_state: "edit_bank_transfer_form"
+        end
+
+        context "on back" do
+          include_examples "has back transition", previous_state: "declaration_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/waste_carriers_engine/edit_bank_transfer_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/edit_bank_transfer_forms_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "EditBankTransferForms", type: :request do
+    describe "GET new_edit_bank_transfer_form" do
+      context "when a valid user is signed in" do
+        let(:user) { create(:user) }
+        before(:each) do
+          sign_in(user)
+        end
+
+        context "when a valid transient registration exists" do
+          let(:transient_registration) do
+            create(:edit_registration, registration_type: "carrier_dealer", workflow_state: "edit_bank_transfer_form")
+          end
+
+          it "creates a new order on the transient registration every time it is called" do
+            expect(transient_registration.finance_details).to be_nil
+
+            get new_edit_bank_transfer_form_path(transient_registration.token)
+
+            first_finance_details = transient_registration.reload.finance_details
+            order = first_finance_details.orders.first
+            order_item = order.order_items.first
+
+            expect(first_finance_details.orders.count).to eq(1)
+            expect(first_finance_details.balance).to eq(4_000)
+            expect(order.order_items.count).to eq(1)
+            expect(order_item.type).to eq("EDIT")
+            expect(order_item.amount).to eq(4_000)
+
+            get new_edit_bank_transfer_form_path(transient_registration.token)
+
+            second_finance_details = transient_registration.reload.finance_details
+
+            expect(first_finance_details).to_not eq(second_finance_details)
+          end
+        end
+      end
+    end
+
+    describe "POST new_edit_bank_transfer_form" do
+      context "when a valid user is signed in" do
+        let(:user) { create(:user) }
+
+        before(:each) do
+          sign_in(user)
+        end
+
+        context "when an order is in progress" do
+          let(:transient_registration) do
+            create(
+              :edit_registration,
+              :has_finance_details,
+              workflow_state: :edit_bank_transfer_form
+            )
+          end
+
+          it "redirects to the completion page" do
+            post_form_with_params(:edit_bank_transfer_form, transient_registration.token)
+
+            expect(response).to redirect_to(new_edit_complete_form_path(transient_registration.token))
+          end
+        end
+      end
+    end
+
+    describe "GET back_edit_bank_transfer_forms_path" do
+      context "when a valid user is signed in" do
+        let(:user) { create(:user) }
+        before(:each) do
+          sign_in(user)
+        end
+
+        context "when a valid transient registration exists" do
+          let(:transient_registration) do
+            create(:edit_registration, workflow_state: :edit_bank_transfer_form)
+          end
+
+          context "when the back action is triggered" do
+            it "returns a 302 response" do
+              get back_edit_bank_transfer_forms_path(transient_registration.token)
+
+              expect(response).to have_http_status(302)
+            end
+
+            it "redirects to the payment_summary form" do
+              get back_edit_bank_transfer_forms_path(transient_registration.token)
+              expect(response).to redirect_to(new_edit_payment_summary_form_path(transient_registration.token))
+            end
+          end
+        end
+
+        context "when the transient registration is in the wrong state" do
+          let(:transient_registration) do
+            create(:edit_registration, workflow_state: :location_form)
+          end
+
+          context "when the back action is triggered" do
+            it "returns a 302 response" do
+              get back_edit_bank_transfer_forms_path(transient_registration.token)
+              expect(response).to have_http_status(302)
+            end
+
+            it "redirects to the correct form for the state" do
+              get back_edit_bank_transfer_forms_path(transient_registration.token)
+              expect(response).to redirect_to(new_location_form_path(transient_registration.token))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/waste_carriers_engine/edit_payment_summary_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/edit_payment_summary_forms_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "EditPaymentSummaryForms", type: :request do
+    describe "GET new_edit_payment_summary_form_path" do
+      context "when a user is signed in" do
+        let(:user) { create(:user) }
+
+        before(:each) do
+          sign_in(user)
+        end
+
+        context "when no matching registration exists" do
+          it "redirects to the invalid token error page" do
+            get new_edit_payment_summary_form_path("CBDU999999999")
+            expect(response).to redirect_to(page_path("invalid"))
+          end
+        end
+
+        context "when a matching registration exists" do
+          let(:edit_registration) do
+            create(:edit_registration,
+                   :has_finance_details,
+                   workflow_state: "edit_payment_summary_form")
+          end
+
+          it "renders the appropriate template and responds with a 200 status code" do
+            get new_edit_payment_summary_form_path(edit_registration.token)
+
+            expect(response).to render_template("waste_carriers_engine/edit_payment_summary_forms/new")
+            expect(response.code).to eq("200")
+          end
+
+          context "when it already has a finance_details" do
+            it "does not modify the finance_details" do
+              expect { get new_edit_payment_summary_form_path(edit_registration.token) }.to_not change { edit_registration.finance_details }
+            end
+          end
+
+          context "when it does not have a finance_details" do
+            let(:edit_registration) do
+              create(:edit_registration,
+                     :has_changed_registration_type,
+                     workflow_state: "edit_payment_summary_form")
+            end
+
+            it "creates a new finance_details" do
+              expect(edit_registration.finance_details).to be_nil
+
+              get new_edit_payment_summary_form_path(edit_registration.token)
+
+              expect(edit_registration.reload.finance_details).to_not be_nil
+            end
+          end
+        end
+      end
+    end
+
+    describe "POST edit_payment_summary_forms_path" do
+      context "when a user is signed in" do
+        let(:user) { create(:user) }
+
+        before(:each) do
+          sign_in(user)
+        end
+
+        context "when no matching registration exists" do
+          it "does not create a new transient registration and redirects to the invalid page" do
+            original_tr_count = EditRegistration.count
+
+            post edit_payment_summary_forms_path(token: "CBDU222")
+
+            expect(response).to redirect_to(page_path("invalid"))
+            expect(EditRegistration.count).to eq(original_tr_count)
+          end
+        end
+
+        context "when a matching registration exists" do
+          let(:edit_registration) { create(:edit_registration, :has_finance_details, workflow_state: "edit_payment_summary_form") }
+
+          context "when valid params are submitted" do
+            let(:valid_params) { { temp_payment_method: temp_payment_method } }
+
+            # TODO
+            # context "when the temp payment method is `card`" do
+            #   let(:temp_payment_method) { "card" }
+            #
+            #   it "updates the transient registration with correct data, returns a 302 response and redirects to the worldpay form" do
+            #     post edit_payment_summary_forms_path(token: edit_registration.token), edit_payment_summary_form: valid_params
+            #
+            #     edit_registration.reload
+            #
+            #     expect(edit_registration.temp_payment_method).to eq("card")
+            #     expect(response).to have_http_status(302)
+            #     expect(response).to redirect_to(new_worldpay_form_path(edit_registration.token))
+            #   end
+            # end
+
+            context "when the temp payment method is `bank_transfer`" do
+              let(:temp_payment_method) { "bank_transfer" }
+
+              it "updates the transient registration with correct data, returns a 302 response and redirects to the bank transfer form" do
+                post edit_payment_summary_forms_path(token: edit_registration.token), edit_payment_summary_form: valid_params
+
+                edit_registration.reload
+
+                expect(edit_registration.temp_payment_method).to eq("bank_transfer")
+                expect(response).to have_http_status(302)
+                expect(response).to redirect_to(new_edit_bank_transfer_form_path(edit_registration.token))
+              end
+            end
+          end
+
+          context "when invalid params are submitted" do
+            let(:invalid_params) { { temp_payment_method: "foo" } }
+
+            it "returns a 200 response and render the new copy cards form" do
+              post edit_payment_summary_forms_path(token: edit_registration.token), edit_payment_summary_form: invalid_params
+
+              expect(response).to have_http_status(200)
+              expect(response).to render_template("waste_carriers_engine/edit_payment_summary_forms/new")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/waste_carriers_engine/build_edit_finance_details_service_spec.rb
+++ b/spec/services/waste_carriers_engine/build_edit_finance_details_service_spec.rb
@@ -19,7 +19,7 @@ module WasteCarriersEngine
         expect(Order).to receive(:new_order_for).with(user).and_return(order)
         expect(transient_registration).to receive(:registration_type_changed?).and_return(true)
         expect(OrderItem).to receive(:new_type_change_item).and_return(order_item)
-        expect(order).to receive(:generate_description)
+        expect(order).to receive(:set_description)
         expect(order).to receive(:[]=).with(:order_items, [order_item])
         expect(order_item).to receive(:[]).with(:amount).and_return(40)
         expect(order).to receive(:[]=).with(:total_amount, 40)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-833

This is part of a set of multiple PRs to configure payment when a carrier type changes during editing.

This PR sets up the workflow and pages for paying for an edit by bank transfer. This includes the payment summary and bank transfer info pages.

WorldPay will be added separately in a future PR.