### PR TITLE
Split up 'renewal received' page

### DIFF
--- a/app/controllers/waste_carriers_engine/renewal_received_pending_conviction_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/renewal_received_pending_conviction_forms_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class RenewalReceivedPendingConvictionFormsController < FormsController
+    helper JourneyLinksHelper
+
+    def new
+      super(RenewalReceivedPendingConvictionForm, "renewal_received_pending_conviction_form")
+    end
+
+    # Overwrite create and go_back as you shouldn't be able to submit or go back
+    def create; end
+
+    def go_back; end
+  end
+end

--- a/app/controllers/waste_carriers_engine/renewal_received_pending_payment_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/renewal_received_pending_payment_forms_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class RenewalReceivedPendingPaymentFormsController < FormsController
+    helper JourneyLinksHelper
+
+    def new
+      super(RenewalReceivedPendingPaymentForm, "renewal_received_pending_payment_form")
+    end
+
+    # Overwrite create and go_back as you shouldn't be able to submit or go back
+    def create; end
+
+    def go_back; end
+  end
+end

--- a/app/forms/waste_carriers_engine/renewal_received_pending_conviction_form.rb
+++ b/app/forms/waste_carriers_engine/renewal_received_pending_conviction_form.rb
@@ -4,19 +4,8 @@ module WasteCarriersEngine
   class RenewalReceivedPendingConvictionForm < BaseForm
     include CannotSubmit
 
-    attr_accessor :contact_email, :pending_convictions_check, :pending_payment, :pending_worldpay_payment
-
     def self.can_navigate_flexibly?
       false
-    end
-
-    def initialize(transient_registration)
-      super
-
-      self.contact_email = transient_registration.contact_email
-      self.pending_convictions_check = transient_registration.conviction_check_required?
-      self.pending_payment = transient_registration.pending_payment?
-      self.pending_worldpay_payment = transient_registration.pending_worldpay_payment?
     end
   end
 end

--- a/app/forms/waste_carriers_engine/renewal_received_pending_conviction_form.rb
+++ b/app/forms/waste_carriers_engine/renewal_received_pending_conviction_form.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module WasteCarriersEngine
-  class RenewalReceivedForm < BaseForm
+  class RenewalReceivedPendingConvictionForm < BaseForm
     include CannotSubmit
 
     attr_accessor :contact_email, :pending_convictions_check, :pending_payment, :pending_worldpay_payment

--- a/app/forms/waste_carriers_engine/renewal_received_pending_payment_form.rb
+++ b/app/forms/waste_carriers_engine/renewal_received_pending_payment_form.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class RenewalReceivedPendingPaymentForm < BaseForm
+    include CannotSubmit
+
+    attr_accessor :contact_email, :pending_convictions_check, :pending_payment, :pending_worldpay_payment
+
+    def self.can_navigate_flexibly?
+      false
+    end
+
+    def initialize(transient_registration)
+      super
+
+      self.contact_email = transient_registration.contact_email
+      self.pending_convictions_check = transient_registration.conviction_check_required?
+      self.pending_payment = transient_registration.pending_payment?
+      self.pending_worldpay_payment = transient_registration.pending_worldpay_payment?
+    end
+  end
+end

--- a/app/forms/waste_carriers_engine/renewal_received_pending_payment_form.rb
+++ b/app/forms/waste_carriers_engine/renewal_received_pending_payment_form.rb
@@ -4,19 +4,10 @@ module WasteCarriersEngine
   class RenewalReceivedPendingPaymentForm < BaseForm
     include CannotSubmit
 
-    attr_accessor :contact_email, :pending_convictions_check, :pending_payment, :pending_worldpay_payment
+    delegate :pending_payment?, :pending_worldpay_payment?, to: :transient_registration
 
     def self.can_navigate_flexibly?
       false
-    end
-
-    def initialize(transient_registration)
-      super
-
-      self.contact_email = transient_registration.contact_email
-      self.pending_convictions_check = transient_registration.conviction_check_required?
-      self.pending_payment = transient_registration.pending_payment?
-      self.pending_worldpay_payment = transient_registration.pending_worldpay_payment?
     end
   end
 end

--- a/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
@@ -275,7 +275,7 @@ module WasteCarriersEngine
                       after: :set_metadata_route
 
           transitions from: :confirm_bank_transfer_form,
