### PR TITLE
Only merge finance details if reg type has changed in edit

### DIFF
--- a/app/services/waste_carriers_engine/edit_completion_service.rb
+++ b/app/services/waste_carriers_engine/edit_completion_service.rb
@@ -30,7 +30,7 @@ module WasteCarriersEngine
 
     def copy_data_to_registration
       copy_attributes
-      merge_finance_details
+      merge_finance_details if transient_registration.registration_type_changed?
       registration.save!
     end
 

--- a/spec/services/waste_carriers_engine/edit_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/edit_completion_service_spec.rb
@@ -40,6 +40,8 @@ module WasteCarriersEngine
     let(:reg_finance_details) { double(:reg_finance_details) }
     let(:transient_finance_details) { double(:transient_finance_details) }
 
+    let(:registration_type_changed) { false }
+
     let(:registration) do
       double(:registration,
              finance_details: reg_finance_details)
@@ -52,17 +54,13 @@ module WasteCarriersEngine
              contact_address: contact_address,
              first_name: first_name,
              last_name: last_name,
-             finance_details: transient_finance_details)
+             finance_details: transient_finance_details,
+             registration_type_changed?: registration_type_changed)
     end
 
     describe ".run" do
       context "when given an edit_registration" do
-        it "updates the registration and deletes the edit_registration" do
-          reg_orders = double(:orders)
-          reg_payments = double(:payments)
-          transient_order = double(:transient_order)
-          transient_payment = double(:transient_payment)
-
+        it "updates the registration without merging finance details and deletes the edit_registration" do
           # Sets up the contact address data
           expect(contact_address).to receive(:first_name=).with(first_name)
           expect(contact_address).to receive(:last_name=).with(last_name)
@@ -73,18 +71,8 @@ module WasteCarriersEngine
           # Updates the registration
           expect(registration).to receive(:write_attributes).with(copyable_attributes)
 
-          # Merges finance details
-          expect(reg_finance_details).to receive(:update_balance)
-
-          # Merges orders
-          allow(reg_finance_details).to receive(:orders).and_return(reg_orders)
-          allow(transient_finance_details).to receive(:orders).and_return([transient_order])
-          expect(reg_orders).to receive(:<<).with(transient_order)
-
-          # Merges payments
-          expect(reg_finance_details).to receive(:payments).and_return(reg_payments).twice
-          expect(transient_finance_details).to receive(:payments).and_return([transient_payment]).twice
-          expect(reg_payments).to receive(:<<).with(transient_payment)
+          # Does not merge finance details
+          expect(reg_finance_details).to_not receive(:update_balance)
 
           # Saves the registration
           expect(registration).to receive(:save!)
@@ -93,6 +81,48 @@ module WasteCarriersEngine
           expect(edit_registration).to receive(:delete)
 
           described_class.run(edit_registration: edit_registration)
+        end
+
+        context "when the carrier type has changed" do
+          let(:registration_type_changed) { true }
+
+          it "updates the registration, merges finance details and deletes the edit_registration" do
+            reg_orders = double(:orders)
+            reg_payments = double(:payments)
+            transient_order = double(:transient_order)
+            transient_payment = double(:transient_payment)
+
+            # Sets up the contact address data
+            expect(contact_address).to receive(:first_name=).with(first_name)
+            expect(contact_address).to receive(:last_name=).with(last_name)
+
+            # Creates a past_registration
+            expect(PastRegistration).to receive(:build_past_registration).with(registration, :edit)
+
+            # Updates the registration
+            expect(registration).to receive(:write_attributes).with(copyable_attributes)
+
+            # Updates the balance
+            expect(reg_finance_details).to receive(:update_balance)
+
+            # Merges orders
+            allow(reg_finance_details).to receive(:orders).and_return(reg_orders)
+            allow(transient_finance_details).to receive(:orders).and_return([transient_order])
+            expect(reg_orders).to receive(:<<).with(transient_order)
+
+            # Merges payments
+            expect(reg_finance_details).to receive(:payments).and_return(reg_payments).twice
+            expect(transient_finance_details).to receive(:payments).and_return([transient_payment]).twice
+            expect(reg_payments).to receive(:<<).with(transient_payment)
+
+            # Saves the registration
+            expect(registration).to receive(:save!)
+
+            # Deletes transient registration
+            expect(edit_registration).to receive(:delete)
+
+            described_class.run(edit_registration: edit_registration)
+          end
         end
       end
     end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-833

Previously we would always call `merge_finance_details` when completing an edit. This is because if the user never changed the reg type, no finance_details were created and so there was nothing to merge.

However, if the user changes the type, goes to the payment page (generating a finance_details object) and then goes back and reverts their original change, the finance_details object will still exist. This will result in an extra order on the registration that the user has no way of paying, and also shouldn't actually pay.

To avoid this happening, we add an extra check to tell the EditCompletionService to only try to merge the finance details when there is something worth keeping.