### PR TITLE
Generate a new registration on completion with pending payments

### DIFF
--- a/app/controllers/waste_carriers_engine/declaration_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/declaration_forms_controller.rb
@@ -19,7 +19,8 @@ module WasteCarriersEngine
     end
 
     def should_check_convictions?
-      @transient_registration.is_a?(RenewingRegistration) || @transient_registration.is_a?(NewRegistration)
+      (@transient_registration.is_a?(RenewingRegistration) || @transient_registration.is_a?(NewRegistration)) &&
+        @transient_registration.upper_tier?
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/registration_received_pending_payment_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/registration_received_pending_payment_forms_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class RegistrationReceivedPendingPaymentFormsController < FormsController
+    def new
+      return unless super(RegistrationReceivedPendingPaymentForm, "registration_received_pending_payment_form")
+
+      begin
+        @registration = RegistrationCompletionService.run(@transient_registration)
+      rescue StandardError => e
+        Airbrake.notify(e, reg_identifier: @transient_registration.reg_identifier)
+        Rails.logger.error e
+      end
+    end
+
+    # Overwrite create and go_back as you shouldn't be able to submit or go back
+    def create; end
+
+    def go_back; end
+  end
+end

--- a/app/forms/waste_carriers_engine/registration_received_pending_payment_form.rb
+++ b/app/forms/waste_carriers_engine/registration_received_pending_payment_form.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class RegistrationReceivedPendingPaymentForm < BaseForm
+    include CannotSubmit
+
+    def self.can_navigate_flexibly?
+      false
+    end
+  end
+end

--- a/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
@@ -62,6 +62,7 @@ module WasteCarriersEngine
         state :bank_transfer_form
 
         state :registration_completed_form
+        state :registration_received_pending_payment_form
 
         # Transitions
         event :next do
@@ -262,6 +263,13 @@ module WasteCarriersEngine
 
           transitions from: :payment_summary_form,
                       to: :bank_transfer_form
+
+          # Registration completion forms
+          transitions from: :bank_transfer_form,
+                      to: :registration_received_pending_payment_form,
+                      # TODO: This don't get triggered if in the `success`
+                      # callback block, hence we went for `after`
+                      after: :set_metadata_route
         end
 
         # Transitions

--- a/app/models/waste_carriers_engine/new_registration.rb
+++ b/app/models/waste_carriers_engine/new_registration.rb
@@ -7,6 +7,8 @@ module WasteCarriersEngine
 
     field :temp_start_option, type: String
 
