### PR TITLE
Add check your tier screen to new registration flow

### DIFF
--- a/app/controllers/waste_carriers_engine/check_your_tier_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/check_your_tier_forms_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class CheckYourTierFormsController < FormsController
+    def new
+      super(CheckYourTierForm, "check_your_tier")
+    end
+
+    def create
+      super(CheckYourTierForm, "check_your_tier")
+    end
+
+    private
+
+    def transient_registration_attributes
+      params.fetch(:check_your_tier_form, {}).permit(:temp_check_your_tier)
+    end
+  end
+end

--- a/app/forms/waste_carriers_engine/check_your_tier_form.rb
+++ b/app/forms/waste_carriers_engine/check_your_tier_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class CheckYourTierForm < BaseForm
+    delegate :temp_check_your_tier, to: :transient_registration
+
+    validates :temp_check_your_tier, inclusion: { in: %w[lower upper unknown] }
+  end
+end

--- a/app/models/waste_carriers_engine/new_registration.rb
+++ b/app/models/waste_carriers_engine/new_registration.rb
@@ -7,6 +7,7 @@ module WasteCarriersEngine
 
     field :temp_start_option, type: String
     field :temp_lookup_number, type: String
+    field :temp_check_your_tier, type: String
 
     after_initialize :build_meta_data
 

--- a/app/views/shared/_what_are_lower_and_upper_tier.html.erb
+++ b/app/views/shared/_what_are_lower_and_upper_tier.html.erb
@@ -1,0 +1,21 @@
+<details>
+  <summary><span class="summary"><%= t(".summary") %></span></summary>
+
+  <div class="panel panel-border-narrow">
+    <p><%= t(".paragraph_1") %></p>
+
+    <ul class="list list-bullet">
+      <% t(".list_1").each do |list_item| %>
+        <li><%= list_item %></li>
+      <% end %>
+    </ul>
+
+    <p><%= t(".paragraph_2") %></p>
+
+    <ul class="list list-bullet">
+      <% t(".list_2").each do |list_item| %>
+        <li><%= list_item %></li>
+      <% end %>
+    </ul>
+  </div>
+</details>

--- a/app/views/waste_carriers_engine/check_your_tier_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/check_your_tier_forms/new.html.erb
@@ -1,0 +1,49 @@
+<%= render("waste_carriers_engine/shared/back", back_path: back_check_your_tier_forms_path(@check_your_tier.token)) %>
+
+<div class="text">
+  <%= form_for(@check_your_tier) do |f| %>
+    <%= render("waste_carriers_engine/shared/errors", object: @check_your_tier) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <p><%= t(".paragraph") %></p>
+
+    <div class="form-group <%= "form-group-error" if @check_your_tier.errors[:temp_check_your_tier].any? %>">
+      <fieldset id="temp_check_your_tier">
+        <legend class="visuallyhidden">
+          <%= t(".heading") %>
+        </legend>
+
+        <% if @check_your_tier.errors[:temp_check_your_tier].any? %>
+          <span class="error-message"><%= @check_your_tier.errors[:temp_check_your_tier].join(", ") %></span>
+        <% end %>
+
+        <div class="multiple-choice">
+          <%= f.radio_button :temp_check_your_tier, 'unknown' %>
+          <%= f.label :temp_check_your_tier, t(".options.unknown"), value: 'unknown' %>
+        </div>
+
+        <div class="multiple-choice">
+          <%= f.radio_button :temp_check_your_tier, 'upper' %>
+          <%= f.label :temp_check_your_tier, t(".options.upper"), value: 'upper' %>
+        </div>
+
+        <div class="multiple-choice">
+          <%= f.radio_button :temp_check_your_tier, 'lower' %>
+          <%= f.label :temp_check_your_tier, t(".options.lower"), value: 'lower' %>
+        </div>
+      </fieldset>
+    </div>
+
+    <div class="form-group">
+      <%= render "shared/what_are_lower_and_upper_tier" %>
+    </div>
+
+    <div class="form-group">
+      <p class="form-hint"><%= t(".help") %></p>
+    </div>
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/waste_carriers_engine/your_tier_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/your_tier_forms/new.html.erb
@@ -7,27 +7,7 @@
     <div class="form-group">
       <p><%= t(".paragraph_1.#{@transient_registration.tier}") %></p>
 
