### PR TITLE
Update text on 'application received' pages

### DIFF
--- a/config/locales/forms/registration_received_pending_conviction_forms/en.yml
+++ b/config/locales/forms/registration_received_pending_conviction_forms/en.yml
@@ -8,11 +8,10 @@ en:
         paragraph_1: "We've sent a confirmation email to %{email}."
         subheading_1: "What happens next"
         paragraph_2: "We’ll check your details and let you know whether your application has been successful. We aim to do this within 10 working days."
-        paragraph_3: "You’re not legally entitled to operate as a waste carrier until we have received your payment and confirmed your registration."
+        paragraph_3: "You’re not legally entitled to operate as a waste carrier until we have confirmed your registration."
         contact:
           paragraph_1: "Contact the Environment Agency on"
           email: "nccc-carrierbroker@environment-agency.gov.uk"
           text: "or 03708 506506 within 28 days if you have questions about your registration."
         survey_link_text: What did you think of the service?
         survey_link_hint: (takes 30 seconds)
-

--- a/config/locales/forms/renewal_received_forms/en.yml
+++ b/config/locales/forms/renewal_received_forms/en.yml
@@ -13,7 +13,7 @@ en:
         awaiting_payment_paragraph_2: Please allow 5 working days for your payment to reach us.
         conviction_check_subheading: What happens next
         conviction_check_paragraph_1: We'll check your details and let you know whether your application has been successful. We aim to do this within 10 working days.
-        paragraph_2: Your registration will not be renewed until we have received your payment and confirmed your registration.
+        paragraph_2: Your registration will not be renewed until we have confirmed your registration.
         paragraph_3: Call our helpline on 03708 506 506 if you have any questions about your renewal.
         survey_link_text: What do you think of this service?
         survey_link_hint: (takes 30 seconds)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-958

This makes a minor text change to the 'renewal received' and 'registration received' pages that are seen when a user submits an application that is pending a conviction check.

Previously this included a mention of payment which could confuse users who had already paid. So this PR updates the text to clarify it.