### PR TITLE
Merge repeating request specs

### DIFF
--- a/spec/requests/waste_carriers_engine/bank_transfer_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/bank_transfer_forms_spec.rb
@@ -48,14 +48,12 @@ module WasteCarriersEngine
               transient_registration.finance_details.orders.first.world_pay_status = "CANCELLED"
             end
 
-            it "replaces the old order" do
-              get new_bank_transfer_form_path(transient_registration.token)
-              expect(transient_registration.reload.finance_details.orders.first.world_pay_status).to eq(nil)
-            end
-
-            it "does not increase the order count" do
+            it "replaces the old order and does not increase the order count" do
               old_order_count = transient_registration.finance_details.orders.count
+
               get new_bank_transfer_form_path(transient_registration.token)
+
+              expect(transient_registration.reload.finance_details.orders.first.world_pay_status).to eq(nil)
               expect(transient_registration.reload.finance_details.orders.count).to eq(old_order_count)
             end
           end
@@ -121,13 +119,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the payment_summary form" do
               get back_bank_transfer_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the payment_summary form" do
-              get back_bank_transfer_forms_path(transient_registration.token)
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_payment_summary_form_path(transient_registration.token))
             end
           end
@@ -143,13 +138,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_bank_transfer_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_bank_transfer_forms_path(transient_registration.token)
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration.token))
             end
           end

--- a/spec/requests/waste_carriers_engine/business_type_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/business_type_forms_spec.rb
@@ -41,15 +41,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the location form" do
               get back_business_type_forms_path(transient_registration.token)
 
               expect(response).to have_http_status(302)
-            end
-
-            it "redirects to the location form" do
-              get back_business_type_forms_path(transient_registration.token)
-
               expect(response).to redirect_to(new_location_form_path(transient_registration.token))
             end
           end
@@ -64,13 +59,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_business_type_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_business_type_forms_path(transient_registration.token)
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_location_form_path(transient_registration.token))
             end
           end

--- a/spec/requests/waste_carriers_engine/cannot_renew_company_no_change_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/cannot_renew_company_no_change_forms_spec.rb
@@ -22,13 +22,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the registration_number form" do
               get back_cannot_renew_company_no_change_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the registration_number form" do
-              get back_cannot_renew_company_no_change_forms_path(transient_registration.token)
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_registration_number_form_path(transient_registration.token))
             end
           end
@@ -43,13 +40,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_cannot_renew_company_no_change_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_cannot_renew_company_no_change_forms_path(transient_registration.token)
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration.token))
             end
           end

--- a/spec/requests/waste_carriers_engine/cannot_renew_lower_tier_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/cannot_renew_lower_tier_forms_spec.rb
@@ -22,16 +22,13 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
-              get back_cannot_renew_lower_tier_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
-
             context "when the tier change is due to the business type" do
               before(:each) { transient_registration.update_attributes(business_type: "charity") }
 
-              it "redirects to the business_type form" do
+              it "returns a 302 response and redirects to the business_type form" do
                 get back_cannot_renew_lower_tier_forms_path(transient_registration.token)
+
+                expect(response).to have_http_status(302)
                 expect(response).to redirect_to(new_business_type_form_path(transient_registration.token))
               end
             end
@@ -43,8 +40,10 @@ module WasteCarriersEngine
                                                          only_amf: "yes")
               end
 
-              it "redirects to the waste_types form" do
+              it "returns a 302 response and redirects to the waste_types form" do
                 get back_cannot_renew_lower_tier_forms_path(transient_registration.token)
+
+                expect(response).to have_http_status(302)
                 expect(response).to redirect_to(new_waste_types_form_path(transient_registration.token))
               end
             end
@@ -55,8 +54,10 @@ module WasteCarriersEngine
                                                          construction_waste: "no")
               end
 
-              it "redirects to the construction_demolition form" do
+              it "returns a 302 response and redirects to the construction_demolition form" do
                 get back_cannot_renew_lower_tier_forms_path(transient_registration.token)
+
+                expect(response).to have_http_status(302)
                 expect(response).to redirect_to(new_construction_demolition_form_path(transient_registration.token))
               end
             end
@@ -72,13 +73,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_cannot_renew_lower_tier_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_cannot_renew_lower_tier_forms_path(transient_registration.token)
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration.token))
             end
           end

--- a/spec/requests/waste_carriers_engine/cannot_renew_type_change_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/cannot_renew_type_change_forms_spec.rb
@@ -22,13 +22,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the business_type form" do
               get back_cannot_renew_type_change_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the business_type form" do
-              get back_cannot_renew_type_change_forms_path(transient_registration.token)
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_business_type_form_path(transient_registration.token))
             end
           end
@@ -43,13 +40,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_cannot_renew_type_change_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_cannot_renew_type_change_forms_path(transient_registration.token)
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration.token))
             end
           end

--- a/spec/requests/waste_carriers_engine/cards_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/cards_forms_spec.rb
@@ -41,13 +41,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the declaration form" do
               get back_cards_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the declaration form" do
-              get back_cards_forms_path(transient_registration.token)
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_declaration_form_path(transient_registration.token))
             end
           end
@@ -62,13 +59,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_cards_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_cards_forms_path(transient_registration.token)
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration.token))
             end
           end

--- a/spec/requests/waste_carriers_engine/cbd_type_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/cbd_type_forms_spec.rb
@@ -41,16 +41,13 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
-              get back_cbd_type_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
-
             context "when the business doesn't carry waste for other businesses or households" do
               before(:each) { transient_registration.update_attributes(other_businesses: "no") }
 
-              it "redirects to the construction_demolition form" do
+              it "returns a 302 response and redirects to the construction_demolition form" do
                 get back_cbd_type_forms_path(transient_registration.token)
+
+                expect(response).to have_http_status(302)
                 expect(response).to redirect_to(new_construction_demolition_form_path(transient_registration.token))
               end
             end
@@ -61,8 +58,10 @@ module WasteCarriersEngine
                                                          is_main_service: "yes")
               end
 
-              it "redirects to the waste_types form" do
+              it "returns a 302 response and redirects to the waste_types form" do
                 get back_cbd_type_forms_path(transient_registration.token)
+
+                expect(response).to have_http_status(302)
                 expect(response).to redirect_to(new_waste_types_form_path(transient_registration.token))
               end
             end
@@ -90,13 +89,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_cbd_type_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_cbd_type_forms_path(transient_registration.token)
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration.token))
             end
           end

--- a/spec/requests/waste_carriers_engine/check_your_answers_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/check_your_answers_forms_spec.rb
@@ -28,13 +28,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the contact_address form" do
               get back_check_your_answers_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the contact_address form" do
-              get back_check_your_answers_forms_path(transient_registration.token)
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_contact_address_form_path(transient_registration.token))
             end
           end
@@ -48,14 +45,11 @@ module WasteCarriersEngine
                    workflow_state: "renewal_start_form")
           end
 
-          context "when the back action is triggered" do
+          context "when the back action is triggered and redirects to the correct form for the state" do
             it "returns a 302 response" do
               get back_check_your_answers_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_check_your_answers_forms_path(transient_registration.token)
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration.token))
             end
           end

--- a/spec/requests/waste_carriers_engine/check_your_tier_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/check_your_tier_forms_spec.rb
@@ -56,15 +56,10 @@ module WasteCarriersEngine
         end
 
         context "when the back action is triggered" do
-          it "returns a 302 response" do
+          it "returns a 302 response and redirects to the business_type form" do
             get back_check_your_tier_forms_path(transient_registration.token)
 
             expect(response).to have_http_status(302)
-          end
-
-          it "redirects to the business_type form" do
-            get back_check_your_tier_forms_path(transient_registration.token)
-
             expect(response).to redirect_to(new_business_type_form_path(transient_registration.token))
           end
         end

--- a/spec/requests/waste_carriers_engine/company_address_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/company_address_forms_spec.rb
@@ -36,18 +36,11 @@ module WasteCarriersEngine
               }
             end
 
-            it "updates the transient registration" do
+            it "updates the transient registration, returns a 302 response and redirects to the main_people form" do
               post company_address_forms_path(transient_registration.token), company_address_form: valid_params
+
               expect(transient_registration.reload.company_address.uprn.to_s).to eq("340116")
-            end
-
-            it "returns a 302 response" do
-              post company_address_forms_path(transient_registration.token), company_address_form: valid_params
               expect(response).to have_http_status(302)
-            end
-
-            it "redirects to the main_people form" do
-              post company_address_forms_path(transient_registration.token), company_address_form: valid_params
               expect(response).to redirect_to(new_main_people_form_path(transient_registration[:token]))
             end
 
@@ -60,19 +53,12 @@ module WasteCarriersEngine
                        workflow_state: "company_address_form")
               end
 
-              it "should have have the same number of addresses before and after submitting" do
+              it "updates the old contact address and does not change the number of addresses" do
                 number_of_addresses = transient_registration.addresses.count
 
                 post company_address_forms_path(transient_registration.token), company_address_form: valid_params
 
                 expect(transient_registration.reload.addresses.count).to eq(number_of_addresses)
