### PR TITLE
Send email when new reg application is pending conviction check

### DIFF
--- a/app/mailers/waste_carriers_engine/new_registration_mailer.rb
+++ b/app/mailers/waste_carriers_engine/new_registration_mailer.rb
@@ -23,5 +23,16 @@ module WasteCarriersEngine
            from: from_email,
            subject: subject)
     end
+
+    def registration_pending_conviction_check(registration)
+      @registration = registration
+
+      subject = I18n.t(".waste_carriers_engine.new_registration_mailer.registration_pending_conviction_check.subject",
+                       reg_identifier: @registration.reg_identifier)
+
+      mail(to: @registration.contact_email,
+           from: from_email,
+           subject: subject)
+    end
   end
 end

--- a/app/services/waste_carriers_engine/registration_completion_service.rb
+++ b/app/services/waste_carriers_engine/registration_completion_service.rb
@@ -73,13 +73,14 @@ module WasteCarriersEngine
       transient_registration.delete
     end
 
+    # Note that we will only send emails here if the registration has pending convictions or pending payments.
+    # In the case when the registration can be completed, the registration activation email is sent from
+    # the RegistrationActivationService.
     def send_confirmation_email
       if registration.unpaid_balance?
         send_pending_payment_email
-        # TODO: Add email for pending convictions
-        # Note that we will only send emails here if the registration has pending convictions or pending payments.
-        # In the case when the registration can be completed, the registration activation email is sent from
-        # the RegistrationActivationService.
+      elsif registration.conviction_check_required?
+        send_pending_conviction_check_email
       end
     rescue StandardError => e
       Airbrake.notify(e, registration_no: registration.reg_identifier) if defined?(Airbrake)
@@ -87,6 +88,10 @@ module WasteCarriersEngine
 
     def send_pending_payment_email
       NewRegistrationMailer.registration_pending_payment(registration).deliver_now
+    end
+
+    def send_pending_conviction_check_email
+      NewRegistrationMailer.registration_pending_conviction_check(registration).deliver_now
     end
 
     def set_reg_identifier

--- a/app/views/waste_carriers_engine/new_registration_mailer/registration_pending_conviction_check.html.erb
+++ b/app/views/waste_carriers_engine/new_registration_mailer/registration_pending_conviction_check.html.erb
@@ -1,0 +1,87 @@
+<!doctype html>
+<!--[if lt IE 7]>  <html class="ie ie6 lte9 lte8 lte7"> <![endif]-->
+<!--[if IE 7]>     <html class="ie ie7 lte9 lte8 lte7"> <![endif]-->
+<!--[if IE 8]>     <html class="ie ie8 lte9 lte8"> <![endif]-->
+<!--[if IE 9]>     <html class="ie ie9 lte9"> <![endif]-->
+<!--[if gt IE 9]>  <html> <![endif]-->
+<!--[if !IE]><!-->
+<html>
+<!--<![endif]-->
+
+<head>
+  <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+  <meta content="utf-8" http-equiv="encoding">
+  <!-- Use title if it's in the page YAML frontmatter -->
+  <title>Waste Carriers Service</title>
+</head>
+
+<body style="font-family: Helvetica, Arial, sans-serif; font-size: 16px; margin: 0; color: #0b0c0c">
+  <table width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+      <td width="100%" height="53px" bgcolor="#0b0c0c">
+        <table width="580" cellpadding="0" cellspacing="0" border="0" align="center">
+          <tr>
+            <td width="100%" bgcolor="#0b0c0c" valign="middle">
+              <%= email_image_tag("govuk_logotype_email.png", { alt: 'GOV.UK', border: '0' }) %>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+  <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF">
+    <tr>
+      <td width="100%">
+        <table width="580" cellpadding="0" cellspacing="0" border="0" align="center">
+          <tr>
+            <td width="100%" class="header" style="padding-top: 10px;" colspan="2">
+              <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF">
+                <tr>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td width="75%" style="font-family: Helvetica, Arial, sans-serif;">
+              <p style="font-weight: 400; font-size: 16px; line-height: 1; margin: 10px 0 10px 0;">&nbsp;</p>
+            </td>
+            <td width="25%">&nbsp;</td>
+          </tr>
+          <tr>
+            <td bgcolor="#28a197" style="font-family: Helvetica, Arial, sans-serif; margin: 0 0 30px 0;">
+              <p style="font-size: 36px; font-weight: bold; text-align: center; color: #ffffff; line-height: 1.315789474; margin: 30px 0px 15px 0px;">
+                <%= t(".section_1.heading") %>
+              </p>
+
+              <p style="font-size: 19px; text-align: center; color: #ffffff; line-height: 1.315789474; margin: 0;">
+                <%= t(".section_1.paragraph_1") %>
+              </p>
+
+              <p style="font-size: 36px; font-weight: bold; text-align: center; color: #ffffff; line-height: 1.315789474; margin: 15px 0px 30px 0px;">
+                <%= @registration.reg_identifier %>
+              </p>
+            </td>
+            <td width="25%">&nbsp;</td>
+          </tr>
+          <tr>
+            <td width="75%" style="font-family: Helvetica, Arial, sans-serif;">
+              <%= t(".section_2.heading") %>
+
+              <ul>
+                <li><%= t(".section_2.list_item_1") %></li>
+                <li><%= t(".section_2.list_item_2") %></li>
+                <li><%= t(".section_2.list_item_3") %></li>
+              </ul>
+
+              <%= t(".section_3.paragraph_1") %>
+            </td>
+            <td width="25%">
+              &nbsp;
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/app/views/waste_carriers_engine/new_registration_mailer/registration_pending_conviction_check.html.erb
+++ b/app/views/waste_carriers_engine/new_registration_mailer/registration_pending_conviction_check.html.erb
@@ -48,12 +48,12 @@
             <td width="25%">&nbsp;</td>
           </tr>
           <tr>