-                      to: :renewal_received_form,
+                      to: :renewal_received_pending_payment_form,
                       success: :send_renewal_received_email,
                       # TODO: This don't get triggered if in the `success`
                       # callback block, hence we went for `after`

--- a/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
@@ -59,6 +59,7 @@ module WasteCarriersEngine
 
         state :renewal_complete_form
         state :renewal_received_form
+        state :renewal_received_pending_payment_form
 
         state :cannot_renew_lower_tier_form
         state :cannot_renew_type_change_form

--- a/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
@@ -58,7 +58,7 @@ module WasteCarriersEngine
         state :confirm_bank_transfer_form
 
         state :renewal_complete_form
-        state :renewal_received_form
+        state :renewal_received_pending_conviction_form
         state :renewal_received_pending_payment_form
 
         state :cannot_renew_lower_tier_form
@@ -261,8 +261,16 @@ module WasteCarriersEngine
                       to: :confirm_bank_transfer_form
 
           transitions from: :worldpay_form,
-                      to: :renewal_received_form,
-                      if: :pending_worldpay_payment_or_convictions_check?,
+                      to: :renewal_received_pending_payment_form,
+                      if: :pending_worldpay_payment?,
+                      success: :send_renewal_received_email,
+                      # TODO: This don't get triggered if in the `success`
+                      # callback block, hence we went for `after`
+                      after: :set_metadata_route
+
+          transitions from: :worldpay_form,
+                      to: :renewal_received_pending_conviction_form,
+                      if: :conviction_check_required?,
                       success: :send_renewal_received_email,
                       # TODO: This don't get triggered if in the `success`
                       # callback block, hence we went for `after`
@@ -557,10 +565,6 @@ module WasteCarriersEngine
 
     def paying_by_card?
       temp_payment_method == "card"
-    end
-
-    def pending_worldpay_payment_or_convictions_check?
-      pending_worldpay_payment? || conviction_check_required?
     end
 
     def send_renewal_received_email

--- a/app/views/waste_carriers_engine/renewal_received_pending_conviction_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/renewal_received_pending_conviction_forms/new.html.erb
@@ -20,26 +20,16 @@
         </p>
       </div>
 
-      <p><%= t(".paragraph_1", email: @renewal_received_pending_conviction_form.contact_email) %></p>
+      <p><%= t(".paragraph_1", email: @renewal_received_pending_conviction_form.transient_registration.contact_email) %></p>
 
-      <% if @renewal_received_pending_conviction_form.pending_worldpay_payment %>
-        <h2 class="heading-medium"><%= t(".processing_payment_subheading") %></h2>
-        <p><%= t(".processing_payment_paragraph_1") %></p>
-      <% elsif @renewal_received_pending_conviction_form.pending_payment %>
-        <h2 class="heading-medium"><%= t(".awaiting_payment_subheading") %></h2>
-        <p><%= t(".awaiting_payment_paragraph_1") %></p>
-        <p><%= t(".awaiting_payment_paragraph_2") %></p>
-      <% end %>
-
-      <% if @renewal_received_pending_conviction_form.pending_convictions_check %>
-        <h2 class="heading-medium"><%= t(".conviction_check_subheading") %></h2>
-        <p><%= t(".conviction_check_paragraph_1") %></p>
-      <% end %>
+      <h2 class="heading-medium"><%= t(".subheading") %></h2>
 
       <p><%= t(".paragraph_2") %></p>
 
+      <p><%= t(".paragraph_3") %></p>
+
       <div class="panel panel-border-wide">
-        <p><%= t(".paragraph_3") %></p>
+        <p><%= t(".paragraph_4") %></p>
       </div>
 
       <p><%= link_to(t(".survey_link_text"), t("layouts.application.feedback_url")) %> <%= t(".survey_link_hint") %></p>

--- a/app/views/waste_carriers_engine/renewal_received_pending_conviction_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/renewal_received_pending_conviction_forms/new.html.erb
@@ -1,37 +1,37 @@
 <div class="column-two-thirds">
-  <% if @renewal_received_form.errors.any? %>
+  <% if @renewal_received_pending_conviction_form.errors.any? %>
 
     <h1 class="heading-large"><%= t(".error_heading") %></h1>
 
