### PR TITLE
Add scope to filter out ad registrations

### DIFF
--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -37,6 +37,12 @@ module WasteCarriersEngine
       where(:expires_on.gte => date)
     end
 
+    def self.not_assisted_digital
+      assisted_digital_email = WasteCarriersEngine.configuration.assisted_digital_email
+
+      where("contactEmail" => { :$nin => [nil, assisted_digital_email] })
+    end
+
     alias pending_manual_conviction_check? conviction_check_required?
     alias pending_payment? unpaid_balance?
 

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -53,6 +53,20 @@ module WasteCarriersEngine
         end
       end
 
+      describe ".not_assisted_digital" do
+        it "returns registrations that are not assited digital" do
+          ad_registration_1 = create(:registration, :has_required_data, contact_email: nil)
+          ad_registration_2 = create(:registration, :has_required_data, contact_email: WasteCarriersEngine.configuration.assisted_digital_email)
+          non_ad_registration = create(:registration, :has_required_data)
+
+          result = described_class.not_assisted_digital
+
+          expect(result).to include(non_ad_registration)
+          expect(result).to_not include(ad_registration_1)
+          expect(result).to_not include(ad_registration_2)
+        end
+      end
+
       describe ".in_grace_window" do
         it "returns registrations whose expired date is in the grace window" do
           allow(Rails.configuration).to receive(:grace_window).and_return(3)

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -55,8 +55,8 @@ module WasteCarriersEngine
 
       describe ".not_assisted_digital" do
         it "returns registrations that are not assited digital" do
-          ad_registration_1 = create(:registration, :has_required_data, contact_email: nil)
-          ad_registration_2 = create(:registration, :has_required_data, contact_email: WasteCarriersEngine.configuration.assisted_digital_email)
+          ad_registration1 = create(:registration, :has_required_data, contact_email: nil)
+          ad_registration2 = create(:registration, :has_required_data, contact_email: WasteCarriersEngine.configuration.assisted_digital_email)
           non_ad_registration = create(:registration, :has_required_data)
 
           result = described_class.not_assisted_digital

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -54,7 +54,7 @@ module WasteCarriersEngine
       end
 
       describe ".not_assisted_digital" do
-        it "returns registrations that are not assited digital" do
+        it "returns registrations that are not assisted digital" do
           ad_registration1 = create(:registration, :has_required_data, contact_email: nil)
           ad_registration2 = create(:registration, :has_required_data, contact_email: WasteCarriersEngine.configuration.assisted_digital_email)
           non_ad_registration = create(:registration, :has_required_data)

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -62,8 +62,8 @@ module WasteCarriersEngine
           result = described_class.not_assisted_digital
 
           expect(result).to include(non_ad_registration)
-          expect(result).to_not include(ad_registration_1)
-          expect(result).to_not include(ad_registration_2)
+          expect(result).to_not include(ad_registration1)
+          expect(result).to_not include(ad_registration2)
         end
       end
 


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-470

This adds a scope to filter out AD registrations, which we consider to be the ones without a contact email or with a contact email that is equal to the default AD email from ENV variables