### PR TITLE
Add renewal number lookup page

### DIFF
--- a/app/controllers/waste_carriers_engine/renew_registration_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/renew_registration_forms_controller.rb
@@ -7,13 +7,31 @@ module WasteCarriersEngine
     end
 
     def create
-      super(RenewRegistrationForm, "renew_registration_form")
+      return false unless set_up_form(RenewRegistrationForm, "renew_registration_form", params[:token])
+
+      submit_form(@renew_registration_form, transient_registration_attributes)
     end
 
     private
 
     def transient_registration_attributes
-      params.fetch(:renew_registration_form, {})
+      params.fetch(:renew_registration_form, {}).permit(:temp_lookup_number)
+    end
+
+    def submit_form(form, params)
+      respond_to do |format|
+        if form.submit(params)
+          format.html { redirect_to_renewal_journey }
+          true
+        else
+          format.html { render :new }
+          false
+        end
+      end
+    end
+
+    def redirect_to_renewal_journey
+      redirect_to renewal_start_forms_path(token: @renew_registration_form.temp_lookup_number)
     end
   end
 end

--- a/app/forms/waste_carriers_engine/renew_registration_form.rb
+++ b/app/forms/waste_carriers_engine/renew_registration_form.rb
@@ -5,5 +5,11 @@ module WasteCarriersEngine
     delegate :temp_lookup_number, to: :transient_registration
 
     validates_with RenewalLookupValidator
+
+    def submit(params)
+      params[:temp_lookup_number].upcase! if params[:temp_lookup_number].present?
+
+      super
+    end
   end
 end

--- a/app/forms/waste_carriers_engine/renew_registration_form.rb
+++ b/app/forms/waste_carriers_engine/renew_registration_form.rb
@@ -2,5 +2,6 @@
 
 module WasteCarriersEngine
   class RenewRegistrationForm < BaseForm
+    delegate :temp_lookup_number, to: :transient_registration
   end
 end

--- a/app/forms/waste_carriers_engine/renew_registration_form.rb
+++ b/app/forms/waste_carriers_engine/renew_registration_form.rb
@@ -3,5 +3,7 @@
 module WasteCarriersEngine
   class RenewRegistrationForm < BaseForm
     delegate :temp_lookup_number, to: :transient_registration
+
+    validates_with RenewalLookupValidator
   end
 end

--- a/app/forms/waste_carriers_engine/renew_registration_form.rb
+++ b/app/forms/waste_carriers_engine/renew_registration_form.rb
@@ -7,7 +7,7 @@ module WasteCarriersEngine
     validates_with RenewalLookupValidator
 
     def submit(params)
-      params[:temp_lookup_number].upcase! if params[:temp_lookup_number].present?
+      params[:temp_lookup_number]&.upcase!
 
       super
     end

--- a/app/models/waste_carriers_engine/new_registration.rb
+++ b/app/models/waste_carriers_engine/new_registration.rb
@@ -6,6 +6,7 @@ module WasteCarriersEngine
     include CanUseLock
 
     field :temp_start_option, type: String
+    field :temp_lookup_number, type: String
 
     after_initialize :build_meta_data
 

--- a/app/services/waste_carriers_engine/registration_completion_service.rb
+++ b/app/services/waste_carriers_engine/registration_completion_service.rb
@@ -81,6 +81,7 @@ module WasteCarriersEngine
         "temp_contact_postcode",
         "temp_os_places_error",
         "temp_payment_method",
+        "temp_lookup_number",
         "temp_tier_check",
         "_type",
         "workflow_state",

--- a/app/validators/waste_carriers_engine/renewal_lookup_validator.rb
+++ b/app/validators/waste_carriers_engine/renewal_lookup_validator.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class RenewalLookupValidator < ActiveModel::Validator
+    def validate(record)
+      matching_registration = Registration.where(reg_identifier: record.temp_lookup_number).first
+
+      return false unless valid_id?(record, matching_registration)
+
+      registration_can_be_renewed?(record, matching_registration)
+    end
+
+    private
+
+    def valid_id?(record, matching_registration)
+      return true if matching_registration.present?
+
+      record.errors.add(:temp_lookup_number, :invalid_format)
+      false
+    end
+
+    def registration_can_be_renewed?(record, matching_registration)
+      return true if matching_registration.can_start_renewal?
+
+      record.errors.add(:temp_lookup_number, :cannot_be_renewed)
+      false
+    end
+  end
+end

