### PR TITLE
Exclude confirmed convictions from :convictions_possible_match scope

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_filter_conviction_status.rb
+++ b/app/models/concerns/waste_carriers_engine/can_filter_conviction_status.rb
@@ -6,7 +6,8 @@ module WasteCarriersEngine
 
     included do
       scope :convictions_possible_match, lambda {
-        where("conviction_sign_offs.0.workflow_state": "possible_match")
+        where("conviction_sign_offs.0.workflow_state": "possible_match",
+              :"conviction_sign_offs.0.confirmed".ne => "yes")
       }
       scope :convictions_checks_in_progress, lambda {
         where("conviction_sign_offs.0.workflow_state": "checks_in_progress")

--- a/spec/support/shared_examples/can_filter_conviction_status.rb
+++ b/spec/support/shared_examples/can_filter_conviction_status.rb
@@ -45,6 +45,17 @@ RSpec.shared_examples "Can filter conviction status" do
     record
   end
 
+  let(:old_confirmed_record) do
+    record = described_class.new(
+      conviction_sign_offs: [
+        WasteCarriersEngine::ConvictionSignOff.new(confirmed: "yes")
+      ]
+    )
+    # Skip the validation so we don't have to include addresses, etc
+    record.save(validate: false)
+    record
+  end
+
   let(:no_status_pending) do
     record = described_class.new(
       conviction_sign_offs: [
@@ -91,6 +102,10 @@ RSpec.shared_examples "Can filter conviction status" do
       expect(scope).to_not include(checks_in_progress)
       expect(scope).to_not include(approved)
       expect(scope).to_not include(rejected)
+      expect(scope).to_not include(old_confirmed_record)
+      expect(scope).to_not include(no_status_pending)
+      expect(scope).to_not include(no_status_active)
+      expect(scope).to_not include(no_status_approved)
     end
   end
 
@@ -102,6 +117,10 @@ RSpec.shared_examples "Can filter conviction status" do
       expect(scope).to include(checks_in_progress)
       expect(scope).to_not include(approved)
       expect(scope).to_not include(rejected)
+      expect(scope).to_not include(old_confirmed_record)
+      expect(scope).to_not include(no_status_pending)
+      expect(scope).to_not include(no_status_active)
+      expect(scope).to_not include(no_status_approved)
     end
   end
 
@@ -113,6 +132,10 @@ RSpec.shared_examples "Can filter conviction status" do
       expect(scope).to_not include(checks_in_progress)
       expect(scope).to include(approved)
       expect(scope).to_not include(rejected)
+      expect(scope).to_not include(old_confirmed_record)
+      expect(scope).to_not include(no_status_pending)
+      expect(scope).to_not include(no_status_active)
+      expect(scope).to_not include(no_status_approved)
     end
   end
 
@@ -124,6 +147,10 @@ RSpec.shared_examples "Can filter conviction status" do
       expect(scope).to_not include(checks_in_progress)
       expect(scope).to_not include(approved)
       expect(scope).to include(rejected)
+      expect(scope).to_not include(old_confirmed_record)
+      expect(scope).to_not include(no_status_pending)
+      expect(scope).to_not include(no_status_active)
+      expect(scope).to_not include(no_status_approved)
     end
   end
 
@@ -135,6 +162,7 @@ RSpec.shared_examples "Can filter conviction status" do
       expect(scope).to_not include(checks_in_progress)
       expect(scope).to_not include(approved)
       expect(scope).to_not include(rejected)
+      expect(scope).to_not include(old_confirmed_record)
       expect(scope).to include(no_status_pending)
       expect(scope).to_not include(no_status_active)
       expect(scope).to_not include(no_status_approved)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-967

Since `possible_match` is the default value for the convictions workflow state, this meant that old confirmed records were sometimes considered to also be possible matches, clogging up the list of convictions to check.

This PR adds an extra filter to the scope to avoid this happening, and increases our tests for the scopes.