-      <details>
-        <summary><span class="summary"><%= t(".details.summary") %></span></summary>
-
-        <div class="panel panel-border-narrow">
-          <p><%= t(".details.paragraph_1") %></p>
-
-          <ul class="list list-bullet">
-            <% t(".details.list_1").each do |list_item| %>
-              <li><%= list_item %></li>
-            <% end %>
-          </ul>
-
-          <p><%= t(".details.paragraph_2") %></p>
-
-          <ul class="list list-bullet">
-            <% t(".details.list_2").each do |list_item| %>
-              <li><%= list_item %></li>
-            <% end %>
-          </ul>
-        </div>
-      </details>
+      <%= render "shared/what_are_lower_and_upper_tier" %>
     </div>
 
     <div class="form-group">

--- a/config/locales/forms/check_your_tier_forms/en.yml
+++ b/config/locales/forms/check_your_tier_forms/en.yml
@@ -1,0 +1,21 @@
+en:
+  waste_carriers_engine:
+    check_your_tier_forms:
+      new:
+        paragraph: "If you are not sure, you can check by answering a few questions about your business activities."
+        title: Check your tier
+        heading: What kind of registration do you need?
+        options:
+          unknown: "Help me decide"
+          lower: "I need a lower tier registration"
+          upper: "I need an upper tier registration"
+        help: We’ll only use your answers to determine what tier your registration should be. Your answers do not affect what you can do as a registered waste carrier, or license you to perform certain activities.
+        error_heading: Something is wrong
+        next_button: Continue
+  activemodel:
+    errors:
+      models:
+        waste_carriers_engine/check_your_tier_form:
+          attributes:
+            temp_check_your_tier:
+              inclusion: "Select help me decide, upper tier or lower tier"

--- a/config/locales/forms/your_tier_forms/en.yml
+++ b/config/locales/forms/your_tier_forms/en.yml
@@ -9,17 +9,4 @@ en:
         paragraph_1:
           UPPER: "It will cost £154 to register as an upper tier waste carrier for 3 years. You will have to renew every 3 years."
           LOWER: "There is no charge to register as a lower tier waste carrier. Your registration will not expire."
-        details:
-          summary: "What are lower and upper tiers?"
-          paragraph_1: "You are lower tier if you:"
-          list_1:
-            - "only carry waste produced by your own business unless it’s construction or demolition waste"
-            - "only work with animal by-products, mining and quarry waste or waste from agricultural premises"
-            - "are a charity or voluntary organisation"
-          paragraph_2: "If none of the lower tier criteria apply, you are upper tier. Examples include if you:"
-          list_2:
-            - "carry other people's waste"
-            - "carry your own construction or demolition waste"
-            - "arrange for waste from other businesses to be carried, recovered or disposed of"
-            - "buy or sell waste, or use an agent to do so"
         next_button: Continue

--- a/config/locales/shared/what_are_lower_and_upper_tier.en.yml
+++ b/config/locales/shared/what_are_lower_and_upper_tier.en.yml
@@ -1,0 +1,15 @@
+en:
+  shared:
+    what_are_lower_and_upper_tier:
+      summary: "What are lower and upper tiers?"
+      paragraph_1: "You are lower tier if you:"
+      list_1:
+        - "only carry waste produced by your own business unless it’s construction or demolition waste"
+        - "only work with animal by-products, mining and quarry waste or waste from agricultural premises"
+        - "are a charity or voluntary organisation"
+      paragraph_2: "If none of the lower tier criteria apply, you are upper tier. Examples include if you:"
+      list_2:
+        - "carry other people's waste"
+        - "carry your own construction or demolition waste"
+        - "arrange for waste from other businesses to be carried, recovered or disposed of"
+        - "buy or sell waste, or use an agent to do so"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,16 @@ WasteCarriersEngine::Engine.routes.draw do
                     on: :collection
               end
 
