### PR TITLE
Remove excessive sentence from reg payment pending page

### DIFF
--- a/app/views/waste_carriers_engine/registration_received_pending_payment_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/registration_received_pending_payment_forms/new.html.erb
@@ -18,7 +18,6 @@
       amount: @registration.finance_details.balance) %>
 
   <p><%= t(".paragraph_1", email: @registration.contact_email) %></p>
-  <p><%= t(".paragraph_2") %></p>
 
   <ul class="list list-bullet">
     <% t(".list_1").each do |list_item| %>

--- a/config/locales/forms/registration_received_pending_payment_forms/en.yml
+++ b/config/locales/forms/registration_received_pending_payment_forms/en.yml
@@ -7,7 +7,6 @@ en:
         highlight_text: "Then email us your registration number:"
         panel_text: "We cannot register you until your payment clears."
         paragraph_1: "We’ve sent an email to %{email} with the payment details and instructions."
-        paragraph_2: "We will not register you until your payment clears."
         list_1:
           - "You’re not legally entitled to operate as a waste carrier until we have received your payment and confirmed your registration."
           - "Please allow 5 working days for your payment to reach us."


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1005

After discussing the content of this page, we agreed to remove this sentence, as there are already multiple occasions where we tell users this information.