--- a/app/validators/waste_carriers_engine/renewal_lookup_validator.rb
+++ b/app/validators/waste_carriers_engine/renewal_lookup_validator.rb
@@ -3,26 +3,61 @@
 module WasteCarriersEngine
   class RenewalLookupValidator < ActiveModel::Validator
     def validate(record)
-      matching_registration = Registration.where(reg_identifier: record.temp_lookup_number).first
+      registration = Registration.where(reg_identifier: record.temp_lookup_number).first
 
-      return false unless valid_id?(record, matching_registration)
+      return false unless valid_id?(record, registration)
+      return false unless registration_is_upper_tier?(record, registration)
+      return false unless renewable_status?(record, registration)
 
-      registration_can_be_renewed?(record, matching_registration)
+      renewable_date?(record, registration)
     end
 
     private
 
-    def valid_id?(record, matching_registration)
-      return true if matching_registration.present?
+    def valid_id?(record, registration)
+      return true if registration.present?
 
-      record.errors.add(:temp_lookup_number, :invalid_format)
+      record.errors.add(:temp_lookup_number, :no_match)
       false
     end
 
-    def registration_can_be_renewed?(record, matching_registration)
-      return true if matching_registration.can_start_renewal?
+    def registration_is_upper_tier?(record, registration)
+      return true if registration.upper_tier?
 
-      record.errors.add(:temp_lookup_number, :cannot_be_renewed)
+      record.errors.add(:temp_lookup_number, :lower_tier)
+      false
+    end
+
+    def renewable_status?(record, registration)
+      return true if registration.active?
+      return true if registration.expired?
+
+      record.errors.add(:temp_lookup_number, :unrenewable_status)
+      false
+    end
+
+    def renewable_date?(record, registration)
+      check_service = ExpiryCheckService.new(registration)
+
+      if check_service.expired?
+        registration_in_expiry_grace_window?(record, check_service)
+      else
+        registration_in_renewal_window?(record, check_service)
+      end
+    end
+
+    def registration_in_expiry_grace_window?(record, check_service)
+      return true if check_service.in_expiry_grace_window?
+
+      record.errors.add(:temp_lookup_number, :expired)
+      false
+    end
+
+    def registration_in_renewal_window?(record, check_service)
+      return true if check_service.in_renewal_window?
+
+      renewable_date = check_service.date_can_renew_from
+      record.errors.add(:temp_lookup_number, :not_yet_renewable, date: renewable_date)
       false
     end
   end

--- a/app/views/waste_carriers_engine/renew_registration_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/renew_registration_forms/new.html.erb
@@ -7,22 +7,16 @@
     <h1 class="heading-large"><%= t(".heading") %></h1>
 
     <div class="form-group <%= "form-group-error" if @renew_registration_form.errors[:temp_lookup_number].any? %>">
-      <fieldset id="temp_lookup_number">
-        <legend class="visuallyhidden">
-          <%= t(".heading") %>
-        </legend>
+      <% if @renew_registration_form.errors[:temp_lookup_number].any? %>
+        <span class="error-message"><%= @renew_registration_form.errors[:temp_lookup_number].join(", ") %></span>
+      <% end %>
 
-        <% if @renew_registration_form.errors[:temp_lookup_number].any? %>
-          <span class="error-message"><%= @renew_registration_form.errors[:temp_lookup_number].join(", ") %></span>
-        <% end %>
+      <%= f.label :temp_lookup_number, class: "form-label" do %>
+        <%= t(".temp_lookup_number_label") %>
+        <span class="form-hint"><%= t(".temp_lookup_number_hint") %></span>
+      <% end %>
 
-        <%= f.label :temp_lookup_number, class: "form-label" do %>
-          <%= t(".temp_lookup_number_label") %>
-          <span class="form-hint"><%= t(".temp_lookup_number_hint") %></span>
-        <% end %>
-
-        <%= f.text_field :temp_lookup_number, value: @renew_registration_form.temp_lookup_number, class: "form-control" %>
-      </fieldset>
+      <%= f.text_field :temp_lookup_number, value: @renew_registration_form.temp_lookup_number, class: "form-control" %>
     </div>
 
     <div class="form-group">

--- a/app/views/waste_carriers_engine/renew_registration_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/renew_registration_forms/new.html.erb
@@ -8,6 +8,10 @@
 
     <div class="form-group <%= "form-group-error" if @renew_registration_form.errors[:temp_lookup_number].any? %>">
       <fieldset id="temp_lookup_number">