-              end
-
-              it "updates the old contact address" do
-                transient_registration.company_address.update_attributes(uprn: "123456")
-
-                post company_address_forms_path(transient_registration.token), company_address_form: valid_params
-
                 expect(transient_registration.reload.company_address.uprn).to eq(340_116)
               end
             end
@@ -101,18 +87,11 @@ module WasteCarriersEngine
             }
           end
 
-          it "does not update the transient registration" do
+          it "does not update the transient registration, returns a 302 response and redirects to the correct form for the state" do
             post company_address_forms_path(transient_registration.token), company_address_form: valid_params
+
             expect(transient_registration.reload.addresses.count).to eq(0)
-          end
-
-          it "returns a 302 response" do
-            post company_address_forms_path(transient_registration.token), company_address_form: valid_params
             expect(response).to have_http_status(302)
-          end
-
-          it "redirects to the correct form for the state" do
-            post company_address_forms_path(transient_registration.token), company_address_form: valid_params
             expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
           end
         end
@@ -136,13 +115,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the company_postcode form" do
               get back_company_address_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the company_postcode form" do
-              get back_company_address_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_company_postcode_form_path(transient_registration[:token]))
             end
           end
@@ -158,13 +134,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_company_address_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_company_address_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
             end
           end
@@ -189,13 +162,10 @@ module WasteCarriersEngine
           end
 
           context "when the skip_to_manual_address action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the company_address_manual form" do
               get skip_to_manual_address_company_address_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the company_address_manual form" do
-              get skip_to_manual_address_company_address_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_company_address_manual_form_path(transient_registration[:token]))
             end
           end
@@ -211,13 +181,10 @@ module WasteCarriersEngine
           end
 
           context "when the skip_to_manual_address action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get skip_to_manual_address_company_address_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get skip_to_manual_address_company_address_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
             end
           end

--- a/spec/requests/waste_carriers_engine/company_address_manual_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/company_address_manual_forms_spec.rb
@@ -32,19 +32,12 @@ module WasteCarriersEngine
               }
             end
 
-            it "updates the transient registration" do
+            it "updates the transient registration, returns a 302 response and redirects to the main_people form" do
               post company_address_manual_forms_path(transient_registration.token), company_address_manual_form: valid_params
+
               expect(transient_registration.reload.registered_address.house_number).to eq("42")
-            end
-
-            it "returns a 302 response" do
-              post company_address_manual_forms_path(transient_registration.token), company_address_manual_form: valid_params
               expect(response).to have_http_status(302)
-            end
-
-            it "redirects to the main_people form" do
-              post company_address_manual_forms_path(transient_registration.token), company_address_manual_form: valid_params
-              expect(response).to redirect_to(new_main_people_form_path(transient_registration.token))
+              expect(response).to redirect_to(new_main_people_form_path(transient_registration[:token]))
             end
 
             context "when the transient registration already has addresses" do
@@ -56,27 +49,17 @@ module WasteCarriersEngine
                        workflow_state: "company_address_manual_form")
               end
 
-              it "should have have the same number of addresses before and after submitting" do
-                number_of_addresses = transient_registration.addresses.count
-                post company_address_manual_forms_path(transient_registration.token), company_address_manual_form: valid_params
-                expect(transient_registration.reload.addresses.count).to eq(number_of_addresses)
-              end
-
-              it "removes the old registered address" do
+              it "removes the old registered address, adds the new registered address, does not modify the existing contact address, and does not change the total number of addresses" do
                 old_registered_address = transient_registration.registered_address
-                post company_address_manual_forms_path(transient_registration.token), company_address_manual_form: valid_params
-                expect(transient_registration.reload.registered_address).to_not eq(old_registered_address)
-              end
-
-              it "adds the new registered address" do
-                post company_address_manual_forms_path(transient_registration.token), company_address_manual_form: valid_params
-                expect(transient_registration.reload.registered_address.address_line_1).to eq("Foo Terrace")
-              end
-
-              it "does not modify the existing contact address" do
                 old_contact_address = transient_registration.contact_address
+                number_of_addresses = transient_registration.addresses.count
+
                 post company_address_manual_forms_path(transient_registration.token), company_address_manual_form: valid_params
+
+                expect(transient_registration.reload.registered_address).to_not eq(old_registered_address)
+                expect(transient_registration.reload.registered_address.address_line_1).to eq("Foo Terrace")
                 expect(transient_registration.reload.contact_address).to eq(old_contact_address)
+                expect(transient_registration.reload.addresses.count).to eq(number_of_addresses)
               end
             end
           end
@@ -100,18 +83,11 @@ module WasteCarriersEngine
             }
           end
 
-          it "does not update the transient registration" do
+          it "does not update the transient registration, returns a 302 response and redirects to the correct form for the state" do
             post company_address_forms_path(transient_registration.token), company_address_form: valid_params
+
             expect(transient_registration.reload.addresses.count).to eq(0)
-          end
-
-          it "returns a 302 response" do
-            post company_address_manual_forms_path(transient_registration.token), company_address_manual_form: valid_params
             expect(response).to have_http_status(302)
-          end
-
-          it "redirects to the correct form for the state" do
-            post company_address_manual_forms_path(transient_registration.token), company_address_manual_form: valid_params
             expect(response).to redirect_to(new_renewal_start_form_path(transient_registration.token))
           end
         end
@@ -134,16 +110,13 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
-              get back_company_address_manual_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
-
             context "when the location is 'overseas'" do
               before(:each) { transient_registration.update_attributes(location: "overseas") }
 
-              it "redirects to the company_name form" do
+              it "returns a 302 response and redirects to the company_name form" do
                 get back_company_address_manual_forms_path(transient_registration.token)
+
+                expect(response).to have_http_status(302)
                 expect(response).to redirect_to(new_company_name_form_path(transient_registration.token))
               end
             end
@@ -151,8 +124,10 @@ module WasteCarriersEngine
             context "when the location is not 'overseas'" do
               before(:each) { transient_registration.update_attributes(location: "england") }
 
-              it "redirects to the company_postcode form" do
+              it "returns a 302 response and redirects to the company_postcode form" do
                 get back_company_address_manual_forms_path(transient_registration.token)
+
+                expect(response).to have_http_status(302)
                 expect(response).to redirect_to(new_company_postcode_form_path(transient_registration.token))
               end
             end
@@ -168,13 +143,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_company_address_manual_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_company_address_manual_forms_path(transient_registration.token)
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration.token))
             end
           end

--- a/spec/requests/waste_carriers_engine/company_name_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/company_name_forms_spec.rb
@@ -41,16 +41,13 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
-              get back_company_name_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
-
             context "when the business type is localAuthority" do
               before(:each) { transient_registration.update_attributes(business_type: "localAuthority") }
 
-              it "redirects to the renewal_information form" do
+              it "returns a 302 response and redirects to the renewal_information form" do
                 get back_company_name_forms_path(transient_registration[:token])
+
+                expect(response).to have_http_status(302)
                 expect(response).to redirect_to(new_renewal_information_form_path(transient_registration[:token]))
               end
             end
@@ -58,8 +55,10 @@ module WasteCarriersEngine
             context "when the business type is limitedCompany" do
               before(:each) { transient_registration.update_attributes(business_type: "limitedCompany") }
 
-              it "redirects to the registration_number form" do
+              it "returns a 302 response and redirects to the registration_number form" do
                 get back_company_name_forms_path(transient_registration[:token])
+
+                expect(response).to have_http_status(302)
                 expect(response).to redirect_to(new_registration_number_form_path(transient_registration[:token]))
               end
             end
@@ -67,8 +66,10 @@ module WasteCarriersEngine
             context "when the business type is limitedLiabilityPartnership" do
               before(:each) { transient_registration.update_attributes(business_type: "limitedLiabilityPartnership") }
 
-              it "redirects to the registration_number form" do
+              it "returns a 302 response and redirects to the registration_number form" do
                 get back_company_name_forms_path(transient_registration[:token])
+
+                expect(response).to have_http_status(302)
                 expect(response).to redirect_to(new_registration_number_form_path(transient_registration[:token]))
               end
             end
@@ -76,8 +77,10 @@ module WasteCarriersEngine
             context "when the location is overseas" do
               before(:each) { transient_registration.update_attributes(location: "overseas") }
 
-              it "redirects to the renewal_information form" do
+              it "returns a 302 response and redirects to the renewal_information form" do
                 get back_company_name_forms_path(transient_registration[:token])
+
+                expect(response).to have_http_status(302)
                 expect(response).to redirect_to(new_renewal_information_form_path(transient_registration[:token]))
               end
             end
@@ -85,8 +88,10 @@ module WasteCarriersEngine
             context "when the business type is partnership" do
               before(:each) { transient_registration.update_attributes(business_type: "partnership") }
 
-              it "redirects to the renewal_information form" do
+              it "returns a 302 response and redirects to the renewal_information form" do
                 get back_company_name_forms_path(transient_registration[:token])
+
+                expect(response).to have_http_status(302)
                 expect(response).to redirect_to(new_renewal_information_form_path(transient_registration[:token]))
               end
             end
@@ -94,8 +99,10 @@ module WasteCarriersEngine
             context "when the business type is soleTrader" do
               before(:each) { transient_registration.update_attributes(business_type: "soleTrader") }
 
