### PR TITLE
Add bank transfer details to renewal pending payment page

### DIFF
--- a/app/views/waste_carriers_engine/renewal_received_pending_payment_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/renewal_received_pending_payment_forms/new.html.erb
@@ -22,24 +22,52 @@
         </p>
       </div>
 
-      <p><%= t(".paragraph_1", email: @renewal_received_pending_payment_form.transient_registration.contact_email) %></p>
-
       <% if @renewal_received_pending_payment_form.pending_worldpay_payment? %>
-        <h2 class="heading-medium"><%= t(".processing_payment_subheading") %></h2>
-        <p><%= t(".processing_payment_paragraph_1") %></p>
-      <% elsif @renewal_received_pending_payment_form.pending_payment? %>
-        <h2 class="heading-medium"><%= t(".awaiting_payment_subheading") %></h2>
-        <p><%= t(".awaiting_payment_paragraph_1") %></p>
-        <p><%= t(".awaiting_payment_paragraph_2") %></p>
+
+        <h2 class="heading-medium"><%= t(".processing_worldpay_payment.subheading") %></h2>
+
+        <p><%= t(".processing_worldpay_payment.paragraph_1",
+                 email: @renewal_received_pending_payment_form.transient_registration.contact_email) %></p>
+
+        <p><%= t(".processing_worldpay_payment.paragraph_2") %></p>
+
+        <div class="panel panel-border-wide">
+          <p><%= t(".processing_worldpay_payment.paragraph_3") %></p>
+        </div>
+
+      <% else %>
+
+        <div class="panel panel-border-wide">
+          <%= t(".bank_transfer.panel_text") %>
+        </div>
+
+        <h2 class="heading-medium"><%= t(".bank_transfer.subheading") %></h2>
+
+        <%= render("waste_carriers_engine/shared/bank_transfer_details",
+            reg_identifier: @renewal_received_pending_payment_form.reg_identifier,
+            payment_due: @renewal_received_pending_payment_form.transient_registration.finance_details.balance) %>
+
+        <%= render("waste_carriers_engine/shared/bank_transfer_email_details",
+            reg_identifier: @renewal_received_pending_payment_form.reg_identifier,
+            amount: @renewal_received_pending_payment_form.transient_registration.finance_details.balance) %>
+
+        <p><%= t(".bank_transfer.paragraph_1",
+                 email: @renewal_received_pending_payment_form.transient_registration.contact_email) %></p>
+        <p><%= t(".bank_transfer.paragraph_2") %></p>
+
+        <ul class="list list-bullet">
+          <% t(".bank_transfer.list_1").each do |list_item| %>
+            <li><%= list_item %></li>
+          <% end %>
+        </ul>
+
       <% end %>
 
-      <p><%= t(".paragraph_2") %></p>
+      <%= render "shared/contact_environment_agency" %>
 
-      <div class="panel panel-border-wide">
-        <p><%= t(".paragraph_3") %></p>
-      </div>
+      <%= render "shared/registration_checks" %>
 
-      <p><%= link_to(t(".survey_link_text"), t("layouts.application.feedback_url")) %> <%= t(".survey_link_hint") %></p>
+      <%= render "shared/link_to_survey" %>
 
       <%= link_to t(".next_button"), renewal_finished_link(reg_identifier: @renewal_received_pending_payment_form.reg_identifier), class: 'button' %>
     <% end %>

--- a/config/locales/forms/renewal_received_pending_payment_forms/en.yml
+++ b/config/locales/forms/renewal_received_pending_payment_forms/en.yml
@@ -5,16 +5,19 @@ en:
         title: Renewal application received
         heading: Application received
         highlight_text: "Your registration number is still"
-        paragraph_1: "We have sent a confirmation email to %{email}."
-        processing_payment_subheading: "Processing your payment"
-        processing_payment_paragraph_1: We are currently processing your payment and will let you know when it has been received.
-        awaiting_payment_subheading: "Next step: pay the renewal charge"
-        awaiting_payment_paragraph_1: We've sent an email telling you how to pay the charge.
-        awaiting_payment_paragraph_2: Please allow 5 working days for your payment to reach us.
-        paragraph_2: Your registration will not be renewed until we have confirmed your registration.
-        paragraph_3: Call our helpline on 03708 506 506 if you have any questions about your renewal.
-        survey_link_text: What do you think of this service?
-        survey_link_hint: (takes 30 seconds)
+        processing_worldpay_payment:
+          subheading: "Processing your payment"
+          paragraph_1: "We have sent a confirmation email to %{email}."
+          paragraph_2: We are currently processing your payment and will let you know when it has been received.
+          paragraph_3: Your registration will not be renewed until we have confirmed your registration.
+        bank_transfer:
+          panel_text: "We cannot register you until your payment clears."
+          subheading: "Next step: pay the renewal charge"
+          paragraph_1: "We’ve sent an email to %{email} with the payment details and instructions."
+          paragraph_2: "We will not register you until your payment clears."
+          list_1:
+            - "Please allow 5 working days for your payment to reach us."
+            - "Alternatively, contact us to pay by credit or debit card."
         error_heading: Something is wrong
         next_button: Finished
   activemodel:

--- a/spec/requests/waste_carriers_engine/renewal_received_pending_payment_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/renewal_received_pending_payment_forms_spec.rb
@@ -4,6 +4,52 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe "RenewalReceivedPendingPaymentForms", type: :request do
-    include_examples "GET locked-in form", "renewal_received_pending_payment_form"
+    describe "GET new_renewal_received_pending_payment_form_path" do
+      context "when a valid user is signed in" do
+        let(:user) { create(:user) }
+        before(:each) do
+          sign_in(user)
+        end
+
+        context "when no renewing registration exists" do
+          it "redirects to the invalid page" do
+            get new_renewal_received_pending_payment_form_path("wibblewobblejellyonaplate")
+
+            expect(response).to redirect_to(page_path("invalid"))
+          end
+        end
+
+        context "when a valid renewing registration exists" do
+          let(:transient_registration) do
+            create(
+              :renewing_registration,
+              :has_unpaid_balance,
+              workflow_state: "renewal_received_pending_payment_form",
+              account_email: user.email
+            )
+          end
+
+          context "when the workflow_state is correct" do
+            it "returns a 200 status and renders the :new template" do
+              get new_renewal_received_pending_payment_form_path(transient_registration.token)
+
+              expect(response).to have_http_status(200)
+              expect(response).to render_template(:new)
+            end
+          end
+
+          context "when the workflow_state is not correct" do
+            before do
+              transient_registration.update_attributes(workflow_state: "payment_summary_form")
+            end
+
+            it "redirects to the correct page" do
+              get new_renewal_received_pending_payment_form_path(transient_registration.token)
+              expect(response).to redirect_to(new_payment_summary_form_path(transient_registration.token))
+            end
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1005

Users expect the bank transfer details to be on the final confirmation screen once they have submitted their registration. This change adds the details to the confirmation page for renewals.

The PR also makes use of some of our shared partials that were created for the new registration journey.