-    <% @renewal_received_form.errors.full_messages.each do |message| %>
+    <% @renewal_received_pending_conviction_form.errors.full_messages.each do |message| %>
       <li><%= message %></li>
     <% end %>
 
   <% else %>
-    <%= form_for(@renewal_received_form) do |f| %>
-      <%= render("waste_carriers_engine/shared/errors", object: @renewal_received_form) %>
+    <%= form_for(@renewal_received_pending_conviction_form) do |f| %>
+      <%= render("waste_carriers_engine/shared/errors", object: @renewal_received_pending_conviction_form) %>
 
       <div class="govuk-box-highlight">
         <h1 class="heading-xlarge"><%= t(".heading") %></h1>
         <p class="font-large">
           <%= t(".highlight_text") %>
           <br>
-          <span class="strong" id="reg_identifier"><%= @renewal_received_form.reg_identifier %></span>
+          <span class="strong" id="reg_identifier"><%= @renewal_received_pending_conviction_form.reg_identifier %></span>
         </p>
       </div>
 
-      <p><%= t(".paragraph_1", email: @renewal_received_form.contact_email) %></p>
+      <p><%= t(".paragraph_1", email: @renewal_received_pending_conviction_form.contact_email) %></p>
 
-      <% if @renewal_received_form.pending_worldpay_payment %>
+      <% if @renewal_received_pending_conviction_form.pending_worldpay_payment %>
         <h2 class="heading-medium"><%= t(".processing_payment_subheading") %></h2>
         <p><%= t(".processing_payment_paragraph_1") %></p>
-      <% elsif @renewal_received_form.pending_payment %>
+      <% elsif @renewal_received_pending_conviction_form.pending_payment %>
         <h2 class="heading-medium"><%= t(".awaiting_payment_subheading") %></h2>
         <p><%= t(".awaiting_payment_paragraph_1") %></p>
         <p><%= t(".awaiting_payment_paragraph_2") %></p>
       <% end %>
 
-      <% if @renewal_received_form.pending_convictions_check %>
+      <% if @renewal_received_pending_conviction_form.pending_convictions_check %>
         <h2 class="heading-medium"><%= t(".conviction_check_subheading") %></h2>
         <p><%= t(".conviction_check_paragraph_1") %></p>
       <% end %>
@@ -44,7 +44,7 @@
 
       <p><%= link_to(t(".survey_link_text"), t("layouts.application.feedback_url")) %> <%= t(".survey_link_hint") %></p>
 
-      <%= link_to t(".next_button"), renewal_finished_link(reg_identifier: @renewal_received_form.reg_identifier), class: 'button' %>
+      <%= link_to t(".next_button"), renewal_finished_link(reg_identifier: @renewal_received_pending_conviction_form.reg_identifier), class: 'button' %>
     <% end %>
 
   <% end %>

--- a/app/views/waste_carriers_engine/renewal_received_pending_conviction_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/renewal_received_pending_conviction_forms/new.html.erb
@@ -3,9 +3,11 @@
 
     <h1 class="heading-large"><%= t(".error_heading") %></h1>
 
-    <% @renewal_received_pending_conviction_form.errors.full_messages.each do |message| %>
-      <li><%= message %></li>
-    <% end %>
+    <ul>
+      <% @renewal_received_pending_conviction_form.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
 
   <% else %>
     <%= form_for(@renewal_received_pending_conviction_form) do |f| %>

--- a/app/views/waste_carriers_engine/renewal_received_pending_payment_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/renewal_received_pending_payment_forms/new.html.erb
@@ -3,9 +3,11 @@
 
     <h1 class="heading-large"><%= t(".error_heading") %></h1>
 
-    <% @renewal_received_pending_payment_form.errors.full_messages.each do |message| %>
-      <li><%= message %></li>
-    <% end %>
+    <ul>
+      <% @renewal_received_pending_payment_form.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
 
   <% else %>
     <%= form_for(@renewal_received_pending_payment_form) do |f| %>

--- a/app/views/waste_carriers_engine/renewal_received_pending_payment_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/renewal_received_pending_payment_forms/new.html.erb
@@ -20,20 +20,15 @@
         </p>
       </div>
 