-              it "redirects to the renewal_information form" do
+              it "returns a 302 response and redirects to the renewal_information form" do
                 get back_company_name_forms_path(transient_registration[:token])
+
+                expect(response).to have_http_status(302)
                 expect(response).to redirect_to(new_renewal_information_form_path(transient_registration[:token]))
               end
             end
@@ -111,13 +118,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_company_name_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_company_name_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
             end
           end

--- a/spec/requests/waste_carriers_engine/company_postcode_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/company_postcode_forms_spec.rb
@@ -34,18 +34,11 @@ module WasteCarriersEngine
               allow_any_instance_of(AddressFinderService).to receive(:search_by_postcode).and_return(example_json)
             end
 
-            it "returns a 302 response" do
+            it "updates the transient registration, returns a 302 response and redirects to the company_address form" do
               post company_postcode_forms_path(transient_registration.token), company_postcode_form: valid_params
-              expect(response).to have_http_status(302)
-            end
 
-            it "updates the transient registration" do
-              post company_postcode_forms_path(transient_registration.token), company_postcode_form: valid_params
               expect(transient_registration.reload[:temp_company_postcode]).to eq(valid_params[:temp_company_postcode])
-            end
-
-            it "redirects to the company_address form" do
-              post company_postcode_forms_path(transient_registration.token), company_postcode_form: valid_params
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_company_address_form_path(transient_registration[:token]))
             end
 
@@ -77,18 +70,11 @@ module WasteCarriersEngine
             }
           end
 
-          it "returns a 302 response" do
+          it "does not update the transient registration, returns a 302 response and redirects to the correct form for the state" do
             post company_postcode_forms_path(transient_registration.token), company_postcode_form: valid_params
-            expect(response).to have_http_status(302)
-          end
 
-          it "does not update the transient registration" do
-            post company_postcode_forms_path(transient_registration.token), company_postcode_form: valid_params
             expect(transient_registration.reload[:temp_company_postcode]).to_not eq(valid_params[:temp_company_postcode])
-          end
-
-          it "redirects to the correct form for the state" do
-            post company_postcode_forms_path(transient_registration.token), company_postcode_form: valid_params
+            expect(response).to have_http_status(302)
             expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
           end
         end
@@ -111,13 +97,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the company_name form" do
               get back_company_postcode_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the company_name form" do
-              get back_company_postcode_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_company_name_form_path(transient_registration[:token]))
             end
           end
@@ -132,13 +115,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_company_postcode_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_company_postcode_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
             end
           end
@@ -163,13 +143,10 @@ module WasteCarriersEngine
           end
 
           context "when the skip_to_manual_address action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the company_address_manual form" do
               get skip_to_manual_address_company_postcode_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the company_address_manual form" do
-              get skip_to_manual_address_company_postcode_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_company_address_manual_form_path(transient_registration[:token]))
             end
           end
@@ -185,13 +162,10 @@ module WasteCarriersEngine
           end
 
           context "when the skip_to_manual_address action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get skip_to_manual_address_company_postcode_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get skip_to_manual_address_company_postcode_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
             end
           end

--- a/spec/requests/waste_carriers_engine/construction_demolition_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/construction_demolition_forms_spec.rb
@@ -41,16 +41,13 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
-              get back_construction_demolition_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
-
             context "when the business does not carry waste for other businesses or households" do
               before(:each) { transient_registration.update_attributes(other_businesses: "no") }
 
-              it "redirects to the other_businesses form" do
+              it "returns a 302 response and redirects to the other_businesses form" do
                 get back_construction_demolition_forms_path(transient_registration.token)
+
+                expect(response).to have_http_status(302)
                 expect(response).to redirect_to(new_other_businesses_form_path(transient_registration.token))
               end
             end
@@ -58,8 +55,10 @@ module WasteCarriersEngine
             context "when the business does carry waste for other businesses or households" do
               before(:each) { transient_registration.update_attributes(other_businesses: "yes") }
 
-              it "redirects to the service_provided form" do
+              it "returns a 302 response and redirects to the service_provided form" do
                 get back_construction_demolition_forms_path(transient_registration.token)
+
+                expect(response).to have_http_status(302)
                 expect(response).to redirect_to(new_service_provided_form_path(transient_registration.token))
               end
             end
@@ -75,13 +74,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_construction_demolition_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_construction_demolition_forms_path(transient_registration.token)
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration.token))
             end
           end

--- a/spec/requests/waste_carriers_engine/contact_address_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/contact_address_forms_spec.rb
@@ -37,19 +37,11 @@ module WasteCarriersEngine
               }
             end
 
-            it "updates the transient registration" do
+            it "updates the transient registration, returns a 302 response and redirects to the check_your_answers form" do
               post contact_address_forms_path(transient_registration.token), contact_address_form: valid_params
 
               expect(transient_registration.reload.contact_address.uprn.to_s).to eq("340116")
-            end
-
-            it "returns a 302 response" do
-              post contact_address_forms_path(transient_registration.token), contact_address_form: valid_params
               expect(response).to have_http_status(302)
-            end
-
-            it "redirects to the check_your_answers form" do
-              post contact_address_forms_path(transient_registration.token), contact_address_form: valid_params
               expect(response).to redirect_to(new_check_your_answers_form_path(transient_registration[:token]))
             end
 
@@ -62,18 +54,14 @@ module WasteCarriersEngine
                        workflow_state: "contact_address_form")
               end
 
-              it "should have have the same number of addresses before and after submitting" do
-                number_of_addresses = transient_registration.addresses.count
-                post contact_address_forms_path(transient_registration.token), contact_address_form: valid_params
-                expect(transient_registration.reload.addresses.count).to eq(number_of_addresses)
-              end
-
-              it "updates the old contact address" do
+              it "updates the contact address and does not modify the number of addresses" do
                 transient_registration.contact_address.update_attributes(uprn: "123456")
+                number_of_addresses = transient_registration.addresses.count
 
                 post contact_address_forms_path(transient_registration.token), contact_address_form: valid_params
 
                 expect(transient_registration.reload.contact_address.uprn).to eq(340_116)
+                expect(transient_registration.reload.addresses.count).to eq(number_of_addresses)
               end
             end
           end
@@ -88,18 +76,11 @@ module WasteCarriersEngine
                    workflow_state: "renewal_start_form")
           end
 
-          it "does not update the transient registration" do
+          it "does not update the transient registration, returns a 302 response and redirects to the correct form for the state" do
             post contact_address_forms_path(transient_registration.token)
+
             expect(transient_registration.reload.addresses.count).to eq(0)
-          end
-
-          it "returns a 302 response" do
-            post contact_address_forms_path(transient_registration.token)
             expect(response).to have_http_status(302)
-          end
-
-          it "redirects to the correct form for the state" do
-            post contact_address_forms_path(transient_registration.token)
             expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
           end
         end
@@ -123,13 +104,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the contact_postcode form" do
               get back_contact_address_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the contact_postcode form" do
-              get back_contact_address_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_contact_postcode_form_path(transient_registration[:token]))
             end
           end
@@ -145,13 +123,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_contact_address_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_contact_address_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
             end
           end
@@ -176,13 +151,10 @@ module WasteCarriersEngine
           end
 
           context "when the skip_to_manual_address action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the contact_address_manual form" do
               get skip_to_manual_address_contact_address_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the contact_address_manual form" do
-              get skip_to_manual_address_contact_address_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_contact_address_manual_form_path(transient_registration[:token]))
             end
           end
@@ -198,13 +170,10 @@ module WasteCarriersEngine
           end
 
           context "when the skip_to_manual_address action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get skip_to_manual_address_contact_address_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get skip_to_manual_address_contact_address_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
             end
           end

--- a/spec/requests/waste_carriers_engine/contact_address_manual_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/contact_address_manual_forms_spec.rb
@@ -33,18 +33,11 @@ module WasteCarriersEngine
               }
             end
 
-            it "updates the transient registration" do
+            it "updates the transient registration, returns a 302 response and redirects to the check_your_answers form" do
               post contact_address_manual_forms_path(transient_registration.token), contact_address_manual_form: valid_params
+
               expect(transient_registration.reload.contact_address.house_number).to eq("42")
-            end
-
-            it "returns a 302 response" do
-              post contact_address_manual_forms_path(transient_registration.token), contact_address_manual_form: valid_params
               expect(response).to have_http_status(302)
-            end
-
-            it "redirects to the check_your_answers form" do
-              post contact_address_manual_forms_path(transient_registration.token), contact_address_manual_form: valid_params
               expect(response).to redirect_to(new_check_your_answers_form_path(transient_registration[:token]))
             end
 
@@ -57,27 +50,17 @@ module WasteCarriersEngine
                        workflow_state: "contact_address_manual_form")
               end
 
-              it "should have have the same number of addresses before and after submitting" do
-                number_of_addresses = transient_registration.addresses.count
-                post contact_address_manual_forms_path(transient_registration.token), contact_address_manual_form: valid_params
-                expect(transient_registration.reload.addresses.count).to eq(number_of_addresses)
-              end
-
-              it "removes the old contact address" do
+              it "removes the old contact address, adds the new contact address, does not modify the existing registered address, and does not change the total number of addresses" do
                 old_contact_address = transient_registration.contact_address
