### PR TITLE
Fix style of registration activated email as per wireframe

### DIFF
--- a/app/services/waste_carriers_engine/registration_activation_service.rb
+++ b/app/services/waste_carriers_engine/registration_activation_service.rb
@@ -39,7 +39,6 @@ module WasteCarriersEngine
     end
 
     def send_confirmation_email
-      # TODO: Add email sent for lower tier
       NewRegistrationMailer.registration_activated(@registration).deliver_now
     rescue StandardError => e
       Airbrake.notify(e, registration_no: @registration.reg_identifier) if defined?(Airbrake)

--- a/app/views/waste_carriers_engine/new_registration_mailer/registration_activated.html.erb
+++ b/app/views/waste_carriers_engine/new_registration_mailer/registration_activated.html.erb
@@ -26,6 +26,7 @@
     </td>
   </tr>
 </table>
+
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF">
   <tr>
     <td width="100%">
@@ -54,11 +55,11 @@
               <% end %>
             </p>
 
-            <p style="font-size: 19px; text-align: center; color: #ffffff; line-height: 1.315789474; margin: 0;">
+            <p style="font-size: 19px; text-align: center; color: #ffffff; line-height: 1.315789474; margin: 30px 0px 0px 0px;">
               <%= t(".section_1.reg_complete_number") %>
             </p>
 
-            <p style="font-size: 36px; font-weight: bold; text-align: center; color: #ffffff; line-height: 1.315789474; margin: 15px 0px 30px 0px;">
+            <p style="font-size: 36px; font-weight: bold; text-align: center; color: #ffffff; line-height: 1.315789474; margin: 0px 0px 30px 0px;">
               <%= @registration.reg_identifier %>
             </p>
           </td>
@@ -105,8 +106,14 @@
                 <li style="font-size: 16px; line-height: 1.125; margin: 0 0 15px 0;">
                   <%= t(".section_3.upper.list_1.item_1") %>
                 </li>
-                <li style="font-size: 16px; line-height: 1.125; margin: 0 0 45px 0;">
+                <li style="font-size: 16px; line-height: 1.125; margin: 0 0 15px 0;">
                   <%= t(".section_3.upper.list_1.item_2") %>
+                </li>
+                <li style="font-size: 16px; line-height: 1.125; margin: 0 0 15px 0;">
+                  <%= t(".section_3.upper.list_1.item_3") %>
+                </li>
+                <li style="font-size: 16px; line-height: 1.125; margin: 0 0 45px 0;">
+                  <%= t(".section_3.upper.list_1.item_4") %>
                 </li>
               </ul>
 
@@ -165,7 +172,7 @@
               <%= t(".section_4.contact_number", number: @registration.phone_number) %>
             </p>
 
-            <p style="font-size: 19px; line-height: 1.315789474;margin: 0 0 15px 0;">
+            <p style="font-size: 19px; line-height: 1.315789474;margin: 15px 0 15px 0;">
               <%= t(".section_4.registered_on", date: @registration.metaData.date_registered.to_formatted_s(:day_month_year)) %>
             </p>
 

--- a/app/views/waste_carriers_engine/new_registration_mailer/registration_activated.txt.erb
+++ b/app/views/waste_carriers_engine/new_registration_mailer/registration_activated.txt.erb
@@ -19,6 +19,8 @@
 
 - <%= t(".section_3.upper.list_1.item_1") %>
 - <%= t(".section_3.upper.list_1.item_2") %>
+- <%= t(".section_3.upper.list_1.item_3") %>
+- <%= t(".section_3.upper.list_1.item_4") %>
 
 <%= t(".section_3.upper.paragraph_3") %>
 - <%= t(".section_3.upper.list_2.item_1") %>

--- a/config/locales/mailers/new_registration_mailer.en.yml
+++ b/config/locales/mailers/new_registration_mailer.en.yml
@@ -7,9 +7,9 @@ en:
           reg_complete:
             lower: "You are now registered as a lower tier waste carrier, broker and dealer"
             upper:
-              carrier_dealer: "You are now registered as an upper-tier waste carrier and dealer"
-              broker_dealer: "You are now registered as an upper-tier waste broker and dealer"
-              carrier_broker_dealer: "You are now registered as an upper-tier waste carrier, broker and dealer"
+              carrier_dealer: "You are now registered as an upper tier waste carrier and dealer"
+              broker_dealer: "You are now registered as an upper tier waste broker and dealer"
+              carrier_broker_dealer: "You are now registered as an upper tier waste carrier, broker and dealer"
           reg_complete_number: "Your registration number is"
         section_2:
           reg_certificate_info: "Your certificate is attached to this email, so we won't post a copy to you unless you contact us to request one."
@@ -22,19 +22,21 @@ en:
               item_2: "you don’t need to renew your registration (it just continues automatically)"
           upper:
             paragraph_1:
-              carrier_dealer: "Based on what you told us about your organisation and what it does, we have registered you as an upper-tier waste carrier and dealer."
-              broker_dealer: "Based on what you told us about your organisation and what it does, we have registered you as an upper-tier waste broker and dealer."
-              carrier_broker_dealer: "Based on what you told us about your organisation and what it does, we have registered you as an upper-tier waste carrier, broker and dealer."
+              carrier_dealer: "Based on what you told us about your organisation and what it does, we have registered you as an upper tier waste carrier and dealer."
+              broker_dealer: "Based on what you told us about your organisation and what it does, we have registered you as an upper tier waste broker and dealer."
+              carrier_broker_dealer: "Based on what you told us about your organisation and what it does, we have registered you as an upper tier waste carrier, broker and dealer."
             paragraph_2:
-              carrier_dealer: "Being an upper-tier waste carrier and dealer means that:"
-              broker_dealer: "Being an upper-tier waste broker and dealer means that:"
-              carrier_broker_dealer: "Being an upper-tier waste carrier, broker and dealer means that:"
+              carrier_dealer: "Being an upper tier waste carrier and dealer means that:"
+              broker_dealer: "Being an upper tier waste broker and dealer means that:"
+              carrier_broker_dealer: "Being an upper tier waste carrier, broker and dealer means that:"
             list_1:
-              item_1: "you need to renew your registration every 3 years (we’ll send you a reminder)"
+              item_1: "you need to renew your registration every 3 years"
               item_2: "you’ll need to pay a registration charge each time you renew"
+              item_3: "we will contact you on this email address when your registration is due to be renewed in 3 years' time"
+              item_4: "if we cannot reach you, you’ll have to pay more for a new registration"
             paragraph_3: "There are some simple rules you must follow:"
             list_2:
-              item_1: "if you give your waste to another person or business you must check they are properly authorised to accept it, e.g. as a permitted site or a registered waste carrier"
+              item_1: "if you give your waste to another person or business you must check they are properly authorised to accept it, for example as a permitted site or a registered waste carrier"
               item_2: "make sure the correct documentation is completed for each transfer of waste and that it correctly describes the waste"
               item_3: "make sure any waste is safely handled and stored"
               item_4: "minimise the environmental impact of waste by prioritising waste prevention, reuse, recycling and recovery over disposal"


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-839

Fix style of the email sent when a registration is active to match the wireframe.

<img width="354" alt="Screenshot 2020-04-14 at 12 52 28" src="https://user-images.githubusercontent.com/1385397/79222083-d5ef4c80-7e4e-11ea-9417-2a31a9f0b173.png">
<img width="379" alt="Screenshot 2020-04-14 at 12 52 33" src="https://user-images.githubusercontent.com/1385397/79222088-d7b91000-7e4e-11ea-9a89-a2ae23052d65.png">