-      <p><%= t(".paragraph_1", email: @renewal_received_pending_payment_form.contact_email) %></p>
+      <p><%= t(".paragraph_1", email: @renewal_received_pending_payment_form.transient_registration.contact_email) %></p>
 
-      <% if @renewal_received_pending_payment_form.pending_worldpay_payment %>
+      <% if @renewal_received_pending_payment_form.pending_worldpay_payment? %>
         <h2 class="heading-medium"><%= t(".processing_payment_subheading") %></h2>
         <p><%= t(".processing_payment_paragraph_1") %></p>
-      <% elsif @renewal_received_pending_payment_form.pending_payment %>
+      <% elsif @renewal_received_pending_payment_form.pending_payment? %>
         <h2 class="heading-medium"><%= t(".awaiting_payment_subheading") %></h2>
         <p><%= t(".awaiting_payment_paragraph_1") %></p>
         <p><%= t(".awaiting_payment_paragraph_2") %></p>
-      <% end %>
-
-      <% if @renewal_received_pending_payment_form.pending_convictions_check %>
-        <h2 class="heading-medium"><%= t(".conviction_check_subheading") %></h2>
-        <p><%= t(".conviction_check_paragraph_1") %></p>
       <% end %>
 
       <p><%= t(".paragraph_2") %></p>

--- a/app/views/waste_carriers_engine/renewal_received_pending_payment_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/renewal_received_pending_payment_forms/new.html.erb
@@ -1,0 +1,51 @@
+<div class="column-two-thirds">
+  <% if @renewal_received_pending_payment_form.errors.any? %>
+
+    <h1 class="heading-large"><%= t(".error_heading") %></h1>
+
+    <% @renewal_received_pending_payment_form.errors.full_messages.each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+
+  <% else %>
+    <%= form_for(@renewal_received_pending_payment_form) do |f| %>
+      <%= render("waste_carriers_engine/shared/errors", object: @renewal_received_pending_payment_form) %>
+
+      <div class="govuk-box-highlight">
+        <h1 class="heading-xlarge"><%= t(".heading") %></h1>
+        <p class="font-large">
+          <%= t(".highlight_text") %>
+          <br>
+          <span class="strong" id="reg_identifier"><%= @renewal_received_pending_payment_form.reg_identifier %></span>
+        </p>
+      </div>
+
+      <p><%= t(".paragraph_1", email: @renewal_received_pending_payment_form.contact_email) %></p>
+
+      <% if @renewal_received_pending_payment_form.pending_worldpay_payment %>
+        <h2 class="heading-medium"><%= t(".processing_payment_subheading") %></h2>
+        <p><%= t(".processing_payment_paragraph_1") %></p>
+      <% elsif @renewal_received_pending_payment_form.pending_payment %>
+        <h2 class="heading-medium"><%= t(".awaiting_payment_subheading") %></h2>
+        <p><%= t(".awaiting_payment_paragraph_1") %></p>
+        <p><%= t(".awaiting_payment_paragraph_2") %></p>
+      <% end %>
+
+      <% if @renewal_received_pending_payment_form.pending_convictions_check %>
+        <h2 class="heading-medium"><%= t(".conviction_check_subheading") %></h2>
+        <p><%= t(".conviction_check_paragraph_1") %></p>
+      <% end %>
+
+      <p><%= t(".paragraph_2") %></p>
+
+      <div class="panel panel-border-wide">
+        <p><%= t(".paragraph_3") %></p>
+      </div>
+
+      <p><%= link_to(t(".survey_link_text"), t("layouts.application.feedback_url")) %> <%= t(".survey_link_hint") %></p>
+
+      <%= link_to t(".next_button"), renewal_finished_link(reg_identifier: @renewal_received_pending_payment_form.reg_identifier), class: 'button' %>
+    <% end %>
+
+  <% end %>
+</div>

--- a/config/locales/forms/renewal_received_pending_conviction_forms/en.yml
+++ b/config/locales/forms/renewal_received_pending_conviction_forms/en.yml
@@ -1,6 +1,6 @@
 en:
   waste_carriers_engine:
-    renewal_received_forms:
+    renewal_received_pending_conviction_forms:
       new:
         title: Renewal application received
         heading: Application received
@@ -22,7 +22,7 @@ en:
   activemodel:
     errors:
       models:
