### PR TITLE
Add completed screen for lower tier registrations

### DIFF
--- a/app/controllers/waste_carriers_engine/lower_tier_registration_completed_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/lower_tier_registration_completed_forms_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class LowerTierRegistrationCompletedFormsController < FormsController
+    def new
+      return unless super(LowerTierRegistrationCompletedForm, "lower_tier_registration_completed_forms")
+
+      begin
+        @registration = RegistrationCompletionService.run(@transient_registration)
+      rescue StandardError => e
+        Airbrake.notify(e, reg_identifier: @transient_registration.reg_identifier)
+        Rails.logger.error e
+      end
+    end
+
+    # Overwrite create and go_back as you shouldn't be able to submit or go back
+    def create; end
+
+    def go_back; end
+  end
+end

--- a/app/forms/waste_carriers_engine/lower_tier_registration_completed_form.rb
+++ b/app/forms/waste_carriers_engine/lower_tier_registration_completed_form.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class LowerTierRegistrationCompletedForm < BaseForm
+    include CannotSubmit
+
+    def self.can_navigate_flexibly?
+      false
+    end
+  end
+end

--- a/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
@@ -63,6 +63,7 @@ module WasteCarriersEngine
 
         state :registration_completed_form
         state :registration_received_pending_payment_form
+        state :lower_tier_registration_completed_form
 
         # Transitions
         event :next do
@@ -248,7 +249,7 @@ module WasteCarriersEngine
                       to: :declaration_form
 
           transitions from: :declaration_form,
-                      to: :registration_completed_form,
+                      to: :lower_tier_registration_completed_form,
                       if: :lower_tier?
 
           transitions from: :declaration_form,

--- a/app/services/waste_carriers_engine/registration_activation_service.rb
+++ b/app/services/waste_carriers_engine/registration_activation_service.rb
@@ -39,6 +39,7 @@ module WasteCarriersEngine
     end
 
     def send_confirmation_email
+      # TODO: Add email sent for lower tier
       NewRegistrationMailer.registration_activated(@registration).deliver_now
     rescue StandardError => e
       Airbrake.notify(e, registration_no: @registration.reg_identifier) if defined?(Airbrake)

--- a/app/views/waste_carriers_engine/lower_tier_registration_completed_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/lower_tier_registration_completed_forms/new.html.erb
@@ -1,0 +1,41 @@
+<div class="column-two-thirds">
+  <div class="govuk-box-highlight">
+    <h1 class="heading-xlarge"><%= t(".heading") %></h1>
+
+    <p class="font-large"><%= t(".highlight_text") %><br>
+
+    <span class="strong"><%= @registration.reg_identifier %></span></p>
+  </div>
+
+  <p><%= t(".paragraph_1", email: @registration.contact_email) %></p>
+
+  <h2 class="heading-medium"><%= t(".subheading_1") %></h2>
+
+  <ul class="list list-bullet">
+    <% t(".list_1").each do |list_item| %>
+      <li><%= list_item %></li>
+    <% end %>
+  </ul>
+
+  <h2 class="heading-medium"><%= t(".subheading_2") %></h2>
+
+  <p><%= t(".paragraph_2") %></p>
+
+  <p>
+    <%= t(".email.heading") %>
+    <br>
+    <a href="mailto:<%= t(".email.value") %>nccc-carrierbroker@environment-agency.gov.uk"><%= t(".email.value") %></a>
+  </p>
+
+  <p>
+    <%= t(".telephone.heading") %>
+    <br>
+    <a href="mailto:<%= t(".telephone.value") %>nccc-carrierbroker@environment-agency.gov.uk"><%= t(".telephone.value") %></a>
+  </p>
+
+  <h2 class="heading-medium"><%= t(".subheading_3") %></h2>
+
+  <p><%= t(".paragraph_3") %></p>
+
+  <p><%= link_to(t(".survey_link_text"), t("layouts.application.feedback_url")) %> <%= t(".survey_link_hint") %></p>
+</div>