-            <td bgcolor="#28a197" style="font-family: Helvetica, Arial, sans-serif; margin: 0 0 30px 0;">
+            <td bgcolor="#1d70b8" style="font-family: Helvetica, Arial, sans-serif; margin: 0 0 30px 0;">
               <p style="font-size: 36px; font-weight: bold; text-align: center; color: #ffffff; line-height: 1.315789474; margin: 30px 0px 15px 0px;">
                 <%= t(".section_1.heading") %>
               </p>
 
-              <p style="font-size: 19px; text-align: center; color: #ffffff; line-height: 1.315789474; margin: 0;">
+              <p style="font-size: 19px; text-align: center; color: #ffffff; line-height: 1.315789474; margin: 0px 30px 0px 30px;">
                 <%= t(".section_1.paragraph_1") %>
               </p>
 
@@ -65,15 +65,29 @@
           </tr>
           <tr>
             <td width="75%" style="font-family: Helvetica, Arial, sans-serif;">
-              <%= t(".section_2.heading") %>
+              <p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 15px 0;">
+                <%= t(".dear", name: "#{@registration.first_name} #{@registration.last_name}") %>
+              </p>
+
+              <p style="font-size: 24px; font-weight: bold; line-height: 1.315789474; margin: 0 0 15px 0;">
+                <%= t(".section_2.heading") %>
+              </p>
 
               <ul>
-                <li><%= t(".section_2.list_item_1") %></li>
-                <li><%= t(".section_2.list_item_2") %></li>
-                <li><%= t(".section_2.list_item_3") %></li>
+                <li style="font-size: 19px; line-height: 1.315789474; margin: 0 0 15px 0;">
+                  <%= t(".section_2.list_item_1") %>
+                </li>
+                <li style="font-size: 19px; line-height: 1.315789474; margin: 0 0 15px 0;">
+                  <%= t(".section_2.list_item_2" ) %>
+                </li>
+                <li style="font-size: 19px; line-height: 1.315789474; margin: 0 0 15px 0;">
+                  <%= t(".section_2.list_item_3_html") %>
+                </li>
               </ul>
 