-        waste_carriers_engine/renewal_received_form:
+        waste_carriers_engine/renewal_received_pending_conviction_form:
           attributes:
             reg_identifier:
               invalid_format: "The registration ID is not in a valid format"

--- a/config/locales/forms/renewal_received_pending_conviction_forms/en.yml
+++ b/config/locales/forms/renewal_received_pending_conviction_forms/en.yml
@@ -6,15 +6,10 @@ en:
         heading: Application received
         highlight_text: "Your registration number is still"
         paragraph_1: "We have sent a confirmation email to %{email}."
-        processing_payment_subheading: "Processing your payment"
-        processing_payment_paragraph_1: We are currently processing your payment and will let you know when it has been received.
-        awaiting_payment_subheading: "Next step: pay the renewal charge"
-        awaiting_payment_paragraph_1: We've sent an email telling you how to pay the charge.
-        awaiting_payment_paragraph_2: Please allow 5 working days for your payment to reach us.
-        conviction_check_subheading: What happens next
-        conviction_check_paragraph_1: We'll check your details and let you know whether your application has been successful. We aim to do this within 10 working days.
-        paragraph_2: Your registration will not be renewed until we have confirmed your registration.
-        paragraph_3: Call our helpline on 03708 506 506 if you have any questions about your renewal.
+        subheading: What happens next
+        paragraph_2: We'll check your details and let you know whether your application has been successful. We aim to do this within 10 working days.
+        paragraph_3: Your registration will not be renewed until we have confirmed your registration.
+        paragraph_4: Call our helpline on 03708 506 506 if you have any questions about your renewal.
         survey_link_text: What do you think of this service?
         survey_link_hint: (takes 30 seconds)
         error_heading: Something is wrong

--- a/config/locales/forms/renewal_received_pending_payment_forms/en.yml
+++ b/config/locales/forms/renewal_received_pending_payment_forms/en.yml
@@ -1,0 +1,30 @@
+en:
+  waste_carriers_engine:
+    renewal_received_pending_payment_forms:
+      new:
+        title: Renewal application received
+        heading: Application received
+        highlight_text: "Your registration number is still"
+        paragraph_1: "We have sent a confirmation email to %{email}."
+        processing_payment_subheading: "Processing your payment"
+        processing_payment_paragraph_1: We are currently processing your payment and will let you know when it has been received.
+        awaiting_payment_subheading: "Next step: pay the renewal charge"
+        awaiting_payment_paragraph_1: We've sent an email telling you how to pay the charge.
+        awaiting_payment_paragraph_2: Please allow 5 working days for your payment to reach us.
+        conviction_check_subheading: What happens next
+        conviction_check_paragraph_1: We'll check your details and let you know whether your application has been successful. We aim to do this within 10 working days.
+        paragraph_2: Your registration will not be renewed until we have confirmed your registration.
+        paragraph_3: Call our helpline on 03708 506 506 if you have any questions about your renewal.
+        survey_link_text: What do you think of this service?
+        survey_link_hint: (takes 30 seconds)
+        error_heading: Something is wrong
+        next_button: Finished
+  activemodel:
+    errors:
+      models:
+        waste_carriers_engine/renewal_received_pending_payment_form:
+          attributes:
+            reg_identifier:
+              invalid_format: "The registration ID is not in a valid format"
+              no_registration: "There is no registration matching this ID"
+              renewal_in_progress: "This renewal is already in progress"

--- a/config/locales/forms/renewal_received_pending_payment_forms/en.yml
+++ b/config/locales/forms/renewal_received_pending_payment_forms/en.yml
@@ -11,8 +11,6 @@ en:
         awaiting_payment_subheading: "Next step: pay the renewal charge"
         awaiting_payment_paragraph_1: We've sent an email telling you how to pay the charge.
         awaiting_payment_paragraph_2: Please allow 5 working days for your payment to reach us.
-        conviction_check_subheading: What happens next
-        conviction_check_paragraph_1: We'll check your details and let you know whether your application has been successful. We aim to do this within 10 working days.
         paragraph_2: Your registration will not be renewed until we have confirmed your registration.
         paragraph_3: Call our helpline on 03708 506 506 if you have any questions about your renewal.
         survey_link_text: What do you think of this service?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -586,6 +586,11 @@ WasteCarriersEngine::Engine.routes.draw do
               path: "renewal-received",
               path_names: { new: "" }
 
