### PR TITLE
Revert "Add scope to filter out ad registrations"

### DIFF
--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -37,12 +37,6 @@ module WasteCarriersEngine
       where(:expires_on.gte => date)
     end
 
-    def self.not_assisted_digital
-      assisted_digital_email = WasteCarriersEngine.configuration.assisted_digital_email
-
-      where("contactEmail" => { :$nin => [nil, assisted_digital_email] })
-    end
-
     alias pending_manual_conviction_check? conviction_check_required?
     alias pending_payment? unpaid_balance?
 

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -53,20 +53,6 @@ module WasteCarriersEngine
         end
       end
 
-      describe ".not_assisted_digital" do
-        it "returns registrations that are not assisted digital" do
-          ad_registration1 = create(:registration, :has_required_data, contact_email: nil)
-          ad_registration2 = create(:registration, :has_required_data, contact_email: WasteCarriersEngine.configuration.assisted_digital_email)
-          non_ad_registration = create(:registration, :has_required_data)
-
-          result = described_class.not_assisted_digital
-
-          expect(result).to include(non_ad_registration)
-          expect(result).to_not include(ad_registration1)
-          expect(result).to_not include(ad_registration2)
-        end
-      end
-
       describe ".in_grace_window" do
         it "returns registrations whose expired date is in the grace window" do
           allow(Rails.configuration).to receive(:grace_window).and_return(3)


### PR DESCRIPTION
Reverts DEFRA/waste-carriers-engine#818

I have just realised that this is already implemented as part of 470 in the back office, and hence we actually don't need this scope here 🤦 