-                post contact_address_manual_forms_path(transient_registration.token), contact_address_manual_form: valid_params
-                expect(transient_registration.reload.contact_address).to_not eq(old_contact_address)
-              end
-
-              it "adds the new contact address" do
-                post contact_address_manual_forms_path(transient_registration.token), contact_address_manual_form: valid_params
-                expect(transient_registration.reload.contact_address.address_line_1).to eq("Foo Terrace")
-              end
-
-              it "does not modify the existing registered address" do
                 old_registered_address = transient_registration.registered_address
+                number_of_addresses = transient_registration.addresses.count
+
                 post contact_address_manual_forms_path(transient_registration.token), contact_address_manual_form: valid_params
+
+                expect(transient_registration.reload.contact_address).to_not eq(old_contact_address)
+                expect(transient_registration.reload.contact_address.address_line_1).to eq("Foo Terrace")
                 expect(transient_registration.reload.registered_address).to eq(old_registered_address)
+                expect(transient_registration.reload.addresses.count).to eq(number_of_addresses)
               end
             end
           end
@@ -102,18 +85,11 @@ module WasteCarriersEngine
             }
           end
 
-          it "does not update the transient registration" do
+          it "does not update the transient registration, returns a 302 response and redirects to the correct form for the state" do
             post contact_address_forms_path(transient_registration.token), contact_address_form: valid_params
+
             expect(transient_registration.reload.addresses.count).to eq(0)
-          end
-
-          it "returns a 302 response" do
-            post contact_address_manual_forms_path(transient_registration.token), contact_address_manual_form: valid_params
             expect(response).to have_http_status(302)
-          end
-
-          it "redirects to the correct form for the state" do
-            post contact_address_manual_forms_path(transient_registration.token), contact_address_manual_form: valid_params
             expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
           end
         end
@@ -136,9 +112,11 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the contact_postcode form" do
               get back_contact_address_manual_forms_path(transient_registration[:token])
+
               expect(response).to have_http_status(302)
+              expect(response).to redirect_to(new_contact_postcode_form_path(transient_registration[:token]))
             end
 
             context "when the location is 'overseas'" do
@@ -149,15 +127,6 @@ module WasteCarriersEngine
                 expect(response).to redirect_to(new_contact_email_form_path(transient_registration[:token]))
               end
             end
-
-            # context "when the location is not 'overseas'" do
-            #   before(:each) { transient_registration.update_attributes(location: "england") }
-            #
-            #   it "redirects to the contact_postcode form" do
-            #     get back_contact_address_manual_forms_path(transient_registration[:token])
-            #     expect(response).to redirect_to(new_contact_postcode_form_path(transient_registration[:token]))
-            #   end
-            # end
           end
         end
 
@@ -170,13 +139,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_contact_address_manual_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_contact_address_manual_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
             end
           end

--- a/spec/requests/waste_carriers_engine/contact_email_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/contact_email_forms_spec.rb
@@ -41,13 +41,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the contact_phone form" do
               get back_contact_email_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the contact_phone form" do
-              get back_contact_email_forms_path(transient_registration.token)
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_contact_phone_form_path(transient_registration.token))
             end
           end
@@ -62,13 +59,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_contact_email_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_contact_email_forms_path(transient_registration.token)
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration.token))
             end
           end

--- a/spec/requests/waste_carriers_engine/contact_name_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/contact_name_forms_spec.rb
@@ -41,13 +41,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the declare_convictions form" do
               get back_contact_name_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the declare_convictions form" do
-              get back_contact_name_forms_path(transient_registration.token)
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_declare_convictions_form_path(transient_registration.token))
             end
           end
@@ -62,13 +59,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_contact_name_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_contact_name_forms_path(transient_registration.token)
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration.token))
             end
           end

--- a/spec/requests/waste_carriers_engine/contact_phone_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/contact_phone_forms_spec.rb
@@ -41,13 +41,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the contact_name form" do
               get back_contact_phone_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the contact_name form" do
-              get back_contact_phone_forms_path(transient_registration.token)
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_contact_name_form_path(transient_registration.token))
             end
           end
@@ -62,13 +59,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_contact_phone_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_contact_phone_forms_path(transient_registration.token)
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration.token))
             end
           end

--- a/spec/requests/waste_carriers_engine/contact_postcode_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/contact_postcode_forms_spec.rb
@@ -33,18 +33,11 @@ module WasteCarriersEngine
               allow_any_instance_of(AddressFinderService).to receive(:search_by_postcode).and_return(example_json)
             end
 
-            it "returns a 302 response" do
+            it "updates the transient registration, returns a 302 response and redirects to the contact_address form" do
               post contact_postcode_forms_path(transient_registration.token), contact_postcode_form: valid_params
-              expect(response).to have_http_status(302)
-            end
 
-            it "updates the transient registration" do
-              post contact_postcode_forms_path(transient_registration.token), contact_postcode_form: valid_params
               expect(transient_registration.reload[:temp_contact_postcode]).to eq(valid_params[:temp_contact_postcode])
-            end
-
-            it "redirects to the contact_address form" do
-              post contact_postcode_forms_path(transient_registration.token), contact_postcode_form: valid_params
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_contact_address_form_path(transient_registration[:token]))
             end
 
@@ -67,13 +60,10 @@ module WasteCarriersEngine
               }
             end
 
-            it "returns a 302 response" do
+            it "returns a 302 response and does not update the transient registration" do
               post contact_postcode_forms_path("foo"), contact_postcode_form: invalid_params
-              expect(response).to have_http_status(302)
-            end
 
-            it "does not update the transient registration" do
-              post contact_postcode_forms_path("foo"), contact_postcode_form: invalid_params
+              expect(response).to have_http_status(302)
               expect(transient_registration.reload[:temp_contact_postcode]).to_not eq(invalid_params[:temp_contact_postcode])
             end
           end
@@ -93,18 +83,11 @@ module WasteCarriersEngine
             }
           end
 
-          it "returns a 302 response" do
+          it "does not update the transient registration, returns a 302 response and redirects to the correct form for the state" do
             post contact_postcode_forms_path(transient_registration[:token]), contact_postcode_form: valid_params
-            expect(response).to have_http_status(302)
-          end
 
-          it "does not update the transient registration" do
-            post contact_postcode_forms_path(transient_registration[:token]), contact_postcode_form: valid_params
             expect(transient_registration.reload[:temp_contact_postcode]).to_not eq(valid_params[:temp_contact_postcode])
-          end
-
-          it "redirects to the correct form for the state" do
-            post contact_postcode_forms_path(transient_registration[:token]), contact_postcode_form: valid_params
+            expect(response).to have_http_status(302)
             expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
           end
         end
@@ -127,13 +110,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the contact_email form" do
               get back_contact_postcode_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the contact_email form" do
-              get back_contact_postcode_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_contact_email_form_path(transient_registration[:token]))
             end
           end
@@ -148,13 +128,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_contact_postcode_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_contact_postcode_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
             end
           end
@@ -179,13 +156,10 @@ module WasteCarriersEngine
           end
 
           context "when the skip_to_manual_address action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the contact_address_manual form" do
               get skip_to_manual_address_contact_postcode_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the contact_address_manual form" do
-              get skip_to_manual_address_contact_postcode_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_contact_address_manual_form_path(transient_registration[:token]))
             end
           end
@@ -201,13 +175,10 @@ module WasteCarriersEngine
           end
 
           context "when the skip_to_manual_address action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get skip_to_manual_address_contact_postcode_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get skip_to_manual_address_contact_postcode_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
             end
           end

--- a/spec/requests/waste_carriers_engine/conviction_details_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/conviction_details_forms_spec.rb
@@ -33,24 +33,15 @@ module WasteCarriersEngine
               }
             end
 
-            it "increases the total number of people" do
+            it "updates the transient registration, returns a 302 response and redirects to the contact_name form" do
               total_people_count = transient_registration.key_people.count
+
               post conviction_details_forms_path(transient_registration.token), conviction_details_form: valid_params
+
               expect(transient_registration.reload.key_people.count).to eq(total_people_count + 1)
-            end
-
-            it "updates the transient registration" do
-              post conviction_details_forms_path(transient_registration.token), conviction_details_form: valid_params
               expect(transient_registration.reload.key_people.last.position).to eq(valid_params[:position])
-            end
 
-            it "returns a 302 response" do
-              post conviction_details_forms_path(transient_registration.token), conviction_details_form: valid_params
               expect(response).to have_http_status(302)
-            end
-
-            it "redirects to the contact_name form" do
-              post conviction_details_forms_path(transient_registration.token), conviction_details_form: valid_params
               expect(response).to redirect_to(new_contact_name_form_path(transient_registration[:token]))
             end
 
@@ -61,14 +52,12 @@ module WasteCarriersEngine
                 transient_registration.update_attributes(key_people: [relevant_conviction_person])
               end
 
-              it "increases the total number of people" do
+              it "increases the total number of people and does not replace the existing relevant conviction person" do
                 total_people_count = transient_registration.key_people.count
-                post conviction_details_forms_path(transient_registration.token), conviction_details_form: valid_params
-                expect(transient_registration.reload.key_people.count).to eq(total_people_count + 1)
-              end
 