-              <%= t(".section_3.paragraph_1") %>
+              <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 15px 0;">
+                <%= t(".section_3.paragraph_1") %>
+              </p>
             </td>
             <td width="25%">
               &nbsp;

--- a/app/views/waste_carriers_engine/new_registration_mailer/registration_pending_conviction_check.txt.erb
+++ b/app/views/waste_carriers_engine/new_registration_mailer/registration_pending_conviction_check.txt.erb
@@ -1,0 +1,13 @@
+<%= t(".dear", name: "#{@registration.first_name} #{@registration.last_name}") %>
+
+<%= t(".section_1.heading") %>
+
+<%= t(".section_1.paragraph_1") %> <%= @registration.reg_identifier %>
+
+<%= t(".section_2.heading") %>
+
+- <%= t(".section_2.list_item_1") %>
+- <%= t(".section_2.list_item_2") %>
+- <%= t(".section_2.list_item_3") %>
+
+<%= t(".section_3.paragraph_1") %>

--- a/config/locales/mailers/new_registration_mailer.en.yml
+++ b/config/locales/mailers/new_registration_mailer.en.yml
@@ -90,3 +90,17 @@ en:
           paragraph_5: "If any of your details change you must update your registration within 28 days."
           paragraph_6: "If you have enquiries please contact the Environment Agency helpline 03708 506506."
           paragraph_7: "This is an automated email, please do not reply."
+      registration_pending_conviction_check:
+        subject: "Application received for waste carrier registration %{reg_identifier}"
+        section_1:
+          heading: "Application received"
+          paragraph_1: "Please use this reference number if you contact us:"
+        dear: "Dear %{name}"
+        section_2:
+          heading: "We'll check your details and let you know whether your application has been successful."
+          list_item_1: "We aim to do this within 10 working days."
+          list_item_2: "You’re not legally entitled to operate as a waste carrier until we have received your payment and confirmed your registration."
+          list_item_3: "Contact the Environment Agency on nccc-carrierbroker@environment-agency.gov.uk or 03708 506506 if you have questions."
+          list_item_3_html: "Contact the Environment Agency on <a href=\"mailto:nccc-carrierbroker@environment-agency.gov.uk\">nccc-carrierbroker@environment-agency.gov.uk</a> or 03708 506506 if you have any questions."
+        section_3:
+          paragraph_1: This is an automated email, please do not reply.

--- a/spec/mailers/waste_carriers_engine/new_registration_mailer_spec.rb
+++ b/spec/mailers/waste_carriers_engine/new_registration_mailer_spec.rb
@@ -107,5 +107,31 @@ module WasteCarriersEngine
         expect(mail.body.encoded).to include(registration.reg_identifier)
       end
     end
+
+    describe "registration_pending_conviction_check" do
+      let(:registration) { create(:registration, :has_required_data, :expires_later) }
+      let(:mail) { NewRegistrationMailer.registration_pending_conviction_check(registration) }
+
+      it "uses the correct 'to' address" do
+        expect(mail.to).to eq([registration.contact_email])
+      end
+
+      it "uses the correct 'from' address" do
+        expect(mail.from).to eq(["test@example.com"])
+      end
+
+      it "uses the correct subject" do
+        subject = "Application received for waste carrier registration #{registration.reg_identifier}"
+        expect(mail.subject).to eq(subject)
+      end
+
+      it "includes the correct template in the body" do
+        expect(mail.body.encoded).to include("check your details")
+      end
+
+      it "includes the correct reg_identifier in the body" do
+        expect(mail.body.encoded).to include(registration.reg_identifier)
+      end
+    end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-842

If a new registration has been paid for but cannot be completed immediately because of convictions checks, we should still send the user a confirmation email to let them know the application was received.

This email is not sent if there is a pending payment at the end of the new registration journey. In that case we send the pending payment email only.

![image](https://user-images.githubusercontent.com/13369917/79564859-590adf80-80a7-11ea-8a95-d99e9bb2d9b8.png)