### PR TITLE
Ask for business type when registration is edited from overseas to UK

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_use_edit_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_edit_registration_workflow.rb
@@ -20,6 +20,7 @@ module WasteCarriersEngine
         state :cbd_type_form
 
         # Business details
+        state :business_type_form
         state :company_name_form
         state :main_people_form
         state :company_postcode_form
@@ -114,6 +115,9 @@ module WasteCarriersEngine
                       to: :edit_form
 
           # Business details
+          transitions from: :business_type_form,
+                      to: :edit_form
+
           transitions from: :company_name_form,
                       to: :edit_form
 
@@ -168,6 +172,10 @@ module WasteCarriersEngine
 
           # Location
           transitions from: :location_form,
+                      to: :business_type_form,
+                      if: :location_changed_from_overseas?
+
+          transitions from: :location_form,
                       to: :edit_form
 
           # Complete an edit
@@ -199,6 +207,9 @@ module WasteCarriersEngine
                       to: :edit_form
 
           # Business details
+          transitions from: :business_type_form,
+                      to: :location_form
+
           transitions from: :company_name_form,
                       to: :edit_form
 

--- a/app/models/waste_carriers_engine/edit_registration.rb
+++ b/app/models/waste_carriers_engine/edit_registration.rb
@@ -35,5 +35,9 @@ module WasteCarriersEngine
         payment_method: mode
       )
     end
+
+    def location_changed_from_overseas?
+      registration.overseas? && uk_location?
+    end
   end
 end

--- a/spec/models/waste_carriers_engine/edit_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/edit_registration_spec.rb
@@ -85,5 +85,55 @@ module WasteCarriersEngine
         subject.prepare_for_payment(mode, user)
       end
     end
+
+    describe "#location_changed_from_overseas?" do
+      context "when the registration is has an overseas location" do
+        before { subject.registration.location = "overseas" }
+
+        context "when the edit_registration has a UK location" do
+          before { subject.location = "england" }
+
+          it "returns true" do
+            expect(subject.location_changed_from_overseas?).to be_truthy
+          end
+        end
+
+        context "when the edit_registration does not have a UK location" do
+          before { subject.location = "overseas" }
+
+          it "returns false" do
+            expect(subject.location_changed_from_overseas?).to be_falsey
+          end
+        end
+      end
+
+      context "when the registration is has an overseas business type" do
+        before { subject.registration.business_type = "overseas" }
+
+        context "when the edit_registration has a UK location" do
+          before { subject.location = "england" }
+
+          it "returns true" do
+            expect(subject.location_changed_from_overseas?).to be_truthy
+          end
+        end
+
+        context "when the edit_registration does not have a UK location" do
+          before { subject.location = "overseas" }
+
+          it "returns false" do
+            expect(subject.location_changed_from_overseas?).to be_falsey
+          end
+        end
+      end
+
+      context "when the registration is not overseas" do
+        before { subject.registration.location = "england" }
+
+        it "returns false" do
+          expect(subject.location_changed_from_overseas?).to be_falsey
+        end
+      end
+    end
   end
 end

--- a/spec/models/waste_carriers_engine/edit_registration_workflow/business_type_form_spec.rb
+++ b/spec/models/waste_carriers_engine/edit_registration_workflow/business_type_form_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe EditRegistration do
+    subject { build(:edit_registration, workflow_state: "business_type_form") }
+
+    describe "#workflow_state" do
+      context ":business_type_form state transitions" do
+        context "on next" do
+          include_examples "has next transition", next_state: "edit_form"
+        end
+
+        context "on back" do
+          include_examples "has back transition", previous_state: "location_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/edit_registration_workflow/location_form_spec.rb
+++ b/spec/models/waste_carriers_engine/edit_registration_workflow/location_form_spec.rb
@@ -3,12 +3,30 @@
 require "rails_helper"
 
 module WasteCarriersEngine
-  RSpec.describe EditRegistration, type: :model do
+  RSpec.describe EditRegistration do
+    subject { build(:edit_registration, workflow_state: "location_form") }
+
     describe "#workflow_state" do
-      it_behaves_like "a simple monodirectional transition",
-                      previous_and_next_state: :edit_form,
-                      current_state: :location_form,
-                      factory: :edit_registration
+      context ":location_form state transitions" do
+        context "on next" do
+          subject { build(:edit_registration, workflow_state: "location_form") }
+
+          include_examples "has next transition", next_state: "edit_form"
+
+          context "when the registration has been edited from overseas to UK" do
+            before do
+              subject.location = "england"
+              subject.registration.business_type = "overseas"
+            end
+
+            include_examples "has next transition", next_state: "business_type_form"
+          end
+        end
+
+        context "on back" do
+          include_examples "has back transition", previous_state: "edit_form"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-830

We spotted an issue where if a user edited a registration's location, but it had previously been overseas, the business type would still be "overseas". This was causing some problems with addresses.

Instead we want to get a more accurate business type for this now-UK business. So after changing the location from overseas to a UK location, we will immediately ask for the business type instead of redirecting to the edit overview.