+    after_initialize :build_meta_data
+
     def prepare_for_payment(mode, _user)
       BuildNewRegistrationFinanceDetailsService.run(
         transient_registration: self,
@@ -26,6 +28,10 @@ module WasteCarriersEngine
 
     def registration_type_base_charges
       [Rails.configuration.new_registration_charge]
+    end
+
+    def build_meta_data
+      build_metaData unless metaData.present?
     end
   end
 end

--- a/app/services/waste_carriers_engine/registration_completion_service.rb
+++ b/app/services/waste_carriers_engine/registration_completion_service.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class RegistrationCompletionService < BaseService
+    attr_reader :transient_registration
+
+    def run(transient_registration)
+      @transient_registration = transient_registration
+
+      transient_registration.with_lock do
+        copy_names_to_contact_address
+        copy_data_from_transient_registration
+
+        set_reg_identifier
+        set_expiry_date
+
+        update_meta_data
+
+        registration.save!
+
+        delete_transient_registration
+        send_confirmation_email
+
+        begin
+          RegistrationActivationService.run(registration: registration)
+        rescue StandardError => e
+          Airbrake.notify(e, reg_identifier: @transient_registration.reg_identifier)
+          Rails.logger.error e
+        end
+      end
+
+      registration
+    end
+
+    private
+
+    def registration
+      @_registration ||= Registration.new
+    end
+
+    def copy_names_to_contact_address
+      transient_registration.contact_address.first_name = transient_registration.first_name
+      transient_registration.contact_address.last_name = transient_registration.last_name
+    end
+
+    def update_meta_data
+      registration.metaData.route = transient_registration.metaData.route
+      registration.metaData.date_registered = Time.current
+    end
+
+    def set_expiry_date
+      registration.expires_on = Rails.configuration.expires_after.years.from_now
+    end
+
+    def delete_transient_registration
+      transient_registration.delete
+    end
+
+    def send_confirmation_email
+      # TODO
+      # Note that we will only send emails here if the registration has pending convictions or pending payments.
+      # In the case when the registration can be completed, the registration activation email is sent from
+      # the RegistrationActivationService.
+    rescue StandardError => e
+      Airbrake.notify(e, registration_no: registration.reg_identifier) if defined?(Airbrake)
+    end
+
+    def set_reg_identifier
+      registration.reg_identifier = transient_registration.reg_identifier
+    end
+
+    def copy_data_from_transient_registration
+      new_attributes = transient_registration.attributes.except(
+        "_id",
+        "reg_identifier",
+        "token",
+        "created_at",
+        "temp_cards",
+        "temp_company_postcode",
+        "temp_start_option",
+        "temp_contact_postcode",
+        "temp_os_places_error",
+        "temp_payment_method",
+        "temp_tier_check",
+        "_type",
+        "workflow_state",
+        "locking_name",
+        "locked_at"
+      )
+
+      registration.write_attributes(new_attributes)
+    end
+  end
+end

--- a/app/views/waste_carriers_engine/registration_received_pending_payment_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/registration_received_pending_payment_forms/new.html.erb
@@ -1,0 +1,26 @@
+<div class="column-two-thirds">
+  <div class="govuk-box-highlight govuk-box-highlight_blue">
+    <h1 class="heading-xlarge"><%= t(".heading") %></h1>
+    <h2 class="heading-large"><%= t(".highlight_text") %><br>
+    <span class="strong"><%= @registration.reg_identifier %></span></p>
+  </div>
+
+  <p><%= t(".paragraph_1", email: @registration.contact_email) %></p>
+  <p><%= t(".paragraph_2") %></p>
+
+  <ul class="list list-bullet">
+    <% t(".list_1").each do |list_item| %>
+      <li><%= list_item %></li>
+    <% end %>
+  </ul>
+
+  <div class="panel">
+    <p>
+      <%= t(".contact.paragraph_1") %>
+      <a href="mailto:<%= t(".contact.email") %>nccc-carrierbroker@environment-agency.gov.uk"><%= t(".contact.email") %></a>
+      <%= t(".contact.text") %>
+    </p>
+  </div>
+
+  <p><%= link_to(t(".survey_link_text"), t("layouts.application.feedback_url")) %> <%= t(".survey_link_hint") %></p>
+</div>

--- a/config/locales/forms/registration_received_pending_payment_forms/en.yml
+++ b/config/locales/forms/registration_received_pending_payment_forms/en.yml
@@ -1,0 +1,20 @@
+en:
+  waste_carriers_engine:
+    registration_received_pending_payment_forms:
+      new:
+        title: "You must now pay by bank transfer"
+        heading: "You must now pay by bank transfer."
+        highlight_text: "Then email us your registration number:"
+        paragraph_1: "We’ve sent an email to %{email} with the payment details and instructions."
+        paragraph_2: "We will not register you until your payment clears."
+        list_1:
+          - "You’re not legally entitled to operate as a waste carrier until we have received your payment and confirmed your registration."
+          - "Please allow 5 working days for your payment to reach us."
+          - "Alternatively, contact us to pay by credit or debit card."
+        contact:
+          paragraph_1: "Contact the Environment Agency on"
+          email: "nccc-carrierbroker@environment-agency.gov.uk"
+          text: "or 03708 506506 within 28 days if your details change."
+        survey_link_text: What did you think of the service?
+        survey_link_hint: (takes 30 seconds)
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,11 @@ WasteCarriersEngine::Engine.routes.draw do
                     as: "back",
                     on: :collection
               end
+
+    resources :registration_received_pending_payment_forms,
+              only: :new,
+              path: "registration-received-pending-payment",
+              path_names: { new: "" }
     # End of new registration flow
 
     # Order copy cards flow

--- a/spec/factories/new_registration.rb
+++ b/spec/factories/new_registration.rb
@@ -2,8 +2,45 @@
 
 FactoryBot.define do
   factory :new_registration, class: WasteCarriersEngine::NewRegistration do
+    metaData { build(:metaData) }
+
+    trait :has_required_data do
+      location { "england" }
+      declared_convictions { "no" }
+      temp_cards { 1 }
+
+      metaData { build(:metaData, route: "DIGITAL") }
+
+      sequence :reg_identifier
+
+      has_addresses
+      has_postcode
+      has_key_people
+      upper
+
+      after(:build, :create) do |registration|
+        registration.prepare_for_payment(:worldpay, nil)
+      end
+    end
+
     trait :upper do
       tier { WasteCarriersEngine::NewRegistration::UPPER_TIER }
+    end
+
+    trait :has_paid_finance_details do
+      finance_details { build(:finance_details, :has_paid_order_and_payment) }
+    end
+
+    trait :has_key_people do
+      key_people do
+        [build(:key_person, :has_required_data, :unmatched_conviction_search_result, :main),
+         build(:key_person, :has_required_data, :unmatched_conviction_search_result, :relevant)]
+      end
+    end
+
+    trait :has_postcode do
+      temp_company_postcode { "BS1 5AH" }
+      temp_contact_postcode { "BS1 5AH" }
     end
 
     trait :lower do

--- a/spec/models/waste_carriers_engine/new_registration_workflow/bank_transfer_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/bank_transfer_form_spec.rb
@@ -8,6 +8,16 @@ module WasteCarriersEngine
 
     describe "#workflow_state" do
       context ":bank_transfer_form state transitions" do
+        context "on next" do
+          include_examples "has next transition", next_state: "registration_received_pending_payment_form"
+
+          it "set a metadata route" do
+            allow(Rails.configuration).to receive(:metadata_route).and_return("test_route")
+
+            expect { subject.next! }.to change { subject.metaData.route }.to("test_route")
+          end
+        end
+
         context "on back" do
           include_examples "has back transition", previous_state: "payment_summary_form"
         end

--- a/spec/requests/waste_carriers_engine/registration_received_pending_payment_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/registration_received_pending_payment_forms_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "RenewalCompleteForms", type: :request do
+    describe "GET new_registration_received_pending_payment_form_path" do
+      context "when no new registration exists" do
+        it "redirects to the invalid page" do
+          get new_registration_received_pending_payment_form_path("wibblewobblejellyonaplate")
+
+          expect(response).to redirect_to(page_path("invalid"))
+        end
+      end
+
+      context "when a valid new registration exists" do
+        let(:transient_registration) do
+          create(
+            :new_registration,
+            :has_required_data,
+            workflow_state: "registration_received_pending_payment_form"
+          )
+        end
+
+        context "when the workflow_state is correct" do
+          it "returns a 200 status, renders the :new template, creates a new registration and deletes the transient registration" do
+            reg_identifier = transient_registration.reg_identifier
+            new_registrations_count = WasteCarriersEngine::NewRegistration.count
+
+            get new_registration_received_pending_payment_form_path(transient_registration.token)
+
+            registration = WasteCarriersEngine::Registration.find_by(reg_identifier: reg_identifier)
+
+            expect(response).to have_http_status(200)
+            expect(response).to render_template(:new)
+            expect(registration).to be_valid
+            expect(WasteCarriersEngine::NewRegistration.count).to eq(new_registrations_count - 1)
+          end
+        end
+
+        context "when the workflow_state is not correct" do
+          before do
+            transient_registration.update_attributes(workflow_state: "payment_summary_form")
+          end
+
+          it "redirects to the correct page and does not creates a new registration nor delete the transient object" do
+            new_registrations_count = WasteCarriersEngine::NewRegistration.count
+
+            get new_registration_received_pending_payment_form_path(transient_registration.token)
+
+            registration_scope = WasteCarriersEngine::Registration.where(reg_identifier: transient_registration.reg_identifier)
+
+            expect(response).to redirect_to(new_payment_summary_form_path(transient_registration.token))
+            expect(WasteCarriersEngine::NewRegistration.count).to eq(new_registrations_count)
+            expect(registration_scope).to be_empty
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/waste_carriers_engine/registration_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/registration_completion_service_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe RegistrationCompletionService do
+    describe ".run" do
+      let(:transient_registration) do
+        create(
+          :new_registration,
+          :has_required_data
+        )
+      end
+
+      it "generates a new registration and copy data to it" do
+        registration_scope = WasteCarriersEngine::Registration.where(reg_identifier: transient_registration.reg_identifier)
+
+        expect(registration_scope.any?).to be_falsey
+
+        registration = described_class.run(transient_registration)
+
+        expect(registration.reg_identifier).to be_present
+        expect(registration.contact_address).to be_present
+        expect(registration.company_address).to be_present
+        expect(registration.expires_on).to be_present
+        expect(registration.metaData.route).to be_present
+        expect(registration.metaData.date_registered).to be_present
+        expect(registration).to be_pending
+      end
+
+      it "deletes the transient registration" do
+        token = transient_registration.token
+
+        described_class.run(transient_registration)
+
+        new_registration_scope = WasteCarriersEngine::NewRegistration.where(token: token)
+
+        expect(new_registration_scope.any?).to be_falsey
+      end
+
+      context "when the balance have been cleared and there are no pending convictions checks" do
+        let(:finance_details) { build(:finance_details, :has_paid_order_and_payment) }
+
+        before do
+          transient_registration.finance_details = finance_details
+          transient_registration.save
+        end
+
+        it "activates the registration" do
+          registration = described_class.run(transient_registration)
+
+          expect(registration).to be_active
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-916

This adds the code necessary to generate a new registration from a transient registration on the new registration journey.
It also add a first received page for upper tier journeys that end with a bank transfer pending payment

<img width="685" alt="Screenshot 2020-03-18 at 19 11 01" src="https://user-images.githubusercontent.com/1385397/77004823-a9cbd300-6957-11ea-874d-54d24d449fc2.png">