+    resources :check_your_tier_forms,
+              only: %i[new create],
+              path: "check-your-tier",
+              path_names: { new: "" } do
+                get "back",
+                    to: "check_your_tier_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+
     resources :registration_received_pending_payment_forms,
               only: :new,
               path: "registration-received-pending-payment",

--- a/spec/models/waste_carriers_engine/new_registration_workflow/business_type_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/business_type_form_spec.rb
@@ -19,7 +19,7 @@ module WasteCarriersEngine
             end
           end
 
-          include_examples "has next transition", next_state: "other_businesses_form"
+          include_examples "has next transition", next_state: "check_your_tier_form"
         end
 
         context "on back" do

--- a/spec/models/waste_carriers_engine/new_registration_workflow/check_your_tier_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/check_your_tier_form_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:new_registration, workflow_state: "check_your_tier_form") }
+
+    describe "#workflow_state" do
+      context ":check_your_tier_form state transitions" do
+        context "on next" do
+          context "when the check your tier answer is unknown" do
+            subject { build(:new_registration, workflow_state: "check_your_tier_form", temp_check_your_tier: "unknown") }
+
+            include_examples "has next transition", next_state: "other_businesses_form"
+          end
+
+          context "when the check your tier answer is upper" do
+            subject { build(:new_registration, workflow_state: "check_your_tier_form", temp_check_your_tier: "upper") }
+
+            include_examples "has next transition", next_state: "your_tier_form"
+
+            it "updates the tier of the object to UPPER" do
+              expect { subject.next }.to change { subject.tier }.to(WasteCarriersEngine::NewRegistration::UPPER_TIER)
+            end
+          end
+
+          context "when the check your tier answer is lower" do
+            subject { build(:new_registration, workflow_state: "check_your_tier_form", temp_check_your_tier: "lower") }
+
+            include_examples "has next transition", next_state: "your_tier_form"
+
+            it "updates the tier of the object to LOWER" do
+              expect { subject.next }.to change { subject.tier }.to(WasteCarriersEngine::NewRegistration::LOWER_TIER)
+            end
+          end
+        end
+
+        context "on back" do
+          subject { build(:new_registration, workflow_state: "check_your_tier_form") }
+
+          include_examples "has back transition", previous_state: "business_type_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/other_businesses_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/other_businesses_form_spec.rb
@@ -27,7 +27,7 @@ module WasteCarriersEngine
             include_examples "has back transition", previous_state: "location_form"
           end
 
-          include_examples "has back transition", previous_state: "business_type_form"
+          include_examples "has back transition", previous_state: "check_your_tier_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/your_tier_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/your_tier_form_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe NewRegistration do
-    subject { build(:new_registration, workflow_state: "your_tier_form") }
+    subject { build(:new_registration, workflow_state: "your_tier_form", temp_check_your_tier: "unknown") }
 
     describe "#workflow_state" do
       context ":your_tier_form state transitions" do
@@ -23,17 +23,23 @@ module WasteCarriersEngine
         end
 
         context "on back" do
+          context "when the check your tier answer is not unknown" do
+            subject { build(:new_registration, workflow_state: "your_tier_form", temp_check_your_tier: "lower") }
+
+            include_examples "has back transition", previous_state: "check_your_tier_form"
+          end
+
           context "when the registration is lower tier" do
-            subject { build(:new_registration, :lower, workflow_state: "your_tier_form") }
+            subject { build(:new_registration, :lower, workflow_state: "your_tier_form", temp_check_your_tier: "unknown") }
 
             context "when the waste is the main service" do
-              subject { build(:new_registration, :lower, workflow_state: "your_tier_form", is_main_service: "yes") }
+              subject { build(:new_registration, :lower, workflow_state: "your_tier_form", is_main_service: "yes", temp_check_your_tier: "unknown") }
 
               include_examples "has back transition", previous_state: "waste_types_form"
             end
 
             context "when the company only carries own waste" do
