### PR TITLE
Use shared examples for renewal address workflow specs

### DIFF
--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/company_address_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/company_address_form_spec.rb
@@ -3,27 +3,10 @@
 require "rails_helper"
 
 module WasteCarriersEngine
-  RSpec.describe RenewingRegistration, type: :model do
-    describe "#workflow_state" do
-      context "when a RenewingRegistration's state is :company_address_form" do
-        let(:transient_registration) do
-          create(:renewing_registration,
-                 :has_required_data,
-                 workflow_state: "company_address_form")
-        end
-
-        it "changes to :company_postcode_form after the 'back' event" do
-          expect(transient_registration).to transition_from(:company_address_form).to(:company_postcode_form).on_event(:back)
-        end
-
-        it "changes to :main_people_form after the 'next' event" do
-          expect(transient_registration).to transition_from(:company_address_form).to(:main_people_form).on_event(:next)
-        end
-
-        it "changes to :company_address_manual_form after the 'skip_to_manual_address' event" do
-          expect(transient_registration).to transition_from(:company_address_form).to(:company_address_manual_form).on_event(:skip_to_manual_address)
-        end
-      end
-    end
+  RSpec.describe RenewingRegistration do
+    it_behaves_like "an address lookup transition",
+                    next_state_if_not_skipping_to_manual: :main_people_form,
+                    address_type: "company",
+                    factory: :renewing_registration
   end
 end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/company_address_manual_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/company_address_manual_form_spec.rb
@@ -3,35 +3,13 @@
 require "rails_helper"
 
 module WasteCarriersEngine
-  RSpec.describe RenewingRegistration, type: :model do
+  RSpec.describe RenewingRegistration do
     describe "#workflow_state" do
-      context "when a RenewingRegistration's state is :company_address_manual_form" do
-        let(:transient_registration) do
-          create(:renewing_registration,
-                 :has_required_data,
-                 workflow_state: "company_address_manual_form")
-        end
-
-        context "when the business is 'overseas'" do
-          before(:each) { transient_registration.location = "overseas" }
-
-          it "changes to :company_name_form after the 'back' event" do
-            expect(transient_registration).to transition_from(:company_address_manual_form).to(:company_name_form).on_event(:back)
-          end
-        end
-
-        context "when the business is not 'overseas'" do
-          before(:each) { transient_registration.location = "england" }
-
-          it "changes to :company_postcode_form after the 'back' event" do
-            expect(transient_registration).to transition_from(:company_address_manual_form).to(:company_postcode_form).on_event(:back)
-          end
-        end
-
-        it "changes to :main_people_form after the 'next' event" do
-          expect(transient_registration).to transition_from(:company_address_manual_form).to(:main_people_form).on_event(:next)
-        end
-      end
+      it_behaves_like "a manual address transition",
+                      previous_state_if_overseas: :company_name_form,
+                      next_state: :main_people_form,
+                      address_type: "company",
+                      factory: :renewing_registration
     end
   end
 end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/company_postcode_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/company_postcode_form_spec.rb
@@ -3,27 +3,12 @@
 require "rails_helper"
 
 module WasteCarriersEngine
-  RSpec.describe RenewingRegistration, type: :model do
+  RSpec.describe RenewingRegistration do
     describe "#workflow_state" do
-      context "when a RenewingRegistration's state is :company_postcode_form" do
-        let(:transient_registration) do
-          create(:renewing_registration,
-                 :has_required_data,
-                 workflow_state: "company_postcode_form")
-        end
-
-        it "changes to :company_name_form after the 'back' event" do
-          expect(transient_registration).to transition_from(:company_postcode_form).to(:company_name_form).on_event(:back)
-        end
-
-        it "changes to :company_address_form after the 'next' event" do
-          expect(transient_registration).to transition_from(:company_postcode_form).to(:company_address_form).on_event(:next)
-        end
-
-        it "changes to :company_address_manual_form after the 'skip_to_manual_address' event" do
-          expect(transient_registration).to transition_from(:company_postcode_form).to(:company_address_manual_form).on_event(:skip_to_manual_address)
-        end
-      end
+      it_behaves_like "a postcode transition",
+                      previous_state: :company_name_form,
+                      address_type: "company",
+                      factory: :renewing_registration
     end
   end
 end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/contact_address_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/contact_address_form_spec.rb