-              it "does not replace the existing relevant conviction person" do
                 post conviction_details_forms_path(transient_registration.token), conviction_details_form: valid_params
+
+                expect(transient_registration.reload.key_people.count).to eq(total_people_count + 1)
                 expect(transient_registration.reload.key_people.first.first_name).to eq(relevant_conviction_person.first_name)
               end
             end
@@ -80,14 +69,12 @@ module WasteCarriersEngine
                 transient_registration.update_attributes(key_people: [main_person])
               end
 
-              it "increases the total number of people" do
+              it "increases the total number of people and does not replace the existing main person" do
                 total_people_count = transient_registration.key_people.count
-                post conviction_details_forms_path(transient_registration.token), conviction_details_form: valid_params
-                expect(transient_registration.reload.key_people.count).to eq(total_people_count + 1)
-              end
 
-              it "does not replace the existing main person" do
                 post conviction_details_forms_path(transient_registration.token), conviction_details_form: valid_params
+
+                expect(transient_registration.reload.key_people.count).to eq(total_people_count + 1)
                 expect(transient_registration.reload.key_people.first.first_name).to eq(main_person.first_name)
               end
             end
@@ -95,6 +82,7 @@ module WasteCarriersEngine
             context "when the submit params say to add another" do
               it "redirects to the conviction_details form" do
                 post conviction_details_forms_path(transient_registration.token), conviction_details_form: valid_params, commit: "Add another person"
+
                 expect(response).to redirect_to(new_conviction_details_form_path(transient_registration[:token]))
               end
             end
@@ -113,7 +101,9 @@ module WasteCarriersEngine
 
             it "does not increase the total number of people" do
               total_people_count = transient_registration.key_people.count
+
               post conviction_details_forms_path(transient_registration.token), conviction_details_form: invalid_params
+
               expect(transient_registration.reload.key_people.count).to eq(total_people_count)
             end
 
@@ -126,6 +116,7 @@ module WasteCarriersEngine
 
               it "does not replace the existing main person" do
                 post conviction_details_forms_path(transient_registration.token), conviction_details_form: invalid_params
+
                 expect(transient_registration.reload.key_people.first.first_name).to eq(existing_main_person.first_name)
               end
             end
@@ -145,7 +136,9 @@ module WasteCarriersEngine
 
             it "does not increase the total number of people" do
               total_people_count = transient_registration.key_people.count
+
               post conviction_details_forms_path(transient_registration.token), conviction_details_form: blank_params
+
               expect(transient_registration.reload.key_people.count).to eq(total_people_count)
             end
           end
@@ -170,18 +163,11 @@ module WasteCarriersEngine
             }
           end
 
-          it "does not update the transient registration" do
+          it "does not update the transient registration, returns a 302 response and redirects to the correct form for the state" do
             post conviction_details_forms_path(transient_registration.token), conviction_details_form: valid_params
+
             expect(transient_registration.reload.key_people).to_not exist
-          end
-
-          it "returns a 302 response" do
-            post conviction_details_forms_path(transient_registration.token), conviction_details_form: valid_params
             expect(response).to have_http_status(302)
-          end
-
-          it "redirects to the correct form for the state" do
-            post conviction_details_forms_path(transient_registration.token), conviction_details_form: valid_params
             expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
           end
         end
@@ -204,13 +190,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the declare_convictions form" do
               get back_conviction_details_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the declare_convictions form" do
-              get back_conviction_details_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_declare_convictions_form_path(transient_registration[:token]))
             end
           end
@@ -225,13 +208,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_conviction_details_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_conviction_details_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
             end
           end
@@ -263,30 +243,19 @@ module WasteCarriersEngine
             end
 
             context "when the delete person action is triggered" do
-              it "returns a 302 response" do
-                delete delete_person_conviction_details_forms_path(id: relevant_person_a[:id], token: transient_registration.token)
-                expect(response).to have_http_status(302)
-              end
-
-              it "redirects to the conviction details form" do
-                delete delete_person_conviction_details_forms_path(id: relevant_person_a[:id], token: transient_registration.token)
-                expect(response).to redirect_to(new_conviction_details_form_path(transient_registration[:token]))
-              end
-
-              it "reduces the total number of people" do
+              it "correctly modifies the list of people, returns a 302 response and redirects to the conviction details form" do
                 total_people_count = transient_registration.key_people.count
+
                 delete delete_person_conviction_details_forms_path(id: relevant_person_a[:id], token: transient_registration.token)
+
                 expect(transient_registration.reload.key_people.count).to eq(total_people_count - 1)
-              end
-
-              it "removes the person" do
-                delete delete_person_conviction_details_forms_path(id: relevant_person_a[:id], token: transient_registration.token)
+                # Removes the correct person
                 expect(transient_registration.reload.key_people.where(id: relevant_person_a[:id]).count).to eq(0)
-              end
-
-              it "does not modify the other people" do
-                delete delete_person_conviction_details_forms_path(id: relevant_person_a[:id], token: transient_registration.token)
+                # Does not affect other people
                 expect(transient_registration.reload.key_people.where(id: relevant_person_b[:id]).count).to eq(1)
+
+                expect(response).to have_http_status(302)
+                expect(response).to redirect_to(new_conviction_details_form_path(transient_registration[:token]))
               end
             end
           end

--- a/spec/requests/waste_carriers_engine/copy_cards_bank_transfer_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/copy_cards_bank_transfer_forms_spec.rb
@@ -80,14 +80,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the payment_summary form" do
               get back_copy_cards_bank_transfer_forms_path(transient_registration.token)
 
               expect(response).to have_http_status(302)
-            end
-
-            it "redirects to the payment_summary form" do
-              get back_copy_cards_bank_transfer_forms_path(transient_registration.token)
               expect(response).to redirect_to(new_copy_cards_payment_form_path(transient_registration.token))
             end
           end
@@ -99,13 +95,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_copy_cards_bank_transfer_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_copy_cards_bank_transfer_forms_path(transient_registration.token)
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_copy_cards_payment_form_path(transient_registration.token))
             end
           end

--- a/spec/requests/waste_carriers_engine/declaration_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/declaration_forms_spec.rb
@@ -47,13 +47,10 @@ module WasteCarriersEngine
 
           let(:params) { { declaration: 1 } }
 
-          it "creates a new conviction_search_result for the registration" do
+          it "creates new conviction_search_results for the registration and key people" do
             post_form_with_params("declaration_form", transient_registration.token, params)
-            expect(transient_registration.reload.conviction_search_result).to_not eq(nil)
-          end
 
-          it "creates a new conviction_search_result for the key people" do
-            post_form_with_params("declaration_form", transient_registration.token, params)
+            expect(transient_registration.reload.conviction_search_result).to_not eq(nil)
             expect(transient_registration.reload.key_people.first.conviction_search_result).to_not eq(nil)
           end
         end
@@ -76,13 +73,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the check_your_answers form" do
               get back_declaration_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the check_your_answers form" do
-              get back_declaration_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_check_your_answers_form_path(transient_registration[:token]))
             end
           end
@@ -97,13 +91,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_declaration_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_declaration_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
             end
           end

--- a/spec/requests/waste_carriers_engine/declare_convictions_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/declare_convictions_forms_spec.rb
@@ -41,13 +41,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the main_people form" do
               get back_declare_convictions_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the main_people form" do
-              get back_declare_convictions_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_main_people_form_path(transient_registration[:token]))
             end
           end
@@ -62,13 +59,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_declare_convictions_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_declare_convictions_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
             end
           end

--- a/spec/requests/waste_carriers_engine/edit_bank_transfer_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/edit_bank_transfer_forms_spec.rb
@@ -80,14 +80,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the payment_summary form" do
               get back_edit_bank_transfer_forms_path(transient_registration.token)
 
               expect(response).to have_http_status(302)
-            end
-
-            it "redirects to the payment_summary form" do
-              get back_edit_bank_transfer_forms_path(transient_registration.token)
               expect(response).to redirect_to(new_edit_payment_summary_form_path(transient_registration.token))
             end
           end
@@ -99,13 +95,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_edit_bank_transfer_forms_path(transient_registration.token)
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_edit_bank_transfer_forms_path(transient_registration.token)
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_location_form_path(transient_registration.token))
             end
           end

--- a/spec/requests/waste_carriers_engine/edit_payment_summary_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/edit_payment_summary_forms_spec.rb
@@ -83,20 +83,19 @@ module WasteCarriersEngine
           context "when valid params are submitted" do
             let(:valid_params) { { temp_payment_method: temp_payment_method } }
 
-            # TODO
-            # context "when the temp payment method is `card`" do
-            #   let(:temp_payment_method) { "card" }
-            #
-            #   it "updates the transient registration with correct data, returns a 302 response and redirects to the worldpay form" do
-            #     post edit_payment_summary_forms_path(token: edit_registration.token), edit_payment_summary_form: valid_params
-            #
-            #     edit_registration.reload
-            #
-            #     expect(edit_registration.temp_payment_method).to eq("card")
-            #     expect(response).to have_http_status(302)
-            #     expect(response).to redirect_to(new_worldpay_form_path(edit_registration.token))
-            #   end
-            # end
+            context "when the temp payment method is `card`" do
+              let(:temp_payment_method) { "card" }
+
+              it "updates the transient registration with correct data, returns a 302 response and redirects to the worldpay form" do
+                post edit_payment_summary_forms_path(token: edit_registration.token), edit_payment_summary_form: valid_params
+
+                edit_registration.reload
+
+                expect(edit_registration.temp_payment_method).to eq("card")
+                expect(response).to have_http_status(302)
+                expect(response).to redirect_to(new_worldpay_form_path(edit_registration.token))
+              end
+            end
 
             context "when the temp payment method is `bank_transfer`" do
               let(:temp_payment_method) { "bank_transfer" }