+        <legend class="visuallyhidden">
+          <%= t(".heading") %>
+        </legend>
+
         <% if @renew_registration_form.errors[:temp_lookup_number].any? %>
           <span class="error-message"><%= @renew_registration_form.errors[:temp_lookup_number].join(", ") %></span>
         <% end %>

--- a/app/views/waste_carriers_engine/renew_registration_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/renew_registration_forms/new.html.erb
@@ -1,5 +1,47 @@
 <%= render("waste_carriers_engine/shared/back", back_path: back_renew_registration_forms_path(token: @renew_registration_form.token)) %>
 
 <div class="text">
-  <h1 class="heading-large">Renew registration Form - TODO</h1>
+  <%= form_for(@renew_registration_form) do |f| %>
+    <%= render("waste_carriers_engine/shared/errors", object: @renew_registration_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <div class="form-group <%= "form-group-error" if @renew_registration_form.errors[:temp_lookup_number].any? %>">
+      <fieldset id="temp_lookup_number">
+        <% if @renew_registration_form.errors[:temp_lookup_number].any? %>
+          <span class="error-message"><%= @renew_registration_form.errors[:temp_lookup_number].join(", ") %></span>
+        <% end %>
+
+        <%= f.label :temp_lookup_number, class: "form-label" do %>
+          <%= t(".temp_lookup_number_label") %>
+          <span class="form-hint"><%= t(".temp_lookup_number_hint") %></span>
+        <% end %>
+
+        <%= f.text_field :temp_lookup_number, value: @renew_registration_form.temp_lookup_number, class: "form-control" %>
+      </fieldset>
+    </div>
+
+    <div class="form-group">
+      <details>
+        <summary>
+          <span class="summary"><%= t(".unknown_number.subheading") %></span>
+        </summary>
+
+        <div class="panel panel-border-narrow">
+          <p>
+            <%= t(".unknown_number.paragraph_1") %>
+            <%= link_to t(".unknown_number.paragraph_1_link_text"), t(".unknown_number.paragraph_1_link_url") %>.
+          </p>
+          <p>
+            <%= t(".unknown_number.paragraph_2") %>
+            <%= mail_to t(".unknown_number.paragraph_2_email") %>.
+          </p>
+        </div>
+      </details>
+    </div>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
 </div>

--- a/config/locales/forms/renew_registration_forms/en.yml
+++ b/config/locales/forms/renew_registration_forms/en.yml
@@ -1,0 +1,16 @@
+en:
+  waste_carriers_engine:
+    renew_registration_forms:
+      new:
+        title: Renew your registration
+        heading: What's your waste carrier registration number?
+        temp_lookup_number_label: Waste carrier registration number
+        temp_lookup_number_hint: "Example: CBDU59475"
+        unknown_number:
+          subheading: I do not know the registration number
+          paragraph_1: Your registration number is on the email we sent you when you registered as a waste carrier. It’s also on your renewal letter.
+          paragraph_1_link_text: You can also search for it on the public register
+          paragraph_1_link_url: https://environment.data.gov.uk/public-register/view/search-waste-carriers-brokers
+          paragraph_2: "If you cannot find it, call the Environment Agency helpline on 03708 506506 (Monday to Friday, 8am to 6pm) or email"
+          paragraph_2_email: nccc-carrierbroker@environment-agency.gov.uk
+        next_button: Continue

--- a/config/locales/forms/renew_registration_forms/en.yml
+++ b/config/locales/forms/renew_registration_forms/en.yml
@@ -20,5 +20,8 @@ en:
         waste_carriers_engine/renew_registration_form:
           attributes:
             temp_lookup_number:
-              invalid_format: "The registration number is not in a valid format"
-              cannot_be_renewed: "You can't renew this registration yet"
+              expired: "The registration number you entered has expired"
+              lower_tier: "This is a lower tier registration so never expires. Call our helpline on 03708 506506 if you think this is incorrect."
+              no_match: "Enter a valid registration number"
+              not_yet_renewable: "This registration is not eligible for renewal until %{date}"
+              unrenewable_status: "This number is not registered. Call our helpline on 03708 506506 if you think this is incorrect."

--- a/config/locales/forms/renew_registration_forms/en.yml
+++ b/config/locales/forms/renew_registration_forms/en.yml
@@ -14,3 +14,11 @@ en:
           paragraph_2: "If you cannot find it, call the Environment Agency helpline on 03708 506506 (Monday to Friday, 8am to 6pm) or email"
           paragraph_2_email: nccc-carrierbroker@environment-agency.gov.uk
         next_button: Continue
+  activemodel:
+    errors:
+      models:
+        waste_carriers_engine/renew_registration_form:
+          attributes:
+            temp_lookup_number:
+              invalid_format: "The registration number is not in a valid format"
+              cannot_be_renewed: "You can't renew this registration yet"

--- a/spec/requests/waste_carriers_engine/renew_registration_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/renew_registration_forms_spec.rb
@@ -67,6 +67,17 @@ module WasteCarriersEngine
               expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(registration.reg_identifier))
             end
