### PR TITLE
Fix W3C fail with tel. no. on reg. complete page

### DIFF
--- a/app/views/waste_carriers_engine/registration_completed_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/registration_completed_forms/new.html.erb
@@ -30,7 +30,7 @@
   <p>
     <%= t(".telephone.heading") %>
     <br>
-    <a href="tel:<%= t(".telephone.value") %>"><%= t(".telephone.value") %></a>
+    <a href="tel:<%= t(".telephone.value.href") %>"><%= t(".telephone.value.display") %></a>
   </p>
 
   <h2 class="heading-medium"><%= t(".subheading_3") %></h2>

--- a/config/locales/forms/registration_completed_forms/en.yml
+++ b/config/locales/forms/registration_completed_forms/en.yml
@@ -20,7 +20,9 @@ en:
           value: "nccc-carrierbroker@environment-agency.gov.uk"
         telephone:
           heading: "Telephone"
-          value: "03708 506 506"
+          value:
+            display: "03708 506 506"
+            href: "03708506506"
         subheading_2: "If your details change"
         paragraph_2: "If any of the details you've given us change, you must update them within 28 days by contacting the Environment Agency."
         subheading_3: "Registration checks"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-918

During the QA of adding a new registration completion page we spotted a W3C validation error being reported.

Specifically it doesn't like that there are spaces in the `tel:` attribute of the **href** element we use to display NCCC's telephone number.

This fix resolves the issue.