### PR TITLE
Add renew via magic link route and function

### DIFF
--- a/app/controllers/waste_carriers_engine/renews_controller.rb
+++ b/app/controllers/waste_carriers_engine/renews_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class RenewsController < ApplicationController
+    before_action :validate_renew_token
+
+    def new
+      # TODO - Should create a renewing registation
+      # @transient_registration = RenewingRegistration.create(reg_identifier: registration.reg_identifier)
+
+      # TODO - Should redirect to start renewing registration journey
+      render text: "OK - I am a renew via magic link page - renewing #{registration.reg_identifier}"
+    end
+
+    private
+
+    def validate_renew_token
+      # TODO
+      # return render(:invalid_magic_link, status: 404) unless registration.present?
+      # return render(:already_renewed) if registration.already_renewed?
+      # return render(:past_renewal_window) if registration.past_renewal_window?
+    end
+
+    def registration
+      @registration ||= Registration.find_by(renew_token: params[:token])
+    end
+  end
+end

--- a/app/controllers/waste_carriers_engine/renews_controller.rb
+++ b/app/controllers/waste_carriers_engine/renews_controller.rb
@@ -5,10 +5,10 @@ module WasteCarriersEngine
     before_action :validate_renew_token
 
     def new
-      # TODO - Should create a renewing registation
+      # TODO: Should create a renewing registation
       # @transient_registration = RenewingRegistration.create(reg_identifier: registration.reg_identifier)
 
-      # TODO - Should redirect to start renewing registration journey
+      # TODO: Should redirect to start renewing registration journey
       render text: "OK - I am a renew via magic link page - renewing #{registration.reg_identifier}"
     end
 

--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -31,6 +31,8 @@ module WasteCarriersEngine
     scope :upper_tier, -> { where(tier: UPPER_TIER) }
     scope :active_and_expired, -> { where("metaData.status" => { :$in => %w[ACTIVE EXPIRED] }) }
 
+    field :renew_token, type: String
+
     def self.in_grace_window
       date = Time.now.in_time_zone("London").beginning_of_day - Rails.configuration.grace_window.days + 1.day
 
@@ -42,6 +44,12 @@ module WasteCarriersEngine
 
     def can_start_renewal?
       renewable_tier? && renewable_status? && renewable_date?
+    end
+
+    def generate_renew_token!
+      self.renew_token = SecureTokenService.run
+
+      save!
     end
 
     def expire!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -630,6 +630,12 @@ WasteCarriersEngine::Engine.routes.draw do
       constraints: { status: /\d{3}/ },
       as: "error"
 
+  # Renew via magic link token
+  get "/renew/:token",
+    constraints: ->(_request) { WasteCarriersEngine::FeatureToggle.active?(:renew_via_magic_link) },
+    to: "renews#new",
+    as: "renew"
+
   # Static pages with HighVoltage
   resources :pages, only: [:show], controller: "pages"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -632,9 +632,9 @@ WasteCarriersEngine::Engine.routes.draw do
 
   # Renew via magic link token
   get "/renew/:token",
-    constraints: ->(_request) { WasteCarriersEngine::FeatureToggle.active?(:renew_via_magic_link) },
-    to: "renews#new",
-    as: "renew"
+      constraints: ->(_request) { WasteCarriersEngine::FeatureToggle.active?(:renew_via_magic_link) },
+      to: "renews#new",
+      as: "renew"
 
   # Static pages with HighVoltage
   resources :pages, only: [:show], controller: "pages"

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -96,6 +96,25 @@ module WasteCarriersEngine
       end
     end
 
+    describe "#generate_renew_token" do
+      let(:registration) { create(:registration, :has_required_data) }
+
+      it "generates a renew token and assign it to the registration every time it is called" do
+        old_renew_token = registration.renew_token
+
+        registration.generate_renew_token!
+
+        expect(registration.renew_token).to be_present
+        expect(registration.renew_token).to_not eq(old_renew_token)
+
+        old_renew_token = registration.renew_token
+
+        registration.generate_renew_token!
+
+        expect(registration.renew_token).to_not eq(old_renew_token)
+      end
+    end
+
     describe "#expire!" do
       it "update the registration status to expired" do
         registration = create(:registration, :is_active, :has_required_data)

--- a/spec/requests/waste_carriers_engine/renews_spec.rb
+++ b/spec/requests/waste_carriers_engine/renews_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "Renews", type: :request do
+    # TODO: Remove once renew via magic link is no longer behind a feature toggle
+    before(:each) { allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:renew_via_magic_link).and_return(true) }
+
+    describe "GET renew_path" do
+      context "when the renew token is valid" do
+        let(:registration) { create(:registration, :has_required_data) }
+
+        it "returns a 200 response" do
+          registration.generate_renew_token!
+
+          get renew_path(token: registration.renew_token)
+
+          expect(response).to have_http_status(200)
+          expect(response.body).to include(registration.reg_identifier)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-986

Add a renew_token field to the registration, along with a function that will generate a renew link.
Add routes to the magic link renewal process.