--- a/config/locales/forms/lower_tier_registration_completed_forms/en.yml
+++ b/config/locales/forms/lower_tier_registration_completed_forms/en.yml
@@ -1,0 +1,24 @@
+en:
+  waste_carriers_engine:
+    lower_tier_registration_completed_forms:
+      new:
+        title: Registration complete
+        heading: Registration complete
+        highlight_text: "Your registration number is"
+        paragraph_1: "We’ve sent a registration confirmation and certificate to %{email}."
+        subheading_1: "What happens next"
+        list_1:
+          - "Your organisation's details will appear on the public register within 5 days."
+          - "Lower tier registrations do not expire."
+        email:
+          heading: "Email"
+          value: "nccc-carrierbroker@environment-agency.gov.uk"
+        telephone:
+          heading: "Telephone"
+          value: "03708 506 506"
+        subheading_2: "If your details change"
+        paragraph_2: "If any of the details you've given us change, you must update them within 28 days by contacting the Environment Agency."
+        subheading_3: "Registration checks"
+        paragraph_3: "Waste carrier registrations are subject to checks. Deliberately providing false details, or not complying with carrier rules, can lead to de-registration and prosecution."
+        survey_link_text: What did you think of the service?
+        survey_link_hint: (takes 30 seconds)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,11 @@ WasteCarriersEngine::Engine.routes.draw do
               only: :new,
               path: "registration-received-pending-payment",
               path_names: { new: "" }
+
+    resources :lower_tier_registration_completed_forms,
+              only: :new,
+              path: "lower-tier-registration-completed",
+              path_names: { new: "" }
     # End of new registration flow
 
     # Order copy cards flow

--- a/spec/factories/new_registration.rb
+++ b/spec/factories/new_registration.rb
@@ -23,6 +23,20 @@ FactoryBot.define do
       end
     end
 
+    trait :has_required_lower_tier_data do
+      location { "england" }
+      declared_convictions { "no" }
+
+      metaData { build(:metaData, route: "DIGITAL") }
+
+      sequence :reg_identifier
+
+      has_addresses
+      has_postcode
+      has_key_people
+      lower
+    end
+
     trait :upper do
       tier { WasteCarriersEngine::NewRegistration::UPPER_TIER }
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/declaration_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/declaration_form_spec.rb
@@ -12,7 +12,7 @@ module WasteCarriersEngine
           context "when the registration is a lower tier" do
             subject { build(:new_registration, :lower, workflow_state: "declaration_form") }
 
-            include_examples "has next transition", next_state: "registration_completed_form"
+            include_examples "has next transition", next_state: "lower_tier_registration_completed_form"
           end
 
           include_examples "has next transition", next_state: "cards_form"

--- a/spec/requests/waste_carriers_engine/lower_tier_registration_completed_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/lower_tier_registration_completed_forms_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "LowerTierRegistrationCompletedForms", type: :request do
+    describe "GET new_lower_tier_registration_completed_form_path" do
+      context "when no new registration exists" do
+        it "redirects to the invalid page" do
+          get new_lower_tier_registration_completed_form_path("wibblewobblejellyonaplate")
+
+          expect(response).to redirect_to(page_path("invalid"))
+        end
+      end
+
+      context "when a valid new registration exists" do
+        let(:transient_registration) do
+          create(
+            :new_registration,
+            :has_required_lower_tier_data,
+            workflow_state: "lower_tier_registration_completed_form"
+          )
+        end
+
+        context "when the workflow_state is correct" do
+          it "returns a 200 status, renders the :new template, creates a new registration and deletes the transient registration" do
+            reg_identifier = transient_registration.reg_identifier
+            new_registrations_count = WasteCarriersEngine::NewRegistration.count
+
+            get new_lower_tier_registration_completed_form_path(transient_registration.token)
+
+            registration = WasteCarriersEngine::Registration.find_by(reg_identifier: reg_identifier)
+
+            expect(response).to have_http_status(200)
+            expect(response).to render_template(:new)
+            expect(registration).to be_active
+            expect(WasteCarriersEngine::NewRegistration.count).to eq(new_registrations_count - 1)
+          end
+        end
+
+        context "when the workflow_state is not correct" do
+          before do
+            transient_registration.update_attributes(workflow_state: "payment_summary_form")
+          end
+
+          it "redirects to the correct page and does not creates a new registration nor delete the transient object" do
+            new_registrations_count = WasteCarriersEngine::NewRegistration.count
+
+            get new_lower_tier_registration_completed_form_path(transient_registration.token)
+
+            registration_scope = WasteCarriersEngine::Registration.where(reg_identifier: transient_registration.reg_identifier)
+
+            expect(response).to redirect_to(new_payment_summary_form_path(transient_registration.token))
+            expect(WasteCarriersEngine::NewRegistration.count).to eq(new_registrations_count)
+            expect(registration_scope).to be_empty
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-838

Add screens for LT completed registration.

<img width="491" alt="Screenshot 2020-03-23 at 10 27 22" src="https://user-images.githubusercontent.com/1385397/77307430-2280b580-6cf1-11ea-9574-e5a1d3301d30.png">