+
+            context "when the params are lowercase" do
+              let(:valid_params) { { temp_lookup_number: registration.reg_identifier.downcase } }
+
+              it "returns a 302 response and redirects to the renewal_start form" do
+                post renew_registration_forms_path(transient_registration[:token]), renew_registration_form: valid_params
+
+                expect(response).to have_http_status(302)
+                expect(response).to redirect_to(new_renewal_start_form_path(registration.reg_identifier))
+              end
+            end
           end
 
           context "when valid params are submitted and the registration cannot be renewed" do

--- a/spec/requests/waste_carriers_engine/renew_registration_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/renew_registration_forms_spec.rb
@@ -70,7 +70,7 @@ module WasteCarriersEngine
           end
 
           context "when valid params are submitted and the registration cannot be renewed" do
-            let(:registration) { create(:registration, :has_required_data, :expires_later) }
+            let(:registration) { create(:registration, :has_required_data, :expired_one_month_ago) }
             let(:valid_params) { { temp_lookup_number: registration.reg_identifier } }
 
             it "returns a 200 response and renders the new template" do

--- a/spec/requests/waste_carriers_engine/renew_registration_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/renew_registration_forms_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "RenewRegistrationForms", type: :request do
+    describe "GET new_renew_registration_form_path" do
+      context "when no new registration exists" do
+        it "redirects to the invalid page" do
+          get new_renew_registration_form_path("wibblewobblejellyonaplate")
+
+          expect(response).to redirect_to(page_path("invalid"))
+        end
+      end
+
+      context "when a valid new registration exists" do
+        let(:transient_registration) do
+          create(
+            :new_registration,
+            workflow_state: "renew_registration_form"
+          )
+        end
+
+        context "when the workflow_state is correct" do
+          it "returns a 200 status and renders the :new template" do
+            get new_renew_registration_form_path(transient_registration.token)
+
+            expect(response).to have_http_status(200)
+            expect(response).to render_template(:new)
+          end
+        end
+
+        context "when the workflow_state is not correct" do
+          before do
+            transient_registration.update_attributes(workflow_state: "payment_summary_form")
+          end
+
+          it "redirects to the correct page" do
+            get new_renew_registration_form_path(transient_registration.token)
+
+            expect(response).to redirect_to(new_payment_summary_form_path(transient_registration.token))
+          end
+        end
+      end
+    end
+
+    describe "POST renew_registration_forms_path" do
+      context "when a valid user is signed in" do
+        let(:user) { create(:user) }
+        before(:each) do
+          sign_in(user)
+        end
+
+        context "when a valid transient registration exists" do
+          let(:transient_registration) do
+            create(:new_registration,
+                   workflow_state: "renew_registration_form")
+          end
+
+          context "when valid params are submitted and the registration can be renewed" do
+            let(:registration) { create(:registration, :has_required_data, :expires_soon) }
+            let(:valid_params) { { temp_lookup_number: registration.reg_identifier } }
+
+            it "returns a 302 response and redirects to the renewal_start form" do
+              post renew_registration_forms_path(transient_registration[:token]), renew_registration_form: valid_params
+
+              expect(response).to have_http_status(302)
+              expect(response).to redirect_to(new_renewal_start_form_path(registration.reg_identifier))
+            end
+          end
+
+          context "when valid params are submitted and the registration cannot be renewed" do
+            let(:registration) { create(:registration, :has_required_data, :expires_later) }
+            let(:valid_params) { { temp_lookup_number: registration.reg_identifier } }
+
+            it "returns a 200 response and renders the new template" do
+              post renew_registration_forms_path(transient_registration[:token]), renew_registration_form: valid_params
+
+              expect(response).to have_http_status(200)
+              expect(response).to render_template("waste_carriers_engine/renew_registration_forms/new")
+            end
+          end
+
+          context "when invalid params are submitted" do
+            let(:invalid_params) { { company_no: "" } }
+
+            it "returns a 200 response and renders the new template" do
+              post renew_registration_forms_path(transient_registration[:token]), renew_registration_form: invalid_params
+
+              expect(response).to have_http_status(200)
+              expect(response).to render_template("waste_carriers_engine/renew_registration_forms/new")
+            end
+          end
+        end
+
+        context "when the transient registration is in the wrong state" do
+          let(:transient_registration) do
+            create(:new_registration,
+                   workflow_state: "contact_name_form")
+          end
+
+          let(:valid_params) { { company_no: "01234567" } }
+
+          it "returns a 302 response and redirects to the correct form for the state" do
+            post renew_registration_forms_path(transient_registration[:token]), renew_registration_form: valid_params
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_contact_name_form_path(transient_registration[:token]))
+          end
+        end
+      end
+    end
+
+    describe "GET back_renew_registration_forms_path" do
+      context "when a valid user is signed in" do
+        let(:user) { create(:user) }
+        before(:each) do
+          sign_in(user)
+        end
+
+        context "when a valid transient registration exists" do
+          let(:transient_registration) do
+            create(:new_registration,
+                   workflow_state: "renew_registration_form")
+          end
+
+          context "when the back action is triggered" do
+            it "returns a 302 response and redirects to the start form" do
+              get back_renew_registration_forms_path(transient_registration[:token])
+
+              expect(response).to have_http_status(302)
+              expect(response).to redirect_to(new_start_form_path(params: { token: transient_registration[:token] }))
+            end
+          end
+        end
+
+        context "when the transient registration is in the wrong state" do
+          let(:transient_registration) do
+            create(:new_registration,
+                   workflow_state: "contact_name_form")
+          end
+
+          context "when the back action is triggered" do
+            it "returns a 302 response and redirects to the correct form for the state" do
+              get back_renew_registration_forms_path(transient_registration[:token])
+
+              expect(response).to have_http_status(302)
+              expect(response).to redirect_to(new_contact_name_form_path(transient_registration[:token]))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/validators/waste_carriers_engine/renewal_lookup_validators_spec.rb
+++ b/spec/validators/waste_carriers_engine/renewal_lookup_validators_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Test
+  RenewalLookupValidatable = Struct.new(:temp_lookup_number) do
+    include ActiveModel::Validations
+
+    attr_reader :temp_lookup_number
+    validates_with WasteCarriersEngine::RenewalLookupValidator
+  end
+end
+
+module WasteCarriersEngine
+  RSpec.describe RenewalLookupValidator do
+    subject { Test::RenewalLookupValidatable.new }
+
+    context "when there is no matching registration" do
+      before do
+        expect(Registration).to receive(:where).and_return(nil)
+      end
+
+      it "is invalid and sets the correct error message" do
+        expect(subject).to receive_message_chain(:errors, :add).with(:temp_lookup_number, :no_match)
+        expect(subject).to_not be_valid
+      end
+    end
+
+    context "when there is a matching registration" do
+      let(:upper_tier) {}
+      let(:active) {}
+      let(:expired) {}
+      let(:registration) do
+        double(:registration,
+               active?: active,
+               expired?: expired,
+               upper_tier?: upper_tier)
+      end
+
+      before do
+        expect(Registration).to receive(:where).and_return([registration])
+      end
+
+      context "when it's lower tier" do
+        let(:upper_tier) { false }
+
+        it "is invalid and sets the correct error message" do
+          expect(subject).to receive_message_chain(:errors, :add).with(:temp_lookup_number, :lower_tier)
+          expect(subject).to_not be_valid
+        end
+      end
+
+      context "when it's upper tier" do
+        let(:upper_tier) { true }
+
+        let(:date_can_renew_from) {}
+        let(:expired_check_service) {}
+        let(:in_expiry_grace_window) {}
+        let(:in_renewal_window) {}
+
+        let(:check_service) do
+          double(:check_service,
+                 date_can_renew_from: date_can_renew_from,
+                 expired?: expired_check_service,
+                 in_expiry_grace_window?: in_expiry_grace_window,
+                 in_renewal_window?: in_renewal_window)
+        end
+
+        context "when the registration is active" do
+          let(:active) { true }
+          let(:expired) { false }
+          let(:expired_check_service) { false }
+
+          before do
+            expect(ExpiryCheckService).to receive(:new).and_return(check_service)
+          end
+
+          context "when it's not yet in the renewal window" do
+            let(:in_renewal_window) { false }
+
+            it "is invalid and sets the correct error message" do
+              expect(subject).to receive_message_chain(:errors, :add).with(:temp_lookup_number, :not_yet_renewable, date_can_renew_from)
+              expect(subject).to_not be_valid
+            end
+          end
+
+          context "when it's within the renewal window" do
+            let(:in_renewal_window) { true }
+
+            it "is valid" do
+              expect(subject).to be_valid
+            end
+          end
+        end
+
+        context "when the registration is expired" do
+          let(:active) { false }
+          let(:expired) { true }
+          let(:expired_check_service) { true }
+
+          before do
+            expect(ExpiryCheckService).to receive(:new).and_return(check_service)
+          end
+
+          context "when it's beyond the expiry grace period" do
+            let(:expired_check_service) { false }
+
+            it "is invalid and sets the correct error message" do
+              expect(subject).to receive_message_chain(:errors, :add).with(:temp_lookup_number, :expired)
+              expect(subject).to_not be_valid
+            end
+          end
+
+          context "when it's within the expiry grace period" do
+            let(:expired_check_service) { true }
+
+            it "is valid" do
+              expect(subject).to be_valid
+            end
+          end
+        end
+
+        context "when the registration is neither active nor expired" do
+          let(:active) { false }
+          let(:expired) { false }
+
+          it "is invalid and sets the correct error message" do
+            expect(subject).to receive_message_chain(:errors, :add).with(:temp_lookup_number, :unrenewable_status)
+            expect(subject).to_not be_valid
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/validators/waste_carriers_engine/renewal_lookup_validators_spec.rb
+++ b/spec/validators/waste_carriers_engine/renewal_lookup_validators_spec.rb
@@ -17,12 +17,12 @@ module WasteCarriersEngine
 
     context "when there is no matching registration" do
       before do
