### PR TITLE
Update content of completed registration email

### DIFF
--- a/app/views/waste_carriers_engine/new_registration_mailer/registration_activated.html.erb
+++ b/app/views/waste_carriers_engine/new_registration_mailer/registration_activated.html.erb
@@ -45,7 +45,7 @@
           <td width="25%">&nbsp;</td>
         </tr>
         <tr>
-          <td bgcolor="#00823B" style="font-family: Helvetica, Arial, sans-serif; margin: 0 0 30px 0;">
+          <td bgcolor="#28A197" style="font-family: Helvetica, Arial, sans-serif; margin: 0 0 30px 0;">
             <p style="font-size: 36px; font-weight: bold; text-align: center; color: #ffffff; line-height: 1.315789474; margin: 30px 0px 15px 0px;">
               <% if @registration.lower_tier? %>
                 <%= t(".section_1.reg_complete.lower") %>
@@ -169,13 +169,9 @@
               <%= t(".section_4.registered_on", date: @registration.metaData.date_registered) %>
             </p>
 
-            <p style="font-size: 19px; line-height: 1.315789474;margin: 0 0 30px 0;">
-              <%= t(".section_4.update_website_link_html", link: "#{Rails.configuration.wcrs_frontend_url}/users/sign_in") %>
-            </p>
-
             <ul>
               <li style="font-size: 16px; color: #6f777b; line-height: 1.125; margin: 0 0 15px 0;">
-                <%= t(".footer.item_1") %>
+                <%= t(".footer.item_1_html") %>
               </li>
               <li style="font-size: 16px; color: #6f777b; line-height: 1.125; margin: 0 0 30px 0;">
                 <%= t(".footer.item_2") %>

--- a/app/views/waste_carriers_engine/new_registration_mailer/registration_activated.txt.erb
+++ b/app/views/waste_carriers_engine/new_registration_mailer/registration_activated.txt.erb
@@ -43,8 +43,6 @@
 <%= t(".section_4.contact_number") %><%= @registration.phone_number %>
 <%= t(".section_4.registered_on", date: @registration.metaData.date_registered) %>
 
-<%= t(".section_4.update_website_link", link: "#{Rails.configuration.wcrs_frontend_url}/users/sign_in") %>
-
 ===================================================================================
 
 <%= t(".footer.item_1") %>

--- a/config/locales/mailers/new_registration_mailer.en.yml
+++ b/config/locales/mailers/new_registration_mailer.en.yml
@@ -43,7 +43,7 @@ en:
           paragraph_1: "If any of the details you've given us change, you must update them within 28 days."
           contact_number: "Telephone number: %{number}"
           registered_on: "Registered on: %{date}"
-          update_website_link_html: "You can <a href='%{link}'>sign in</a> here to view your certificate or make a change to your registration."
         footer:
-          item_1: "If you have enquiries please contact the Environment Agency helpline: 03708 506506"
+          item_1: "If you have enquiries please email nccc-carrierbroker@environment-agency.gov.uk or contact the Environment Agency helpline: 03708 506506"
+          item_1_html: "If you have enquiries please email <a href=\"mailto:nccc-carrierbroker@environment-agency.gov.uk\">nccc-carrierbroker@environment-agency.gov.uk</a> or contact the Environment Agency helpline: 03708 506506"
           item_2: "This is an automated email, please do not reply"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-911

Minor tweaks to the content of the 'registration completed' email to make it match the wireframe, including:

- changing the colour of the main banner
- removing the link to log in with a user account
- adding a contact email address