### PR TITLE
Use fixed final state workflow examples for renewals

### DIFF
--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/renewal_complete_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/renewal_complete_form_spec.rb
@@ -5,21 +5,9 @@ require "rails_helper"
 module WasteCarriersEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
-      context "when a RenewingRegistration's state is :renewal_complete_form" do
-        let(:transient_registration) do
-          create(:renewing_registration,
-                 :has_required_data,
-                 workflow_state: "renewal_complete_form")
-        end
-
-        it "does not respond to the 'back' event" do
-          expect(transient_registration).to_not allow_event :back
-        end
-
-        it "does not respond to the 'next' event" do
-          expect(transient_registration).to_not allow_event :next
-        end
-      end
+      it_behaves_like "a fixed final state",
+                      current_state: :renewal_complete_form,
+                      factory: :renewing_registration
     end
   end
 end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/renewal_received_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/renewal_received_form_spec.rb
@@ -5,21 +5,9 @@ require "rails_helper"
 module WasteCarriersEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
-      context "when a RenewingRegistration's state is :renewal_received_form" do
-        let(:transient_registration) do
-          create(:renewing_registration,
-                 :has_required_data,
-                 workflow_state: "renewal_received_form")
-        end
-
-        it "does not respond to the 'back' event" do
-          expect(transient_registration).to_not allow_event :back
-        end
-
-        it "does not respond to the 'next' event" do
-          expect(transient_registration).to_not allow_event :next
-        end
-      end
+      it_behaves_like "a fixed final state",
+                      current_state: :renewal_received_form,
+                      factory: :renewing_registration
     end
   end
 end


### PR DESCRIPTION
These shared examples can be used for the renewal complete and renewal received forms.