-        expect(Registration).to receive(:where).and_return(nil)
+        expect(Registration).to receive(:where).and_return([])
       end
 
       it "is invalid and sets the correct error message" do
-        expect(subject).to receive_message_chain(:errors, :add).with(:temp_lookup_number, :no_match)
         expect(subject).to_not be_valid
+        expect(subject.errors[:temp_lookup_number].first).to include("no_match")
       end
     end
 
@@ -45,8 +45,8 @@ module WasteCarriersEngine
         let(:upper_tier) { false }
 
         it "is invalid and sets the correct error message" do
-          expect(subject).to receive_message_chain(:errors, :add).with(:temp_lookup_number, :lower_tier)
           expect(subject).to_not be_valid
+          expect(subject.errors[:temp_lookup_number].first).to include("lower_tier")
         end
       end
 
@@ -79,8 +79,8 @@ module WasteCarriersEngine
             let(:in_renewal_window) { false }
 
             it "is invalid and sets the correct error message" do
-              expect(subject).to receive_message_chain(:errors, :add).with(:temp_lookup_number, :not_yet_renewable, date_can_renew_from)
               expect(subject).to_not be_valid
+              expect(subject.errors[:temp_lookup_number].first).to include("not_yet_renewable")
             end
           end
 
@@ -103,16 +103,16 @@ module WasteCarriersEngine
           end
 
           context "when it's beyond the expiry grace period" do
-            let(:expired_check_service) { false }
+            let(:in_expiry_grace_window) { false }
 
             it "is invalid and sets the correct error message" do
-              expect(subject).to receive_message_chain(:errors, :add).with(:temp_lookup_number, :expired)
               expect(subject).to_not be_valid
+              expect(subject.errors[:temp_lookup_number].first).to include("expired")
             end
           end
 
           context "when it's within the expiry grace period" do
-            let(:expired_check_service) { true }
+            let(:in_expiry_grace_window) { true }
 
             it "is valid" do
               expect(subject).to be_valid
@@ -125,8 +125,8 @@ module WasteCarriersEngine
           let(:expired) { false }
 
           it "is invalid and sets the correct error message" do
-            expect(subject).to receive_message_chain(:errors, :add).with(:temp_lookup_number, :unrenewable_status)
             expect(subject).to_not be_valid
+            expect(subject.errors[:temp_lookup_number].first).to include("unrenewable_status")
           end
         end
       end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-841

When external users enter the service, they see a page that asks what the user wants to do - start a new registration or renew. If they select 'renew', they see this page: 'What is your waste carrier registration number?'

We need to replace this page from the frontend with a new version.