### PR TITLE
Fix edit redirect URLs

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,42 +96,42 @@ WasteCarriersEngine::Engine.routes.draw do
               only: %i[new create],
               path: "edit",
               path_names: { new: "" } do
-                get "cbd_type",
+                get "cbd-type",
                     to: "edit_forms#edit_cbd_type",
                     as: "cbd_type",
                     on: :collection
 
-                get "company_name",
+                get "company-name",
                     to: "edit_forms#edit_company_name",
                     as: "company_name",
                     on: :collection
 
-                get "main_people",
+                get "main-people",
                     to: "edit_forms#edit_main_people",
                     as: "main_people",
                     on: :collection
 
-                get "company_address",
+                get "company-address",
                     to: "edit_forms#edit_company_address",
                     as: "company_address",
                     on: :collection
 
-                get "contact_name",
+                get "contact-name",
                     to: "edit_forms#edit_contact_name",
                     as: "contact_name",
                     on: :collection
 
-                get "contact_phone",
+                get "contact-phone",
                     to: "edit_forms#edit_contact_phone",
                     as: "contact_phone",
                     on: :collection
 
-                get "contact_email",
+                get "contact-email",
                     to: "edit_forms#edit_contact_email",
                     as: "contact_email",
                     on: :collection
 
-                get "contact_address",
+                get "contact-address",
                     to: "edit_forms#edit_contact_address",
                     as: "contact_address",
                     on: :collection


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-830

These had underscores. But they should have hyphens. Now they do!