### PR TITLE
Make declaration error message more generic

### DIFF
--- a/config/locales/forms/declaration_forms/en.yml
+++ b/config/locales/forms/declaration_forms/en.yml
@@ -16,7 +16,7 @@ en:
         waste_carriers_engine/declaration_form:
           attributes:
             declaration:
-              inclusion: "You cannot renew if you do not understand and agree with the declaration"
+              inclusion: "You cannot continue if you do not understand and agree with the declaration"
             reg_identifier:
               invalid_format: "The registration ID is not in a valid format"
               no_registration: "There is no registration matching this ID"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-830

This error message was built with renewals in mind. However the page is now used for lots of other journeys, so we should have an error message that works for all of them.