### PR TITLE
Make post-QA fixes to bank transfer confirmation pages

### DIFF
--- a/app/views/waste_carriers_engine/shared/_bank_transfer_details.html.erb
+++ b/app/views/waste_carriers_engine/shared/_bank_transfer_details.html.erb
@@ -9,22 +9,22 @@
     <tbody>
       <tr>
         <th scope="row"><%= t(".uk_payment_table.sort_code.label") %></th>
-        <td><%= t(".uk_payment_table.sort_code.value") %></td>
+        <td><span class="bold"><%= t(".uk_payment_table.sort_code.value") %></span></td>
       </tr>
       <tr>
         <th scope="row"><%= t(".uk_payment_table.account_number.label") %></th>
-        <td><%= t(".uk_payment_table.account_number.value") %></td>
+        <td><span class="bold"><%= t(".uk_payment_table.account_number.value") %></span></td>
       </tr>
       <tr>
         <th scope="row">
           <%= t(".uk_payment_table.reference_number.label") %>
           <span class="form-hint"><%= t(".uk_payment_table.reference_number.hint") %></span>
         </th>
-        <td><%= reg_identifier %></td>
+        <td><span class="bold"><%= reg_identifier %></span></td>
       </tr>
       <tr>
         <th scope="row"><%= t(".uk_payment_table.payment_due.label") %></th>
-        <td>£<%= display_pence_as_pounds(payment_due) %></td>
+        <td><span class="bold">£<%= display_pence_as_pounds(payment_due) %></span></td>
       </tr>
     </tbody>
   </table>
@@ -52,11 +52,11 @@
     <tbody>
       <tr>
         <th scope="row"><%= t(".send_confirmation.email_us.label") %></th>
-        <td><%= t(".send_confirmation.email_us.value") %></td>
+        <td><span class="bold"><%= t(".send_confirmation.email_us.value") %></span></td>
       </tr>
       <tr>
         <th scope="row"><%= t(".send_confirmation.payment_reference.label") %></th>
-        <td><%= reg_identifier %></td>
+        <td><span class="bold"><%= reg_identifier %></span></td>
       </tr>
     </tbody>
   </table>

--- a/config/locales/forms/registration_received_pending_payment_forms/en.yml
+++ b/config/locales/forms/registration_received_pending_payment_forms/en.yml
@@ -3,7 +3,7 @@ en:
     registration_received_pending_payment_forms:
       new:
         title: "You must now pay by bank transfer"
-        heading: "You must now pay by bank transfer."
+        heading: "You must now pay by bank transfer"
         highlight_text: "Then email us your registration number:"
         panel_text: "We cannot register you until your payment clears."
         paragraph_1: "We’ve sent an email to %{email} with the payment details and instructions."


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1005

This PR:

- bolds some text in the bank transfer info that should have been bolded
- removes the full stop from 'You must now pay by bank transfer.'