### PR TITLE
Add scopes to fetch active and expired registrations in grace window

### DIFF
--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -29,9 +29,7 @@ module WasteCarriersEngine
     scope :active, -> { where("metaData.status" => "ACTIVE") }
     scope :expired_at_end_of_today, -> { where(:expires_on.lte => Time.now.in_time_zone("London").end_of_day) }
     scope :upper_tier, -> { where(tier: UPPER_TIER) }
-
     scope :active_and_expired, -> { where("metaData.status" => { :$in => %w[ACTIVE EXPIRED] }) }
-    scope :in_grace_window, -> { where(:expires_on.lte => Time.now.in_time_zone("London").end_of_day - Rails.configuration.grace_window.days) }
 
     def self.in_grace_window
       date = Time.now.in_time_zone("London").beginning_of_day - Rails.configuration.grace_window.days

--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -30,6 +30,15 @@ module WasteCarriersEngine
     scope :expired_at_end_of_today, -> { where(:expires_on.lte => Time.now.in_time_zone("London").end_of_day) }
     scope :upper_tier, -> { where(tier: UPPER_TIER) }
 
+    scope :active_and_expired, -> { where("metaData.status" => { :$in => %w[ACTIVE EXPIRED] }) }
+    scope :in_grace_window, -> { where(:expires_on.lte => Time.now.in_time_zone("London").end_of_day - Rails.configuration.grace_window.days) }
+
+    def self.in_grace_window
+      date = Time.now.in_time_zone("London").beginning_of_day - Rails.configuration.grace_window.days
+
+      where(:expires_on.gte => date)
+    end
+
     alias pending_manual_conviction_check? conviction_check_required?
     alias pending_payment? unpaid_balance?
 


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-982

This adds relevant scopes to fetch registrations that are Active or Expired but still in the grace window.