### PR TITLE
Fixes to lower tier registration

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_change_registration_status.rb
+++ b/app/models/concerns/waste_carriers_engine/can_change_registration_status.rb
@@ -57,6 +57,8 @@ module WasteCarriersEngine
 
       # Transition effects
       def set_expiry_date
+        return if registration.lower_tier?
+
         registration.update_attributes(expires_on: Rails.configuration.expires_after.years.from_now)
       end
 

--- a/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
@@ -259,7 +259,10 @@ module WasteCarriersEngine
 
           transitions from: :declaration_form,
                       to: :registration_completed_form,
-                      if: :lower_tier?
+                      if: :lower_tier?,
+                      # TODO: This don't get triggered if in the `success`
+                      # callback block, hence we went for `after`
+                      after: :set_metadata_route
 
           transitions from: :declaration_form,
                       to: :cards_form

--- a/app/models/waste_carriers_engine/new_registration.rb
+++ b/app/models/waste_carriers_engine/new_registration.rb
@@ -9,7 +9,7 @@ module WasteCarriersEngine
 
     after_initialize :build_meta_data
 
-    def prepare_for_payment(mode, _user)
+    def prepare_for_payment(mode, _user = nil)
       BuildNewRegistrationFinanceDetailsService.run(
         transient_registration: self,
         payment_method: mode

--- a/app/models/waste_carriers_engine/order.rb
+++ b/app/models/waste_carriers_engine/order.rb
@@ -100,6 +100,8 @@ module WasteCarriersEngine
     private
 
     def generate_description
+      return unless order_items.any?
+
       description = order_items.map(&:description)
                                .join(", plus ")
 

--- a/app/services/waste_carriers_engine/build_new_registration_finance_details_service.rb
+++ b/app/services/waste_carriers_engine/build_new_registration_finance_details_service.rb
@@ -24,9 +24,9 @@ module WasteCarriersEngine
 
       order.order_items = []
 
-      order.order_items << OrderItem.new_registration_item
+      order.order_items << OrderItem.new_registration_item if transient_registration.upper_tier?
 
-      if transient_registration.temp_cards.positive?
+      if transient_registration.temp_cards&.positive?
         order.order_items << OrderItem.new_copy_cards_item(transient_registration.temp_cards)
       end
 

--- a/spec/services/waste_carriers_engine/build_new_registration_finance_details_service_spec.rb
+++ b/spec/services/waste_carriers_engine/build_new_registration_finance_details_service_spec.rb
@@ -5,7 +5,14 @@ require "rails_helper"
 module WasteCarriersEngine
   RSpec.describe BuildNewRegistrationFinanceDetailsService do
     describe ".run" do
-      let(:transient_registration) { double(:transient_registration, contact_email: "user@example.com", temp_cards: 2) }
+      let(:transient_registration) do
+        double(
+          :transient_registration,
+          contact_email: "user@example.com",
+          temp_cards: 2,
+          upper_tier?: true
+        )
+      end
       let(:order) { double(:order, order_items: []) }
 
       before do

--- a/spec/services/waste_carriers_engine/registration_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/registration_completion_service_spec.rb
@@ -38,6 +38,25 @@ module WasteCarriersEngine
         expect(new_registration_scope.any?).to be_falsey
       end
 
+      context "when the registration is a lower tier registration" do
+        let(:transient_registration) do
+          create(
+            :new_registration,
+            :has_required_lower_tier_data
+          )
+        end
+
+        it "activates the registration, set up finance details and does not set an expire date" do
+          registration = described_class.run(transient_registration)
+
+          expect(registration.expires_on).to be_nil
+          expect(registration).to be_active
+          expect(registration.finance_details).to be_present
+          expect(registration.finance_details.orders.count).to eq(1)
+          expect(registration.finance_details.balance).to eq(0)
+        end
+      end
+
       context "when the balance have been cleared and there are no pending convictions checks" do
         let(:finance_details) { build(:finance_details, :has_paid_order_and_payment) }
 


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-838

This fixes various issue on the lower tier registration created during the new journey.
 - The route was not set when completing the registration, fixed in the state machine
 - The registration finance details were not set. Since the old system generates a fake worldpay payment for an order of 0 balance and no items, we reproduced the same here in the completion job
 - Make sure we don't set an expire date on LT registration