### PR TITLE
Factory-generated renewals always initialise with registration

### DIFF
--- a/spec/factories/renewing_registration.rb
+++ b/spec/factories/renewing_registration.rb
@@ -2,15 +2,15 @@
 
 FactoryBot.define do
   factory :renewing_registration, class: WasteCarriersEngine::RenewingRegistration do
+    # Create a new registration when initializing so we can copy its data
+    initialize_with { new(reg_identifier: create(:registration, :has_required_data, :expires_soon).reg_identifier) }
+
     trait :has_required_data do
       location { "england" }
       declared_convictions { "no" }
       temp_cards { 1 }
 
       has_postcode
-
-      # Create a new registration when initializing so we can copy its data
-      initialize_with { new(reg_identifier: create(:registration, :has_required_data, :expires_soon).reg_identifier) }
     end
 
     trait :has_addresses do


### PR DESCRIPTION
Without this, the renewal object cannot validate, which essentially means that we have to include the `:has_required_data` trait any time we want to create a renewal. This is a huge pain - it clutters up the specs and also makes it difficult to reuse some shared examples.

I plan to do an additional sweep of the specs once this is merged and remove no-longer-needed `:has_required_data` calls.