+    resources :renewal_received_pending_payment_forms,
+              only: %i[new create],
+              path: "renewal-received-pending-payment",
+              path_names: { new: "" }
+
     resources :cannot_renew_lower_tier_forms,
               only: %i[new create],
               path: "cannot-renew-lower-tier",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -581,7 +581,7 @@ WasteCarriersEngine::Engine.routes.draw do
               path: "renewal-complete",
               path_names: { new: "" }
 
-    resources :renewal_received_forms,
+    resources :renewal_received_pending_conviction_forms,
               only: %i[new create],
               path: "renewal-received",
               path_names: { new: "" }

--- a/spec/factories/forms/renewal_received_form.rb
+++ b/spec/factories/forms/renewal_received_form.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-FactoryBot.define do
-  factory :renewal_received_form, class: WasteCarriersEngine::RenewalReceivedForm do
-    trait :has_required_data do
-      initialize_with { new(create(:renewing_registration, :has_required_data, workflow_state: "renewal_received_form")) }
-    end
-  end
-end

--- a/spec/forms/waste_carriers_engine/renewal_received_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/renewal_received_forms_spec.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-require "rails_helper"
-
-module WasteCarriersEngine
-  RSpec.describe RenewalReceivedForm, type: :model do
-  end
-end

--- a/spec/models/waste_carriers_engine/renewing_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_spec.rb
@@ -19,7 +19,7 @@ module WasteCarriersEngine
         end
       end
 
-      context "when transitioning from confirm_bank_transfer_form to renewal_received_form succesfully" do
+      context "when transitioning from confirm_bank_transfer_form to renewal_received_pending_payment_form successfully" do
         it "set the transient registration metadata route" do
           expect(renewing_registration).to receive(:set_metadata_route).once
 
@@ -28,20 +28,22 @@ module WasteCarriersEngine
         end
       end
 
-      context "when transitioning from worldpay_form to renewal_complete_form succesfully" do
+      context "when transitioning from worldpay_form to renewal_complete_form successfully" do
         it "set the transient registration metadata route" do
           expect(renewing_registration).to receive(:set_metadata_route).once
-          expect(renewing_registration).to receive(:pending_worldpay_payment_or_convictions_check?).and_return(false)
+          expect(renewing_registration).to receive(:pending_worldpay_payment?).and_return(false)
+          expect(renewing_registration).to receive(:conviction_check_required?).and_return(false)
 
           renewing_registration.update_attributes(workflow_state: :worldpay_form)
           renewing_registration.next
         end
       end
 
-      context "when transitioning from worldpay_form to renewal_received_form succesfully" do
+      context "when transitioning from worldpay_form to renewal_received_pending_conviction_form succesfully" do
         it "set the transient registration metadata route" do
           expect(renewing_registration).to receive(:set_metadata_route).once
-          expect(renewing_registration).to receive(:pending_worldpay_payment_or_convictions_check?).and_return(true)
+          expect(renewing_registration).to receive(:pending_worldpay_payment?).and_return(false)
+          expect(renewing_registration).to receive(:conviction_check_required?).and_return(true)
 
           renewing_registration.update_attributes(workflow_state: :worldpay_form)
           renewing_registration.next

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/confirm_bank_transfer_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/confirm_bank_transfer_form_spec.rb
@@ -14,7 +14,7 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":confirm_bank_transfer_form state transitions" do
         context "on next" do
-          include_examples "has next transition", next_state: "renewal_received_form"
+          include_examples "has next transition", next_state: "renewal_received_pending_payment_form"
 
           it "sends a confirmation email after the 'next' event" do
             expect { subject.next! }.to change { ActionMailer::Base.deliveries.count }.by(1)

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/renewal_received_pending_conviction_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/renewal_received_pending_conviction_form_spec.rb
@@ -6,7 +6,7 @@ module WasteCarriersEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
       it_behaves_like "a fixed final state",
-                      current_state: :renewal_received_form,
+                      current_state: :renewal_received_pending_conviction_form,
                       factory: :renewing_registration
     end
   end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/renewal_received_pending_payment_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/renewal_received_pending_payment_form_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe RenewingRegistration, type: :model do
