### PR TITLE
Do not copy new temp attribute to registration

### DIFF
--- a/app/services/waste_carriers_engine/registration_completion_service.rb
+++ b/app/services/waste_carriers_engine/registration_completion_service.rb
@@ -104,6 +104,7 @@ module WasteCarriersEngine
         "temp_payment_method",
         "temp_lookup_number",
         "temp_tier_check",
+        "temp_check_your_tier",
         "_type",
         "workflow_state",
         "locking_name",

--- a/spec/factories/new_registration.rb
+++ b/spec/factories/new_registration.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
 
       metaData { build(:metaData, route: "DIGITAL") }
 
+      temp_check_your_tier { "unknown" }
       sequence :reg_identifier
 
       has_addresses


### PR DESCRIPTION
This fixes a bug on the completion service trying to copy a temporary attribute in the registration which is not suppose to persist the data