--- a/spec/requests/waste_carriers_engine/errors_spec.rb
+++ b/spec/requests/waste_carriers_engine/errors_spec.rb
@@ -6,16 +6,11 @@ module WasteCarriersEngine
   RSpec.describe "Errors", type: :request do
     describe "#show" do
       %w[401 403 404 422].each do |code|
-        it "renders the error_#{code} template" do
-          get error_path(code)
-
-          expect(response).to render_template("error_#{code}")
-        end
-
-        it "responds with a status of #{code}" do
+        it "responds with a status of #{code} and renders the error_#{code} template" do
           get error_path(code)
 
           expect(response.code).to eq(code)
+          expect(response).to render_template("error_#{code}")
         end
       end
 

--- a/spec/requests/waste_carriers_engine/location_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/location_forms_spec.rb
@@ -41,13 +41,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the renewal_start form" do
               get back_location_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the renewal_start form" do
-              get back_location_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
             end
           end
@@ -62,13 +59,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_location_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_location_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_company_name_form_path(transient_registration[:token]))
             end
           end

--- a/spec/requests/waste_carriers_engine/main_people_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/main_people_forms_spec.rb
@@ -32,24 +32,14 @@ module WasteCarriersEngine
               }
             end
 
-            it "increases the number of key_people" do
+            it "correctly updates the key people, returns a 302 response and redirects to the declare_convictions form" do
               key_people_count = transient_registration.key_people.count
+
               post main_people_forms_path(transient_registration.token), main_people_form: valid_params
+
               expect(transient_registration.reload.key_people.count).to eq(key_people_count + 1)
-            end
-
-            it "updates the transient registration" do
-              post main_people_forms_path(transient_registration.token), main_people_form: valid_params
               expect(transient_registration.reload.key_people.last.first_name).to eq(valid_params[:first_name])
-            end
-
-            it "returns a 302 response" do
-              post main_people_forms_path(transient_registration.token), main_people_form: valid_params
               expect(response).to have_http_status(302)
-            end
-
-            it "redirects to the declare_convictions form" do
-              post main_people_forms_path(transient_registration.token), main_people_form: valid_params
               expect(response).to redirect_to(new_declare_convictions_form_path(transient_registration[:token]))
             end
 
@@ -63,6 +53,7 @@ module WasteCarriersEngine
               context "when there can be multiple main people" do
                 it "does not replace the existing main person" do
                   post main_people_forms_path(transient_registration.token), main_people_form: valid_params
+
                   expect(transient_registration.reload.key_people.first.first_name).to eq(existing_main_person.first_name)
                 end
               end
@@ -72,15 +63,13 @@ module WasteCarriersEngine
                   transient_registration.update_attributes(business_type: "soleTrader")
                 end
 
-                it "does not increase the number of key_people" do
+                it "replaces the existing main person and does not increase the number of key_people" do
                   key_people_count = transient_registration.key_people.count
-                  post main_people_forms_path(transient_registration.token), main_people_form: valid_params
-                  expect(transient_registration.reload.key_people.count).to eq(key_people_count)
-                end
 
-                it "replaces the existing main person" do
                   post main_people_forms_path(transient_registration.token), main_people_form: valid_params
+
                   expect(transient_registration.reload.key_people.first.first_name).to_not eq(existing_main_person.first_name)
+                  expect(transient_registration.reload.key_people.count).to eq(key_people_count)
                 end
               end
             end
@@ -93,14 +82,12 @@ module WasteCarriersEngine
               end
 
               context "when there can be multiple key people" do
-                it "increases the number of key people" do
+                it "increases the number of key people and does not replace the relevant conviction person" do
                   key_people_count = transient_registration.key_people.count
-                  post main_people_forms_path(transient_registration.token), main_people_form: valid_params
-                  expect(transient_registration.reload.key_people.count).to eq(key_people_count + 1)
-                end
 
-                it "does not replace the relevant conviction person" do
                   post main_people_forms_path(transient_registration.token), main_people_form: valid_params
+
+                  expect(transient_registration.reload.key_people.count).to eq(key_people_count + 1)
                   expect(transient_registration.reload.key_people.first.first_name).to eq(relevant_conviction_person.first_name)
                 end
               end
@@ -110,19 +97,13 @@ module WasteCarriersEngine
                   transient_registration.update_attributes(business_type: "soleTrader")
                 end
 
-                it "increases the number of key_people" do
+                it "increases the number of key_people, adds the new main person and does not replace the relevant conviction person" do
                   key_people_count = transient_registration.key_people.count
+
                   post main_people_forms_path(transient_registration.token), main_people_form: valid_params
+
                   expect(transient_registration.reload.key_people.count).to eq(key_people_count + 1)
-                end
-
-                it "adds the new main person" do
-                  post main_people_forms_path(transient_registration.token), main_people_form: valid_params
                   expect(transient_registration.reload.key_people.last.first_name).to eq(valid_params[:first_name])
-                end
-
-                it "does not replace the relevant conviction person" do
-                  post main_people_forms_path(transient_registration.token), main_people_form: valid_params
                   expect(transient_registration.reload.key_people.first.first_name).to eq(relevant_conviction_person.first_name)
                 end
               end
@@ -204,18 +185,11 @@ module WasteCarriersEngine
             }
           end
 
-          it "does not update the transient registration" do
+          it "does not update the transient registration, returns a 302 response and redirects to the correct form for the state" do
             post main_people_forms_path(transient_registration.token), main_people_form: valid_params
+
             expect(transient_registration.reload.key_people).to_not exist
-          end
-
-          it "returns a 302 response" do
-            post main_people_forms_path(transient_registration.token), main_people_form: valid_params
             expect(response).to have_http_status(302)
-          end
-
-          it "redirects to the correct form for the state" do
-            post main_people_forms_path(transient_registration.token), main_people_form: valid_params
             expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
           end
         end
@@ -272,13 +246,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_main_people_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_main_people_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
             end
           end
@@ -310,30 +281,19 @@ module WasteCarriersEngine
             end
 
             context "when the delete person action is triggered" do
-              it "returns a 302 response" do
-                delete delete_person_main_people_forms_path(main_person_a[:id], token: transient_registration.token)
-                expect(response).to have_http_status(302)
-              end
-
-              it "redirects to the main people form" do
-                delete delete_person_main_people_forms_path(main_person_a[:id], token: transient_registration.token)
-                expect(response).to redirect_to(new_main_people_form_path(transient_registration[:token]))
-              end
-
-              it "reduces the number of key_people" do
+              it "correctly updates the key people, returns a 302 response and redirects to the main people form" do
                 key_people_count = transient_registration.key_people.count
+
                 delete delete_person_main_people_forms_path(main_person_a[:id], token: transient_registration.token)
+
                 expect(transient_registration.reload.key_people.count).to eq(key_people_count - 1)
-              end
-
-              it "removes the main person" do
-                delete delete_person_main_people_forms_path(main_person_a[:id], token: transient_registration.token)
+                # Removes the correct person
                 expect(transient_registration.reload.key_people.where(id: main_person_a[:id]).count).to eq(0)
-              end
-
-              it "does not modify the other key_people" do
-                delete delete_person_main_people_forms_path(main_person_a[:id], token: transient_registration.token)
+                # Does not affect other people
                 expect(transient_registration.reload.key_people.where(id: main_person_b[:id]).count).to eq(1)
+
+                expect(response).to have_http_status(302)
+                expect(response).to redirect_to(new_main_people_form_path(transient_registration[:token]))
               end
             end
           end

--- a/spec/requests/waste_carriers_engine/other_businesses_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/other_businesses_forms_spec.rb
@@ -41,13 +41,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the tier_check form" do
               get back_other_businesses_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the tier_check form" do
-              get back_other_businesses_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_tier_check_form_path(transient_registration[:token]))
             end
           end
@@ -62,13 +59,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_other_businesses_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_other_businesses_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
             end
           end

--- a/spec/requests/waste_carriers_engine/payment_summary_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/payment_summary_forms_spec.rb
@@ -41,13 +41,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the cards form" do
               get back_payment_summary_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the cards form" do
-              get back_payment_summary_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_cards_form_path(transient_registration[:token]))
             end
           end
@@ -62,13 +59,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_payment_summary_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_payment_summary_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
             end
           end

--- a/spec/requests/waste_carriers_engine/register_in_northern_ireland_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/register_in_northern_ireland_forms_spec.rb
@@ -24,13 +24,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the location form" do
               get back_register_in_northern_ireland_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the location form" do
-              get back_register_in_northern_ireland_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_location_form_path(transient_registration[:token]))
             end
           end