@@ -3,27 +3,10 @@
 require "rails_helper"
 
 module WasteCarriersEngine
-  RSpec.describe RenewingRegistration, type: :model do
-    describe "#workflow_state" do
-      context "when a RenewingRegistration's state is :contact_address_form" do
-        let(:transient_registration) do
-          create(:renewing_registration,
-                 :has_required_data,
-                 workflow_state: "contact_address_form")
-        end
-
-        it "changes to :contact_postcode_form after the 'back' event" do
-          expect(transient_registration).to transition_from(:contact_address_form).to(:contact_postcode_form).on_event(:back)
-        end
-
-        it "changes to :check_your_answers_form after the 'next' event" do
-          expect(transient_registration).to transition_from(:contact_address_form).to(:check_your_answers_form).on_event(:next)
-        end
-
-        it "changes to :contact_address_manual_form after the 'skip_to_manual_address' event" do
-          expect(transient_registration).to transition_from(:contact_address_form).to(:contact_address_manual_form).on_event(:skip_to_manual_address)
-        end
-      end
-    end
+  RSpec.describe RenewingRegistration do
+    it_behaves_like "an address lookup transition",
+                    next_state_if_not_skipping_to_manual: :check_your_answers_form,
+                    address_type: "contact",
+                    factory: :renewing_registration
   end
 end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/contact_address_manual_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/contact_address_manual_form_spec.rb
@@ -3,35 +3,13 @@
 require "rails_helper"
 
 module WasteCarriersEngine
-  RSpec.describe RenewingRegistration, type: :model do
+  RSpec.describe RenewingRegistration do
     describe "#workflow_state" do
-      context "when a RenewingRegistration's state is :contact_address_manual_form" do
-        let(:transient_registration) do
-          create(:renewing_registration,
-                 :has_required_data,
-                 workflow_state: "contact_address_manual_form")
-        end
-
-        context "when the business is 'overseas'" do
-          before(:each) { transient_registration.location = "overseas" }
-
-          it "changes to :contact_name_form after the 'back' event" do
-            expect(transient_registration).to transition_from(:contact_address_manual_form).to(:contact_email_form).on_event(:back)
-          end
-        end
-
-        # context "when the business is not 'overseas'" do
-        #   before(:each) { transient_registration.location = "england" }
-        #
-        #   it "changes to :contact_postcode_form after the 'back' event" do
-        #     expect(transient_registration).to transition_from(:contact_address_manual_form).to(:contact_postcode_form).on_event(:back)
-        #   end
-        # end
-
-        it "changes to :main_people_form after the 'next' event" do
-          expect(transient_registration).to transition_from(:contact_address_manual_form).to(:check_your_answers_form).on_event(:next)
-        end
-      end
+      it_behaves_like "a manual address transition",
+                      previous_state_if_overseas: :contact_email_form,
+                      next_state: :check_your_answers_form,
+                      address_type: "contact",
+                      factory: :renewing_registration
     end
   end
 end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/contact_postcode_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/contact_postcode_form_spec.rb
@@ -3,27 +3,12 @@
 require "rails_helper"
 
 module WasteCarriersEngine
-  RSpec.describe RenewingRegistration, type: :model do
+  RSpec.describe RenewingRegistration do
     describe "#workflow_state" do
-      context "when a RenewingRegistration's state is :contact_postcode_form" do
-        let(:transient_registration) do
-          create(:renewing_registration,
-                 :has_required_data,
-                 workflow_state: "contact_postcode_form")
-        end
-
-        it "changes to :contact_email_form after the 'back' event" do
-          expect(transient_registration).to transition_from(:contact_postcode_form).to(:contact_email_form).on_event(:back)
-        end
-
-        it "changes to :contact_address_form after the 'next' event" do
-          expect(transient_registration).to transition_from(:contact_postcode_form).to(:contact_address_form).on_event(:next)
-        end
-
-        it "changes to :contact_address_manual_form after the 'skip_to_manual_address' event" do
-          expect(transient_registration).to transition_from(:contact_postcode_form).to(:contact_address_manual_form).on_event(:skip_to_manual_address)
-        end
-      end
+      it_behaves_like "a postcode transition",
+                      previous_state: :contact_email_form,
+                      address_type: "contact",
+                      factory: :renewing_registration
     end
   end
 end


### PR DESCRIPTION
This PR replaces our individual specs for testing the renewal address workflows with the shared examples we use elsewhere.