-              subject { build(:new_registration, :lower, workflow_state: "your_tier_form", other_businesses: "no") }
+              subject { build(:new_registration, :lower, workflow_state: "your_tier_form", other_businesses: "no", temp_check_your_tier: "unknown") }
 
               include_examples "has back transition", previous_state: "construction_demolition_form"
             end
@@ -42,13 +48,13 @@ module WasteCarriersEngine
           end
 
           context "when the company deals with more than amf waste" do
-            subject { build(:new_registration, workflow_state: "your_tier_form", only_amf: "no") }
+            subject { build(:new_registration, workflow_state: "your_tier_form", only_amf: "no", temp_check_your_tier: "unknown") }
 
             include_examples "has back transition", previous_state: "waste_types_form"
           end
 
           context "when the registration's company is a charity" do
-            subject { build(:new_registration, workflow_state: "your_tier_form", business_type: "charity") }
+            subject { build(:new_registration, workflow_state: "your_tier_form", business_type: "charity", temp_check_your_tier: "unknown") }
 
             include_examples "has back transition", previous_state: "business_type_form"
           end

--- a/spec/requests/waste_carriers_engine/check_your_tier_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/check_your_tier_forms_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "CheckYourTierForms", type: :request do
+    describe "GET new_check_your_tier_form_path" do
+      context "when a registration is in progress" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 :has_required_data,
+                 workflow_state: "check_your_tier_form")
+        end
+
+        context "when the workflow_state matches the request" do
+          it "loads the requested page and returns a 200 state" do
+            get new_check_your_tier_form_path(transient_registration.token)
+
+            expect(response).to render_template(:new)
+            expect(response).to have_http_status(200)
+          end
+        end
+
+        context "when the workflow_state is a flexible form" do
+          before do
+            transient_registration.update_attributes(workflow_state: "business_type_form")
+          end
+
+          it "updates the workflow_state to match the requested page and loads the requested page" do
+            get new_check_your_tier_form_path(transient_registration.token)
+
+            expect(transient_registration.reload[:workflow_state]).to eq("check_your_tier_form")
+            expect(response).to render_template("check_your_tier_forms/new")
+          end
+        end
+      end
+    end
+
+    describe "POST check_your_tier_path" do
+      let(:transient_registration) do
+        create(:new_registration, workflow_state: "check_your_tier_form")
+      end
+
+      include_examples "POST form",
+                       "check_your_tier_form",
+                       valid_params: { temp_check_your_tier: "lower" },
+                       invalid_params: { temp_check_your_tier: "foo" }
+    end
+
+    describe "GET back_check_your_tier_forms_path" do
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 :has_required_data,
+                 workflow_state: "check_your_tier_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response" do
+            get back_check_your_tier_forms_path(transient_registration.token)
+
+            expect(response).to have_http_status(302)
+          end
+
+          it "redirects to the business_type form" do
+            get back_check_your_tier_forms_path(transient_registration.token)
+
+            expect(response).to redirect_to(new_business_type_form_path(transient_registration.token))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 :has_required_data,
+                 workflow_state: "location_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the correct form for the state" do
+            get back_check_your_tier_forms_path(transient_registration.token)
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_location_form_path(transient_registration.token))
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-970

This adds the code necessary to show the check your tier screen as per wireframe and flow.

<details>
<summary>
Error Screenshots
</summary>

![Screenshot 2020-04-03 at 12 24 16](https://user-images.githubusercontent.com/1385397/78357551-90f32c80-75a9-11ea-9d23-66293bdf6658.png)

</details>

<details>
<summary>
Page Screenshots
</summary>

![Screenshot 2020-04-03 at 12 24 24](https://user-images.githubusercontent.com/1385397/78357559-92bcf000-75a9-11ea-855b-2916792c567c.png)


</details>