@@ -45,13 +42,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_register_in_northern_ireland_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_register_in_northern_ireland_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
             end
           end

--- a/spec/requests/waste_carriers_engine/register_in_scotland_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/register_in_scotland_forms_spec.rb
@@ -24,13 +24,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the location form" do
               get back_register_in_scotland_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the location form" do
-              get back_register_in_scotland_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_location_form_path(transient_registration[:token]))
             end
           end
@@ -45,13 +42,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_register_in_scotland_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_register_in_scotland_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
             end
           end

--- a/spec/requests/waste_carriers_engine/register_in_wales_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/register_in_wales_forms_spec.rb
@@ -24,13 +24,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the location form" do
               get back_register_in_wales_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the location form" do
-              get back_register_in_wales_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_location_form_path(transient_registration[:token]))
             end
           end
@@ -45,13 +42,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_register_in_wales_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_register_in_wales_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
             end
           end

--- a/spec/requests/waste_carriers_engine/registration_number_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/registration_number_forms_spec.rb
@@ -28,13 +28,10 @@ module WasteCarriersEngine
           context "when valid params are submitted and the company_no is the same as the original registration" do
             let(:valid_params) { { company_no: transient_registration[:company_no] } }
 
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the company_name form" do
               post registration_number_forms_path(transient_registration[:token]), registration_number_form: valid_params
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the company_name form" do
-              post registration_number_forms_path(transient_registration[:token]), registration_number_form: valid_params
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_company_name_form_path(transient_registration[:token]))
             end
 
@@ -44,13 +41,10 @@ module WasteCarriersEngine
                 registration.update_attributes(company_no: "9360070")
               end
 
-              it "returns a 302 response" do
+              it "returns a 302 response and redirects to the company_name form" do
                 post registration_number_forms_path(transient_registration[:token]), registration_number_form: valid_params
-                expect(response).to have_http_status(302)
-              end
 
-              it "redirects to the company_name form" do
-                post registration_number_forms_path(transient_registration[:token]), registration_number_form: valid_params
+                expect(response).to have_http_status(302)
                 expect(response).to redirect_to(new_company_name_form_path(transient_registration[:token]))
               end
             end
@@ -59,18 +53,11 @@ module WasteCarriersEngine
           context "when valid params are submitted and the company_no is different to the original registration" do
             let(:valid_params) { { company_no: "01234567" } }
 
-            it "updates the transient registration" do
+            it "updates the transient registration, returns a 302 response and redirects to the cannot_renew_company_no_change form" do
               post registration_number_forms_path(transient_registration[:token]), registration_number_form: valid_params
+
               expect(transient_registration.reload[:company_no].to_s).to eq(valid_params[:company_no])
-            end
-
-            it "returns a 302 response" do
-              post registration_number_forms_path(transient_registration[:token]), registration_number_form: valid_params
               expect(response).to have_http_status(302)
-            end
-
-            it "redirects to the cannot_renew_company_no_change form" do
-              post registration_number_forms_path(transient_registration[:token]), registration_number_form: valid_params
               expect(response).to redirect_to(new_cannot_renew_company_no_change_form_path(transient_registration[:token]))
             end
           end
@@ -95,18 +82,11 @@ module WasteCarriersEngine
 
           let(:valid_params) { { company_no: "01234567" } }
 
-          it "does not update the transient registration" do
+          it "does not update the transient registration, returns a 302 response and redirects to the correct form for the state" do
             post registration_number_forms_path(transient_registration[:token]), registration_number_form: valid_params
+
             expect(transient_registration.reload[:company_no].to_s).to_not eq(valid_params[:company_no])
-          end
-
-          it "returns a 302 response" do
-            post registration_number_forms_path(transient_registration[:token]), registration_number_form: valid_params
             expect(response).to have_http_status(302)
-          end
-
-          it "redirects to the correct form for the state" do
-            post registration_number_forms_path(transient_registration[:token]), registration_number_form: valid_params
             expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
           end
         end
@@ -129,13 +109,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the renewal_information form" do
               get back_registration_number_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the renewal_information form" do
-              get back_registration_number_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_information_form_path(transient_registration[:token]))
             end
           end
@@ -152,11 +129,8 @@ module WasteCarriersEngine
           context "when the back action is triggered" do
             it "returns a 302 response" do
               get back_registration_number_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_registration_number_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
             end
           end

--- a/spec/requests/waste_carriers_engine/renewal_complete_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/renewal_complete_forms_spec.rb
@@ -29,15 +29,13 @@ module WasteCarriersEngine
           end
 
           context "when the workflow_state is correct" do
-            it "loads the page" do
-              get new_renewal_complete_form_path(transient_registration.token)
-              expect(response).to have_http_status(200)
-            end
-
-            it "renews the registration" do
+            it "returns a 200 response and renews the registration" do
               registration = Registration.where(reg_identifier: transient_registration.reg_identifier).first
               old_expires_on = registration.expires_on
+
               get new_renewal_complete_form_path(transient_registration.token)
+
+              expect(response).to have_http_status(200)
               expect(registration.reload.expires_on).to_not eq(old_expires_on)
             end
           end
@@ -47,15 +45,13 @@ module WasteCarriersEngine
               transient_registration.update_attributes(workflow_state: "payment_summary_form")
             end
 
-            it "redirects to the correct page" do
-              get new_renewal_complete_form_path(transient_registration.token)
-              expect(response).to redirect_to(new_payment_summary_form_path(transient_registration.token))
-            end
-
-            it "does not renew the registration" do
+            it "redirects to the correct page and does not renew the registration" do
               registration = Registration.where(reg_identifier: transient_registration.reg_identifier).first
               old_expires_on = registration.expires_on
+
               get new_renewal_complete_form_path(transient_registration.token)
+
+              expect(response).to redirect_to(new_payment_summary_form_path(transient_registration.token))
               expect(registration.reload.expires_on).to eq(old_expires_on)
             end
           end

--- a/spec/requests/waste_carriers_engine/renewal_information_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/renewal_information_forms_spec.rb
@@ -24,13 +24,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the cbd_type form" do
               get back_renewal_information_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the cbd_type form" do
-              get back_renewal_information_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_cbd_type_form_path(transient_registration[:token]))
             end
           end
@@ -45,13 +42,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_renewal_information_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_renewal_information_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
             end
           end

--- a/spec/requests/waste_carriers_engine/renewal_start_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/renewal_start_forms_spec.rb
@@ -124,13 +124,10 @@ module WasteCarriersEngine
           sign_out(user)
         end
 
-        it "returns a 302 response" do
+        it "returns a 302 response and redirects to the sign in page" do
           get new_renewal_start_form_path("foo")
-          expect(response).to have_http_status(302)
-        end
 
-        it "redirects to the sign in page" do
-          get new_renewal_start_form_path("foo")
+          expect(response).to have_http_status(302)
           expect(response).to redirect_to(new_user_session_path)
         end
       end
@@ -165,17 +162,14 @@ module WasteCarriersEngine
         context "when the token doesn't match the format" do
           let(:invalid_renewal) { "foo" }
 
-          it "redirects to the invalid token error page" do
-            post renewal_start_forms_path(invalid_renewal)
-            expect(response).to redirect_to(page_path("invalid"))
-          end
-
-          it "does not create a new transient registration" do
+          it "redirects to the invalid token error page and does not create a new transient registration" do
             original_tr_count = RenewingRegistration.count
-            post renewal_start_forms_path(invalid_renewal)
-            updated_tr_count = RenewingRegistration.count
 
-            expect(original_tr_count).to eq(updated_tr_count)
+            post renewal_start_forms_path(invalid_renewal)
+
+            expect(response).to redirect_to(page_path("invalid"))
+
+            expect(RenewingRegistration.count).to eq(original_tr_count)
           end
         end
 
@@ -193,31 +187,18 @@ module WasteCarriersEngine
               context "when valid params are submitted" do
                 let(:valid_registration) { registration.reg_identifier }
 
-                it "creates a new transient registration" do
-                  expected_tr_count = RenewingRegistration.count + 1
-                  post renewal_start_forms_path(valid_registration)
-                  updated_tr_count = RenewingRegistration.count
+                it "creates a new transient registration with correct data, returns a 302 response and redirects to the business type form" do
+                  original_count = RenewingRegistration.count
 
-                  expect(expected_tr_count).to eq(updated_tr_count)
-                end
-
-                it "creates a transient registration with correct data" do
                   post renewal_start_forms_path(valid_registration)
+
+                  expect(RenewingRegistration.count).to eq(original_count + 1)
+
                   transient_registration = RenewingRegistration.where(reg_identifier: valid_registration).first
-
                   expect(transient_registration.reg_identifier).to eq(registration.reg_identifier)
                   expect(transient_registration.company_name).to eq(registration.company_name)
-                end
 
-                it "returns a 302 response" do
-                  post renewal_start_forms_path(valid_registration)
                   expect(response).to have_http_status(302)
-                end
-
-                it "redirects to the business type form" do
-                  post renewal_start_forms_path(valid_registration)
-                  transient_registration = RenewingRegistration.where(reg_identifier: valid_registration).first
-
                   expect(response).to redirect_to(new_location_form_path(transient_registration.token))
                 end
 
