### PR TITLE
Backfill individual DOB fields when initialising key person

### DIFF
--- a/app/models/waste_carriers_engine/key_person.rb
+++ b/app/models/waste_carriers_engine/key_person.rb
@@ -10,6 +10,7 @@ module WasteCarriersEngine
 
     accepts_nested_attributes_for :conviction_search_result
 
+    after_initialize :set_individual_dob_fields
     after_initialize :set_date_of_birth
 
     field :first_name,  type: String
@@ -38,6 +39,15 @@ module WasteCarriersEngine
       errors.add(:dob, :invalid_date)
     rescue TypeError
       errors.add(:dob, :invalid_date)
+    end
+
+    def set_individual_dob_fields
+      return if dob_year.present? & dob_month.present? & dob_day.present?
+      return if dob.blank?
+
+      self.dob_year = dob.year
+      self.dob_month = dob.month
+      self.dob_day = dob.mday
     end
   end
 end

--- a/app/models/waste_carriers_engine/key_person.rb
+++ b/app/models/waste_carriers_engine/key_person.rb
@@ -42,7 +42,7 @@ module WasteCarriersEngine
     end
 
     def set_individual_dob_fields
-      return if dob_year.present? & dob_month.present? & dob_day.present?
+      return if dob_year.present? && dob_month.present? && dob_day.present?
       return if dob.blank?
 
       self.dob_year = dob.year

--- a/spec/models/waste_carriers_engine/key_person_spec.rb
+++ b/spec/models/waste_carriers_engine/key_person_spec.rb
@@ -4,24 +4,48 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe KeyPerson, type: :model do
-    describe "#dob" do
-      context "when the provided fields make a valid date" do
-        # Can't use factories as we have to trigger the after_initialize method at correct time
-        let(:key_person) { KeyPerson.new(dob_day: 1, dob_month: 2, dob_year: 2000) }
+    context "Initialization" do
+      describe "#set_individual_dob_fields" do
+        context "when there is a valid dob" do
+          let(:key_person) { KeyPerson.new(dob: Date.new(2000, 2, 1)) }
 
-        it "should return the date when setting date of birth" do
-          expect(key_person.dob).to eq(Date.new(key_person.dob_year,
-                                                key_person.dob_month,
-                                                key_person.dob_day))
+          it "assigns the correct values to the individual fields" do
+            expect(key_person.dob_year).to eq(2000)
+            expect(key_person.dob_month).to eq(2)
+            expect(key_person.dob_day).to eq(1)
+          end
+        end
+
+        context "when there is not a valid dob" do
+          let(:key_person) { KeyPerson.new }
+
+          it "does not assign values to the individual fields" do
+            expect(key_person.dob_day).to be_nil
+            expect(key_person.dob_month).to be_nil
+            expect(key_person.dob_year).to be_nil
+          end
         end
       end
 
-      context "when the provided fields don't make a valid date" do
-        # Can't use factories as we have to trigger the after_initialize method at correct time
-        let(:key_person) { KeyPerson.new(dob_day: 31, dob_month: 2, dob_year: 2000) }
+      describe "#set_date_of_birth" do
+        context "when the provided fields make a valid date" do
+          # Can't use factories as we have to trigger the after_initialize method at correct time
+          let(:key_person) { KeyPerson.new(dob_day: 1, dob_month: 2, dob_year: 2000) }
 
-        it "should return nil when setting date of birth" do
-          expect(key_person.dob).to eq(nil)
+          it "should return the date when setting date of birth" do
+            expect(key_person.dob).to eq(Date.new(key_person.dob_year,
+                                                  key_person.dob_month,
+                                                  key_person.dob_day))
+          end
+        end
+
+        context "when the provided fields don't make a valid date" do
+          # Can't use factories as we have to trigger the after_initialize method at correct time
+          let(:key_person) { KeyPerson.new(dob_day: 31, dob_month: 2, dob_year: 2000) }
+
+          it "should return nil when setting date of birth" do
+            expect(key_person.dob).to eq(nil)
+          end
         end
       end
     end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-830

We spotted that when editing a sole trader's key person, the birthday wasn't always pre-populated.

This turned out to be because any registrations generated in the frontend and not since modified did not store values for `dob_day`, `dob_month` and `dob_year`. Instead they just had the single `dob`. But any records generated in the new engine have all 4 values.

To get around this, we set the values of the individual fields to match the value of `dob`. This happens when a new key person is initialised, specifically when we load an older one from the database.