### PR TITLE
Update workflow on new registration

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
@@ -124,7 +124,13 @@ module WasteCarriersEngine
                       if: :check_your_tier_unknown?
 
           transitions from: :check_your_tier_form,
-                      to: :your_tier_form,
+                      to: :company_name_form,
+                      if: :check_your_tier_lower?,
+                      after: :set_tier_from_check_your_tier_form
+
+          transitions from: :check_your_tier_form,
+                      to: :cbd_type_form,
+                      if: :check_your_tier_upper?,
                       after: :set_tier_from_check_your_tier_form
 
           transitions from: :your_tier_form,
@@ -351,6 +357,10 @@ module WasteCarriersEngine
 
           # Smart answers
           transitions from: :company_name_form,
+                      to: :check_your_tier_form,
+                      if: :check_your_tier_lower?
+
+          transitions from: :company_name_form,
                       to: :your_tier_form,
                       if: :lower_tier?
 
@@ -400,6 +410,10 @@ module WasteCarriersEngine
 
           transitions from: :construction_demolition_form,
                       to: :service_provided_form
+
+          transitions from: :cbd_type_form,
+                      to: :check_your_tier_form,
+                      if: :check_your_tier_upper?
 
           transitions from: :cbd_type_form,
                       to: :your_tier_form
@@ -597,6 +611,14 @@ module WasteCarriersEngine
 
       def check_your_tier_unknown?
         temp_check_your_tier == "unknown"
+      end
+
+      def check_your_tier_lower?
+        temp_check_your_tier == "lower"
+      end
+
+      def check_your_tier_upper?
+        temp_check_your_tier == "upper"
       end
 
       def set_tier_from_check_your_tier_form

--- a/spec/models/waste_carriers_engine/new_registration_workflow/cbd_type_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/cbd_type_form_spec.rb
@@ -19,6 +19,12 @@ module WasteCarriersEngine
         end
 
         context "on back" do
+          context "when the answer to check your tier is upper" do
+            subject { build(:new_registration, workflow_state: "cbd_type_form", temp_check_your_tier: "upper") }
+
+            include_examples "has back transition", previous_state: "check_your_tier_form"
+          end
+
           include_examples "has back transition", previous_state: "your_tier_form"
         end
       end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/check_your_tier_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/check_your_tier_form_spec.rb
@@ -18,7 +18,7 @@ module WasteCarriersEngine
           context "when the check your tier answer is upper" do
             subject { build(:new_registration, workflow_state: "check_your_tier_form", temp_check_your_tier: "upper") }
 
-            include_examples "has next transition", next_state: "your_tier_form"
+            include_examples "has next transition", next_state: "cbd_type_form"
 
             it "updates the tier of the object to UPPER" do
               expect { subject.next }.to change { subject.tier }.to(WasteCarriersEngine::NewRegistration::UPPER_TIER)
@@ -28,7 +28,7 @@ module WasteCarriersEngine
           context "when the check your tier answer is lower" do
             subject { build(:new_registration, workflow_state: "check_your_tier_form", temp_check_your_tier: "lower") }
 
-            include_examples "has next transition", next_state: "your_tier_form"
+            include_examples "has next transition", next_state: "company_name_form"
 
             it "updates the tier of the object to LOWER" do
               expect { subject.next }.to change { subject.tier }.to(WasteCarriersEngine::NewRegistration::LOWER_TIER)

--- a/spec/models/waste_carriers_engine/new_registration_workflow/company_name_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/company_name_form_spec.rb
@@ -28,6 +28,12 @@ module WasteCarriersEngine
           context "when the registration is lower tier" do
             subject { build(:new_registration, :lower, workflow_state: "company_name_form") }
 
+            context "when the check your tier answer is lower" do
+              subject { build(:new_registration, :lower, workflow_state: "company_name_form", temp_check_your_tier: "lower") }
+
+              include_examples "has back transition", previous_state: "check_your_tier_form"
+            end
+
             include_examples "has back transition", previous_state: "your_tier_form"
           end
 


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-972

Make sure the user do not navigate through the `your_tier_form` state if they choose to be `upper` or `lower` tier from the `check_your_tier` page.