@@ -243,25 +224,16 @@ module WasteCarriersEngine
 
             let(:valid_renewal) { transient_registration.token }
 
-            it "returns a 302 response" do
-              post renewal_start_forms_path(valid_renewal)
-              expect(response).to have_http_status(302)
-            end
-
-            it "redirects to the business type form" do
-              post renewal_start_forms_path(valid_renewal)
-              expect(response).to redirect_to(new_location_form_path(valid_renewal))
-            end
-
-            it "does not create a new transient registration" do
+            it "does not create a new transient registration, returns a 302 response and redirects to the business type form" do
               # Touch the test object so it gets created now and the count is correct
               transient_registration.touch
-
               original_tr_count = RenewingRegistration.count
-              post renewal_start_forms_path(valid_renewal)
-              updated_tr_count = RenewingRegistration.count
 
-              expect(original_tr_count).to eq(updated_tr_count)
+              post renewal_start_forms_path(valid_renewal)
+
+              expect(RenewingRegistration.count).to eq(original_tr_count)
+              expect(response).to have_http_status(302)
+              expect(response).to redirect_to(new_location_form_path(valid_renewal))
             end
 
             context "when the state is different" do
@@ -272,25 +244,16 @@ module WasteCarriersEngine
                        workflow_state: "other_businesses_form")
               end
 
-              it "returns a 302 response" do
-                post renewal_start_forms_path(valid_renewal)
-                expect(response).to have_http_status(302)
-              end
-
-              it "redirects to the correct form" do
-                post renewal_start_forms_path(valid_renewal)
-                expect(response).to redirect_to(new_other_businesses_form_path(valid_renewal))
-              end
-
-              it "does not create a new transient registration" do
+              it "does not create a new transient registration, returns a 302 response and redirects to the correct form" do
                 # Touch the test object so it gets created now and the count is correct
                 transient_registration.touch
-
                 original_tr_count = RenewingRegistration.count
-                post renewal_start_forms_path(valid_renewal)
-                updated_tr_count = RenewingRegistration.count
 
-                expect(original_tr_count).to eq(updated_tr_count)
+                post renewal_start_forms_path(valid_renewal)
+
+                expect(RenewingRegistration.count).to eq(original_tr_count)
+                expect(response).to have_http_status(302)
+                expect(response).to redirect_to(new_other_businesses_form_path(valid_renewal))
               end
             end
           end
@@ -338,21 +301,14 @@ module WasteCarriersEngine
           sign_out(user)
         end
 
-        it "returns a 302 response" do
-          post renewal_start_forms_path(valid_registration)
-          expect(response).to have_http_status(302)
-        end
-
-        it "redirects to the sign in page" do
-          post renewal_start_forms_path(valid_registration)
-          expect(response).to redirect_to(new_user_session_path)
-        end
-
-        it "does not create a new transient registration" do
+        it "does not create a new transient registration, returns a 302 response and redirects to the sign in page" do
           original_tr_count = RenewingRegistration.count
+
           post renewal_start_forms_path(valid_registration)
-          updated_tr_count = RenewingRegistration.count
-          expect(original_tr_count).to eq(updated_tr_count)
+
+          expect(RenewingRegistration.count).to eq(original_tr_count)
+          expect(response).to have_http_status(302)
+          expect(response).to redirect_to(new_user_session_path)
         end
       end
     end

--- a/spec/requests/waste_carriers_engine/service_provided_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/service_provided_forms_spec.rb
@@ -41,13 +41,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the other_businesses form" do
               get back_service_provided_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the other_businesses form" do
-              get back_service_provided_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_other_businesses_form_path(transient_registration[:token]))
             end
           end
@@ -62,13 +59,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_service_provided_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_service_provided_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
             end
           end

--- a/spec/requests/waste_carriers_engine/tier_check_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/tier_check_forms_spec.rb
@@ -28,13 +28,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the business_type form" do
               get back_tier_check_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the business_type form" do
-              get back_tier_check_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_business_type_form_path(transient_registration[:token]))
             end
           end
@@ -51,11 +48,8 @@ module WasteCarriersEngine
           context "when the back action is triggered" do
             it "returns a 302 response" do
               get back_tier_check_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_tier_check_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
             end
           end

--- a/spec/requests/waste_carriers_engine/waste_types_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/waste_types_forms_spec.rb
@@ -41,13 +41,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the service_provided form" do
               get back_waste_types_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the service_provided form" do
-              get back_waste_types_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_service_provided_form_path(transient_registration[:token]))
             end
           end
@@ -62,13 +59,10 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response" do
+            it "returns a 302 response and redirects to the correct form for the state" do
               get back_waste_types_forms_path(transient_registration[:token])
-              expect(response).to have_http_status(302)
-            end
 
-            it "redirects to the correct form for the state" do
-              get back_waste_types_forms_path(transient_registration[:token])
+              expect(response).to have_http_status(302)
               expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
             end
           end

--- a/spec/support/shared_examples/request_get_flexible_form.rb
+++ b/spec/support/shared_examples/request_get_flexible_form.rb
@@ -45,13 +45,10 @@ RSpec.shared_examples "GET flexible form" do |form|
           transient_registration.update_attributes(workflow_state: saved_state)
         end
 
-        it "updates the workflow_state to match the requested page" do
+        it "updates the workflow_state to match the requested page and loads the requested page" do
           get new_path_for(form, transient_registration)
-          expect(transient_registration.reload[:workflow_state]).to eq(form)
-        end
 
-        it "loads the requested page" do
-          get new_path_for(form, transient_registration)
+          expect(transient_registration.reload[:workflow_state]).to eq(form)
           expect(response).to render_template("#{form}s/new")
         end
       end
@@ -67,15 +64,13 @@ RSpec.shared_examples "GET flexible form" do |form|
           transient_registration.update_attributes(workflow_state: saved_state)
         end
 
-        it "redirects to the saved workflow_state" do
+        it "does not change the workflow_state and redirects to the saved workflow_state" do
           workflow_state = transient_registration[:workflow_state]
-          get new_path_for(form, transient_registration)
-          expect(response).to redirect_to(new_path_for(workflow_state, transient_registration))
-        end
 
-        it "does not change the workflow_state" do
           get new_path_for(form, transient_registration)
+
           expect(transient_registration.reload[:workflow_state]).to eq(saved_state)
+          expect(response).to redirect_to(new_path_for(workflow_state, transient_registration))
         end
       end
     end

--- a/spec/support/shared_examples/request_get_locked_in_form.rb
+++ b/spec/support/shared_examples/request_get_locked_in_form.rb
@@ -25,14 +25,12 @@ RSpec.shared_examples "GET locked-in form" do |form|
           transient_registration.update_attributes(workflow_state: form)
         end
 
-        it "loads the form" do
-          get new_path_for(form, transient_registration)
-          expect(response).to have_http_status(200)
-        end
-
-        it "does not change the workflow_state" do
+        it "loads the form and does not change the workflow_state" do
           state_before_request = transient_registration[:workflow_state]
+
           get new_path_for(form, transient_registration)
+
+          expect(response).to have_http_status(200)
           expect(transient_registration.reload[:workflow_state]).to eq(state_before_request)
         end
       end
@@ -42,16 +40,13 @@ RSpec.shared_examples "GET locked-in form" do |form|
           transient_registration.update_attributes(workflow_state: "other_businesses_form")
         end
 
-        it "redirects to the saved workflow_state" do
+        it "does not change the workflow_state and redirects to the saved workflow_state" do
           workflow_state = transient_registration[:workflow_state]
-          get new_path_for(form, transient_registration)
-          expect(response).to redirect_to(new_path_for(workflow_state, transient_registration))
-        end
 
-        it "does not change the workflow_state" do
-          state_before_request = transient_registration[:workflow_state]
           get new_path_for(form, transient_registration)
-          expect(transient_registration.reload[:workflow_state]).to eq(state_before_request)
+
+          expect(transient_registration.reload[:workflow_state]).to eq(workflow_state)
+          expect(response).to redirect_to(new_path_for(workflow_state, transient_registration))
         end
       end
 
@@ -67,16 +62,13 @@ RSpec.shared_examples "GET locked-in form" do |form|
           transient_registration.update_attributes(workflow_state: different_state)
         end
 
-        it "redirects to the saved workflow_state" do
+        it "does not change the workflow_state and redirects to the saved workflow_state" do
           workflow_state = transient_registration[:workflow_state]
-          get new_path_for(form, transient_registration)
-          expect(response).to redirect_to(new_path_for(workflow_state, transient_registration))
-        end
 
-        it "does not change the workflow_state" do
-          state_before_request = transient_registration[:workflow_state]
           get new_path_for(form, transient_registration)
-          expect(transient_registration.reload[:workflow_state]).to eq(state_before_request)
+
+          expect(transient_registration.reload[:workflow_state]).to eq(workflow_state)
+          expect(response).to redirect_to(new_path_for(workflow_state, transient_registration))
         end
       end
     end


### PR DESCRIPTION
We have a lot of request specs which are very time-expensive to run. It now takes over 4 minutes to run the unit test suite locally.

To speed up the test suite, any request tests which make the same request repeatedly (eg submitting a form with the same parameters multiple times to test individual things) should be merged together.