### PR TITLE
Add rules to completed screen for lower tier registrations

### DIFF
--- a/app/services/waste_carriers_engine/registration_activation_service.rb
+++ b/app/services/waste_carriers_engine/registration_activation_service.rb
@@ -39,6 +39,7 @@ module WasteCarriersEngine
     end
 
     def send_confirmation_email
+      # TODO: Add email sent for lower tier
       NewRegistrationMailer.registration_activated(@registration).deliver_now
     rescue StandardError => e
       Airbrake.notify(e, registration_no: @registration.reg_identifier) if defined?(Airbrake)

--- a/app/views/waste_carriers_engine/registration_completed_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/registration_completed_forms/new.html.erb
@@ -12,7 +12,7 @@
   <h2 class="heading-medium"><%= t(".subheading_1") %></h2>
 
   <ul class="list list-bullet">
-    <% t(".list_1", expires_on: @registration.expires_on.to_formatted_s(:month_year)).each do |list_item| %>
+    <% t(".list_1.#{@registration.tier}", expires_on: @registration.expires_on&.to_formatted_s(:month_year)).each do |list_item| %>
       <li><%= list_item %></li>
     <% end %>
   </ul>

--- a/config/locales/forms/registration_completed_forms/en.yml
+++ b/config/locales/forms/registration_completed_forms/en.yml
@@ -8,9 +8,13 @@ en:
         paragraph_1: "We’ve sent a registration confirmation and certificate to %{email}."
         subheading_1: "What happens next"
         list_1:
-          - "Your organisation's details will appear on the public register within 5 days."
-          - "We will contact you on this email address before this registration is due to expire in %{expires_on}."
-          - "If we cannot reach you when the renewal is due, you’ll have to pay more for a new upper tier registration."
+          UPPER:
+            - "Your organisation's details will appear on the public register within 5 days."
+            - "We will contact you on this email address before this registration is due to expire in %{expires_on}."
+            - "If we cannot reach you when the renewal is due, you’ll have to pay more for a new upper tier registration."
+          LOWER:
+            - "Your organisation's details will appear on the public register within 5 days."
+            - "Lower tier registrations do not expire."
         email:
           heading: "Email"
           value: "nccc-carrierbroker@environment-agency.gov.uk"

--- a/spec/factories/new_registration.rb
+++ b/spec/factories/new_registration.rb
@@ -23,6 +23,20 @@ FactoryBot.define do
       end
     end
 
+    trait :has_required_lower_tier_data do
+      location { "england" }
+      declared_convictions { "no" }
+
+      metaData { build(:metaData, route: "DIGITAL") }
+
+      sequence :reg_identifier
+
+      has_addresses
+      has_postcode
+      has_key_people
+      lower
+    end
+
     trait :requires_conviction_check do
       key_people { [build(:key_person, :matched_conviction_search_result)] }
       conviction_search_result { build(:conviction_search_result, :match_result_yes) }


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-838

This adds some rules so that the registration completed screen can be rendered on lower tier registrations

<img width="491" alt="Screenshot 2020-03-23 at 10 27 22" src="https://user-images.githubusercontent.com/1385397/77316582-932fce00-6d01-11ea-9575-817e56e1bcc1.png">
