### PR TITLE
Remove = in Travis rubocop command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,6 @@ before_script:
   - mongo waste-carriers-users-test --eval 'db.createUser({user:"mongoUser", pwd:"password1234", roles:["readWrite", "dbAdmin", "userAdmin"]})'
 
 script:
-  - bundle exec rubocop --format progress --format=json --out=rubocop-result.json
+  - bundle exec rubocop --format progress --format json --out rubocop-result.json
   - bundle exec rspec
   - sonar-scanner


### PR DESCRIPTION
We have been going through the repos updating our Travis config to use a rubocop command that has multiple formatters. As part of that work @irisfaraway pointed out that there is no need to have the = sign in the command. This is confirmed by the examples she found https://github.com/rubocop-hq/rubocop/blob/master/manual/formatters.md.

So the version we have been using in the other repos doesn't have the = sign and this change updates this project to match.