### PR TITLE
Fix SSCL email address

### DIFF
--- a/config/locales/forms/bank_transfer_forms/en.yml
+++ b/config/locales/forms/bank_transfer_forms/en.yml
@@ -27,7 +27,7 @@ en:
           heading: "Email us your registration number %{reg_identifier} to confirm you’ve paid"
         email_us:
           label: "Email us"
-          value: "ea_fsc_ar@sscl.gse.gov.uk"
+          value: "ea_fsc_ar@gov.sscl.com"
         payment_reference:
           label: "Payment reference"
         paragraph_1: "We’ll send you an email with these payment details and instructions."

--- a/config/locales/forms/copy_cards_bank_transfer_forms/en.yml
+++ b/config/locales/forms/copy_cards_bank_transfer_forms/en.yml
@@ -28,6 +28,6 @@ en:
           sub_heading: "Remind the customer to send us notification of the payment once the bank transfer has been arranged."
         email_us:
           label: "Email us"
-          value: "ea_fsc_ar@sscl.gse.gov.uk"
+          value: "ea_fsc_ar@gov.sscl.com"
         cards_info: "Cards will be sent out after the payment has cleared."
         next_button: "Complete order"

--- a/config/locales/forms/shared/bank_transfer_details.en.yml
+++ b/config/locales/forms/shared/bank_transfer_details.en.yml
@@ -24,6 +24,6 @@ en:
           heading: "Email us your registration number %{reg_identifier} to confirm you’ve paid"
           email_us:
             label: "Email us"
-            value: "ea_fsc_ar@sscl.gse.gov.uk"
+            value: "ea_fsc_ar@gov.sscl.com"
           payment_reference:
             label: "Payment reference"

--- a/config/locales/mailers/new_registration_mailer.en.yml
+++ b/config/locales/mailers/new_registration_mailer.en.yml
@@ -81,7 +81,7 @@ en:
         section_4:
           heading: "Email us your registration %{reg_identifier} to confirm you’ve paid"
           paragraph_1: "Email us at"
-          email_text: "ea_fsc_ar@sscl.gse.gov.uk"
+          email_text: "ea_fsc_ar@gov.sscl.com"
           email_subject: "Payment confirmation registration %{reg_identifier}"
           email_body: "Payment confirmation reference %{reg_identifier}%0D%0ADate paid:%0D%0AAmount:"
           paragraph_2: "Payment reference %{reg_identifier}"

--- a/config/locales/mailers/order_copy_cards_mailer.en.yml
+++ b/config/locales/mailers/order_copy_cards_mailer.en.yml
@@ -42,7 +42,7 @@ en:
           heading: "2. Then send us confirmation that you have paid"
           email_us:
             label: "Email us"
-            email: "ea_fsc_ar@sscl.gse.gov.uk"
+            email: "ea_fsc_ar@gov.sscl.com"
           fax:
             label: "Fax"
             value: "01733 464 892"

--- a/config/locales/mailers/renewal_mailer.en.yml
+++ b/config/locales/mailers/renewal_mailer.en.yml
@@ -113,7 +113,7 @@ en:
           send_confirmation_table:
             email:
               label: Email
-              value: ea_fsc_ar@sscl.gse.gov.uk
+              value: ea_fsc_ar@gov.sscl.com
             fax:
               label: Fax
               value: "01733 464892"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-994

The contact address for SSCL has to be updated to use a different domain.