### PR TITLE
Rename RegistrationCompletionService to RegistrationActivationService

### DIFF
--- a/app/services/waste_carriers_engine/registration_activation_service.rb
+++ b/app/services/waste_carriers_engine/registration_activation_service.rb
@@ -4,7 +4,7 @@ module WasteCarriersEngine
   class UnpaidBalanceError < StandardError; end
   class PendingConvictionsError < StandardError; end
 
-  class RegistrationCompletionService < BaseService
+  class RegistrationActivationService < BaseService
     def run(registration:)
       @registration = registration
 

--- a/spec/services/waste_carriers_engine/registration_activation_service_spec.rb
+++ b/spec/services/waste_carriers_engine/registration_activation_service_spec.rb
@@ -3,10 +3,10 @@
 require "rails_helper"
 
 module WasteCarriersEngine
-  RSpec.describe RegistrationCompletionService do
+  RSpec.describe RegistrationActivationService do
     let(:registration) { create(:registration, :has_required_data, :is_pending) }
 
-    let(:service) { RegistrationCompletionService.run(registration: registration) }
+    let(:service) { RegistrationActivationService.run(registration: registration) }
 
     let(:current_time) { Time.new(2020, 1, 1) }
 


### PR DESCRIPTION
Given that we now have the need to have a completion service for registrations which will convert a transient to a registration, we are renaming the existing completion service to be an activation service so that we can free the naming to create a completion service that is in line with our conventions.