### PR TITLE
Edit registration copy over order

### DIFF
--- a/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
@@ -7,6 +7,7 @@ module WasteCarriersEngine
       super(WorldpayForm, "worldpay_form")
 
       payment_info = prepare_for_payment
+
       if payment_info == :error
         flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.new.setup_error")
         go_back

--- a/app/services/waste_carriers_engine/edit_completion_service.rb
+++ b/app/services/waste_carriers_engine/edit_completion_service.rb
@@ -29,8 +29,8 @@ module WasteCarriersEngine
     end
 
     def copy_data_to_registration
-      copy_attributes
       merge_finance_details if transient_registration.registration_type_changed?
+      copy_attributes
       registration.save!
     end
 

--- a/spec/requests/waste_carriers_engine/edit_complete_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/edit_complete_forms_spec.rb
@@ -64,6 +64,28 @@ module WasteCarriersEngine
 
               expect(response).to have_http_status(200)
             end
+
+            context "when there is a change in registration type" do
+              let(:transient_registration) do
+                create(:edit_registration,
+                       :has_changed_registration_type,
+                       contact_email: updated_email,
+                       addresses: [updated_registered_address, updated_contact_address],
+                       key_people: [updated_person],
+                       workflow_state: "edit_complete_form")
+              end
+
+              it "generates a new order in the registration" do
+                old_orders_count = registration.finance_details.orders.count
+                transient_registration.prepare_for_payment(:bank_transfer, user)
+
+                get new_edit_complete_form_path(transient_registration.token)
+
+                registration.reload
+
+                expect(registration.finance_details.orders.count).to eq(old_orders_count + 1)
+              end
+            end
           end
 
           context "when the workflow_state is not correct" do


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-833

Make sure we merge finance details into the registration when an edit is completed. 
The bug was given by the fact that we were checking the registration_type has changed after copy its value on the registration object, and hence never merging the finance details.