### PR TITLE
Make main people form work with old business types

### DIFF
--- a/app/forms/waste_carriers_engine/main_people_form.rb
+++ b/app/forms/waste_carriers_engine/main_people_form.rb
@@ -56,16 +56,13 @@ module WasteCarriersEngine
     end
 
     def age_cutoff_date
-      age_limits = {
-        limitedCompany: 16.years,
-        limitedLiabilityPartnership: 17.years,
-        localAuthority: 17.years,
-        overseas: 17.years,
-        partnership: 17.years,
-        soleTrader: 17.years
-      }
+      age_limit = if business_type == "limitedCompany"
+                    16.years
+                  else
+                    17.years
+                  end
 
-      (Date.today - age_limits[business_type.to_sym]) + 1.day
+      (Date.today - age_limit) + 1.day
     end
 
     def age_limit_error_message

--- a/config/locales/forms/main_people_forms/en.yml
+++ b/config/locales/forms/main_people_forms/en.yml
@@ -13,6 +13,8 @@ en:
           overseas: Business owner details
           partnership: Partner details
           soleTrader: Business owner details
+          authority: Chief executive details
+          publicBody: Chief executive details
         description_1:
           localAuthority: Enter the name and date of birth for each chief executive of the business.
           limitedCompany: Enter the name and date of birth for each director of the business.
@@ -20,6 +22,8 @@ en:
           overseas: Enter the name and date of birth for each owner of the business.
           partnership:  Enter the name and date of birth for each partner of the business.
           soleTrader: Enter the name and date of birth of the business owner.
+          authority: Enter the name and date of birth for each chief executive of the business.
+          publicBody: Enter the name and date of birth for each chief executive of the business.
         add_person_link: Add another person
         next_button: Continue
   activemodel:
@@ -43,6 +47,8 @@ en:
               age_limit_overseas: "Business owners must be 17 or older"
               age_limit_partnership: "Partners must be 17 or older"
               age_limit_soleTrader: "Business owners must be 17 or older"
+              age_limit_authority: "Chief executives must be 17 or older"
+              age_limit_publicBody: "Chief executives must be 17 or older"
               not_a_date: "You must enter a valid date"
               day_blank: "You must enter a day"
               day_integer: "The day must be a number"

--- a/spec/forms/waste_carriers_engine/main_people_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/main_people_forms_spec.rb
@@ -308,32 +308,36 @@ module WasteCarriersEngine
           end
         end
 
-        shared_examples_for "age limits for main people" do |business_type, age_limit|
+        context "when the business type is limitedCompany" do
           before(:each) do
-            main_people_form.business_type = business_type
+            main_people_form.business_type = "limitedCompany"
           end
 
-          it "should be valid when at the age limit" do
-            main_people_form.dob = Date.today - age_limit.years
+          it "should be valid when 16 years old" do
+            main_people_form.dob = Date.today - 16.years
             expect(main_people_form).to be_valid
           end
 
-          it "should not be valid when under the age limit" do
-            main_people_form.dob = Date.today - (age_limit.years - 1.year)
+          it "should not be valid when less than 16 years old" do
+            main_people_form.dob = Date.today - 15.years
             expect(main_people_form).to_not be_valid
           end
         end
 
-        {
-          # Permutation table of business_type and age limit
-          "localAuthority" => 17,
-          "limitedCompany" => 16,
-          "limitedLiabilityPartnership" => 17,
-          "overseas" => 17,
-          "partnership" => 17,
-          "soleTrader" => 17
-        }.each do |business_type, age_limit|
-          it_behaves_like "age limits for main people", business_type, age_limit
+        context "when the business type is not limitedCompany" do
+          before(:each) do
+            main_people_form.business_type = "soleTrader"
+          end
+
+          it "should be valid when 17 years old" do
+            main_people_form.dob = Date.today - 17.years
+            expect(main_people_form).to be_valid
+          end
+
+          it "should not be valid when less than 17 years old" do
+            main_people_form.dob = Date.today - 16.years
+            expect(main_people_form).to_not be_valid
+          end
         end
       end
     end


### PR DESCRIPTION
We still have some regs hanging around with `publicBody` or `authority` business types.

The main people form was designed for the renewals journey, where these no longer exist. So it needs a few tweaks to work with these old types, just around text and the validation for age limits.

This PR simplifies the age validation while we're at it.