### PR TITLE
Add missing translations for authority and public body

### DIFF
--- a/config/locales/forms/company_address_forms/en.yml
+++ b/config/locales/forms/company_address_forms/en.yml
@@ -10,6 +10,8 @@ en:
           partnership: What's the address of the partnership?
           soleTrader: What's the address of the business?
           charity: What's the address of the charity or trust?
+          authority: What's the address of the local authority?
+          publicBody: What's the address of the public body?
         postcode_label: Postcode
         postcode_change_link: "Change postcode"
         manual_address_link: "I cannot find the address in the list"

--- a/config/locales/forms/company_address_manual_forms/en.yml
+++ b/config/locales/forms/company_address_manual_forms/en.yml
@@ -11,6 +11,8 @@ en:
           soleTrader: What's the address of the business?
           overseas: What's the address of the business or organisation?
           charity: What's the address of the charity or trust?
+          authority: What's the address of the local authority?
+          publicBody: What's the address of the public body?
         os_places_error_heading: Our address finder is not working
         os_places_error_text: Please enter the address below.
         preset_postcode_label: Postcode

--- a/config/locales/forms/company_name_forms/en.yml
+++ b/config/locales/forms/company_name_forms/en.yml
@@ -11,6 +11,8 @@ en:
           partnership: What's the name of the partnership?
           soleTrader: What's the name of the business?
           charity: What's the name of the charity or trust?
+          authority: What's the name of the local authority?
+          publicBody: What's the name of the public body?
         company_name_label:
           localAuthority: Local authority or public body name
           limitedCompany: Company trading name
@@ -19,6 +21,8 @@ en:
           partnership: Partnership trading name
           soleTrader: Business trading name
           charity: Charity or trust registered name
+          authority: Local authority name
+          publicBody: Public body name
         error_heading: Something is wrong
         next_button: Continue
   activemodel:

--- a/config/locales/forms/company_postcode_forms/en.yml
+++ b/config/locales/forms/company_postcode_forms/en.yml
@@ -10,6 +10,8 @@ en:
           partnership: What's the address of the partnership?
           soleTrader: What's the address of the business?
           charity: What's the address of the charity or trust?
+          authority: What's the address of the local authority?
+          publicBody: What's the address of the public body?
         temp_company_postcode_label: Please enter a UK postcode
         temp_company_postcode_hint: For example, BS1 5AH
         error_heading: A problem to fix

--- a/config/locales/forms/edit_forms/en.yml
+++ b/config/locales/forms/edit_forms/en.yml
@@ -67,6 +67,8 @@ en:
             partnership: partner
             soleTrader: business owner
             charity: charity or trust owner
+            authority: chief executive
+            publicBody: chief executive
           location:
             england: England
             wales: Wales


### PR DESCRIPTION
As with https://github.com/DEFRA/waste-carriers-engine/pull/765 we have some pages which weren't expected to be used with the business type `publicBody` or `authority` as these are being phased out.

In the meantime, however, they should have working text.