+    describe "#workflow_state" do
+      it_behaves_like "a fixed final state",
+                      current_state: :renewal_received_pending_payment_form,
+                      factory: :renewing_registration
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/worldpay_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/worldpay_form_spec.rb
@@ -26,6 +26,8 @@ module WasteCarriersEngine
                 allow(subject).to receive(:pending_worldpay_payment?).and_return(false)
               end
 
+              include_examples "has next transition", next_state: "renewal_complete_form"
+
               it "does not send a confirmation email after the 'next' event" do
                 expect { subject.next! }.to_not change { ActionMailer::Base.deliveries.count }
               end
@@ -36,7 +38,7 @@ module WasteCarriersEngine
                 allow(subject).to receive(:pending_worldpay_payment?).and_return(true)
               end
 
-              include_examples "has next transition", next_state: "renewal_received_form"
+              include_examples "has next transition", next_state: "renewal_received_pending_payment_form"
 
               it "sends a confirmation email after the 'next' event" do
                 expect { subject.next! }.to change { ActionMailer::Base.deliveries.count }.by(1)
@@ -49,7 +51,7 @@ module WasteCarriersEngine
               allow(subject).to receive(:conviction_check_required?).and_return(true)
             end
 
-            include_examples "has next transition", next_state: "renewal_received_form"
+            include_examples "has next transition", next_state: "renewal_received_pending_conviction_form"
 
             it "sends a confirmation email after the 'next' event" do
               expect { subject.next! }.to change { ActionMailer::Base.deliveries.count }.by(1)

--- a/spec/requests/waste_carriers_engine/renewal_received_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/renewal_received_forms_spec.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require "rails_helper"
-
-module WasteCarriersEngine
-  RSpec.describe "RenewalReceivedForms", type: :request do
-    include_examples "GET locked-in form", "renewal_received_form"
-  end
-end

--- a/spec/requests/waste_carriers_engine/renewal_received_pending_conviction_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/renewal_received_pending_conviction_forms_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "RenewalReceivedPendingConvictionForms", type: :request do
+    include_examples "GET locked-in form", "renewal_received_pending_conviction_form"
+  end
+end

--- a/spec/requests/waste_carriers_engine/renewal_received_pending_payment_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/renewal_received_pending_payment_forms_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "RenewalReceivedPendingPaymentForms", type: :request do
+    include_examples "GET locked-in form", "renewal_received_pending_payment_form"
+  end
+end

--- a/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
@@ -134,7 +134,7 @@ module WasteCarriersEngine
                 transient_registration.conviction_sign_offs = [build(:conviction_sign_off)]
               end
 
-              it "updates the transient registration metadata attributes from application configuration and redirects to renewal_received_form" do
+              it "updates the transient registration metadata attributes from application configuration and redirects to renewal_received_pending_conviction_form" do
                 allow(Rails.configuration).to receive(:metadata_route).and_return("ASSISTED_DIGITAL")
 
                 expect(transient_registration.reload.metaData.route).to be_nil
@@ -142,7 +142,7 @@ module WasteCarriersEngine
                 get success_worldpay_forms_path(token), params
 
                 expect(transient_registration.reload.metaData.route).to eq("ASSISTED_DIGITAL")
-                expect(response).to redirect_to(new_renewal_received_form_path(token))
+                expect(response).to redirect_to(new_renewal_received_pending_conviction_form_path(token))
               end
 
               context "when the mailer fails" do
@@ -214,9 +214,9 @@ module WasteCarriersEngine
               allow_any_instance_of(RenewingRegistration).to receive(:pending_worldpay_payment?).and_return(true)
             end
 
-            it "redirects to renewal_received_form" do
+            it "redirects to renewal_received_pending_payment_form" do
               get pending_worldpay_forms_path(token), params
-              expect(response).to redirect_to(new_renewal_received_form_path(token))
+              expect(response).to redirect_to(new_renewal_received_pending_payment_form_path(token))
             end
           end
 


### PR DESCRIPTION
Currently, if a user renews but the application has a pending payment or convictions check, they will be sent to the renewal received page.

This is a single page, but with a lot of conditional logic about what to display depending on the reason for them seeing it.

In new registrations, we just have two separate pages and everything is a lot clearer.

In preparation for updating the bank transfer info for the 'pending payment' version of this page, this PR splits the page into two separate controllers, routes, views, etc.