### PR TITLE
Add new confirmation screen for pending WorldPay payment

### DIFF
--- a/app/controllers/waste_carriers_engine/registration_received_pending_worldpay_payment_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/registration_received_pending_worldpay_payment_forms_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class RegistrationReceivedPendingWorldpayPaymentFormsController < FormsController
+    def new
+      return unless super(
+        RegistrationReceivedPendingWorldpayPaymentForm,
+        "registration_received_pending_worldpay_payment_form"
+      )
+
+      begin
+        @registration = RegistrationCompletionService.run(@transient_registration)
+      rescue StandardError => e
+        Airbrake.notify(e, reg_identifier: @transient_registration.reg_identifier)
+        Rails.logger.error e
+      end
+    end
+
+    # Overwrite create and go_back as you shouldn't be able to submit or go back
+    def create; end
+
+    def go_back; end
+  end
+end

--- a/app/forms/waste_carriers_engine/registration_received_pending_worldpay_payment_form.rb
+++ b/app/forms/waste_carriers_engine/registration_received_pending_worldpay_payment_form.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class RegistrationReceivedPendingWorldpayPaymentForm < BaseForm
+    include CannotSubmit
+
+    def self.can_navigate_flexibly?
+      false
+    end
+  end
+end

--- a/app/mailers/waste_carriers_engine/new_registration_mailer.rb
+++ b/app/mailers/waste_carriers_engine/new_registration_mailer.rb
@@ -13,6 +13,17 @@ module WasteCarriersEngine
            subject: I18n.t(".waste_carriers_engine.new_registration_mailer.registration_activated.subject"))
     end
 
+    def registration_pending_worldpay_payment(registration)
+      @registration = registration
+
+      subject = I18n.t(".waste_carriers_engine.new_registration_mailer.registration_pending_worldpay_payment.subject",
+                       reg_identifier: @registration.reg_identifier)
+
+      mail(to: @registration.contact_email,
+           from: from_email,
+           subject: subject)
+    end
+
     def registration_pending_payment(registration)
       @registration = registration
 

--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -109,6 +109,14 @@ module WasteCarriersEngine
         contact_email.blank? || contact_email == WasteCarriersEngine.configuration.assisted_digital_email
       end
 
+      def pending_worldpay_payment?
+        return false unless finance_details.present? &&
+                            finance_details.orders.present? &&
+                            finance_details.orders.first.present?
+
+        Order.valid_world_pay_status?(:pending, finance_details.orders.first.world_pay_status)
+      end
+
       # Some business types should not have a company_no
       def company_no_required?
         return false if overseas?

--- a/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
@@ -67,6 +67,7 @@ module WasteCarriersEngine
         state :registration_completed_form
         state :registration_received_pending_payment_form
         state :registration_received_pending_conviction_form
+        state :registration_received_pending_worldpay_payment_form
 
         # Transitions
         event :next do
@@ -295,6 +296,13 @@ module WasteCarriersEngine
           # Registration completion forms
           transitions from: :confirm_bank_transfer_form,
                       to: :registration_received_pending_payment_form,
+                      # TODO: This don't get triggered if in the `success`
+                      # callback block, hence we went for `after`
+                      after: :set_metadata_route
+
+          transitions from: :worldpay_form,
+                      to: :registration_received_pending_worldpay_payment_form,
+                      if: :pending_worldpay_payment?,
                       # TODO: This don't get triggered if in the `success`
                       # callback block, hence we went for `after`
                       after: :set_metadata_route

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -45,14 +45,6 @@ module WasteCarriersEngine
       unpaid_balance?
     end
 
-    def pending_worldpay_payment?
-      return false unless finance_details.present? &&
-                          finance_details.orders.present? &&
-                          finance_details.orders.first.present?
-
-      Order.valid_world_pay_status?(:pending, finance_details.orders.first.world_pay_status)
-    end
-
     def pending_manual_conviction_check?
       conviction_check_required?
     end

--- a/app/services/waste_carriers_engine/registration_completion_service.rb
+++ b/app/services/waste_carriers_engine/registration_completion_service.rb
@@ -77,7 +77,9 @@ module WasteCarriersEngine
     # In the case when the registration can be completed, the registration activation email is sent from
     # the RegistrationActivationService.
     def send_confirmation_email
-      if registration.unpaid_balance?
+      if registration.pending_worldpay_payment?
+        send_worldpay_pending_payment_email
+      elsif registration.unpaid_balance?
         send_pending_payment_email
       elsif registration.conviction_check_required?
         send_pending_conviction_check_email
@@ -88,6 +90,10 @@ module WasteCarriersEngine
 
     def send_pending_payment_email
       NewRegistrationMailer.registration_pending_payment(registration).deliver_now
+    end
+
+    def send_worldpay_pending_payment_email
+      NewRegistrationMailer.registration_pending_worldpay_payment(registration).deliver_now
     end
 
     def send_pending_conviction_check_email

--- a/app/views/waste_carriers_engine/new_registration_mailer/registration_pending_worldpay_payment.html.erb
+++ b/app/views/waste_carriers_engine/new_registration_mailer/registration_pending_worldpay_payment.html.erb
@@ -1,0 +1,101 @@
+<!doctype html>
+<!--[if lt IE 7]>  <html class="ie ie6 lte9 lte8 lte7"> <![endif]-->
+<!--[if IE 7]>     <html class="ie ie7 lte9 lte8 lte7"> <![endif]-->
+<!--[if IE 8]>     <html class="ie ie8 lte9 lte8"> <![endif]-->
+<!--[if IE 9]>     <html class="ie ie9 lte9"> <![endif]-->
+<!--[if gt IE 9]>  <html> <![endif]-->
+<!--[if !IE]><!-->
+<html>
+<!--<![endif]-->
+
+<head>
+  <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+  <meta content="utf-8" http-equiv="encoding">
+  <!-- Use title if it's in the page YAML frontmatter -->
+  <title>Waste Carriers Service</title>
+</head>
+
+<body style="font-family: Helvetica, Arial, sans-serif; font-size: 16px; margin: 0; color: #0b0c0c">
+  <table width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+      <td width="100%" height="53px" bgcolor="#0b0c0c">
+        <table width="580" cellpadding="0" cellspacing="0" border="0" align="center">
+          <tr>
+            <td width="100%" bgcolor="#0b0c0c" valign="middle">
+              <%= email_image_tag("govuk_logotype_email.png", { alt: 'GOV.UK', border: '0' }) %>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+  <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF">
+    <tr>
+      <td width="100%">
+        <table width="580" cellpadding="0" cellspacing="0" border="0" align="center">
+          <tr>
+            <td width="100%" class="header" style="padding-top: 10px;" colspan="2">
+              <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF">
+                <tr>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td width="75%" style="font-family: Helvetica, Arial, sans-serif;">
+              <p style="font-weight: 400; font-size: 16px; line-height: 1; margin: 10px 0 10px 0;">&nbsp;</p>
+            </td>
+            <td width="25%">&nbsp;</td>
+          </tr>
+          <tr>
+            <td bgcolor="#1d70b8" style="font-family: Helvetica, Arial, sans-serif; margin: 0 0 30px 0;">
+              <p style="font-size: 36px; font-weight: bold; text-align: center; color: #ffffff; line-height: 1.315789474; margin: 30px 0px 15px 0px;">
+                <%= t(".section_1.heading") %>
+              </p>
+
+              <p style="font-size: 19px; text-align: center; color: #ffffff; line-height: 1.315789474; margin: 0px 30px 0px 30px;">
+                <%= t(".section_1.paragraph_1") %>
+              </p>
+
+              <p style="font-size: 36px; font-weight: bold; text-align: center; color: #ffffff; line-height: 1.315789474; margin: 15px 0px 30px 0px;">
+                <%= @registration.reg_identifier %>
+              </p>
+            </td>
+            <td width="25%">&nbsp;</td>
+          </tr>
+          <tr>
+            <td width="75%" style="font-family: Helvetica, Arial, sans-serif;">
+              <p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 15px 0;">
+                <%= t(".dear", name: "#{@registration.first_name} #{@registration.last_name}") %>
+              </p>
+
+              <p style="font-size: 24px; font-weight: bold; line-height: 1.315789474; margin: 0 0 15px 0;">
+                <%= t(".section_2.heading") %>
+              </p>
+
+              <ul>
+                <li style="font-size: 19px; line-height: 1.315789474; margin: 0 0 15px 0;">
+                  <%= t(".section_2.list_item_1") %>
+                </li>
+                <li style="font-size: 19px; line-height: 1.315789474; margin: 0 0 15px 0;">
+                  <%= t(".section_2.list_item_2" ) %>
+                </li>
+                <li style="font-size: 19px; line-height: 1.315789474; margin: 0 0 15px 0;">
+                  <%= t(".section_2.list_item_3_html") %>
+                </li>
+              </ul>
+
+              <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 15px 0;">
+                <%= t(".section_3.paragraph_1") %>
+              </p>
+            </td>
+            <td width="25%">
+              &nbsp;
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/app/views/waste_carriers_engine/registration_received_pending_worldpay_payment_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/registration_received_pending_worldpay_payment_forms/new.html.erb
@@ -1,0 +1,21 @@
+<div class="column-two-thirds">
+  <div class="govuk-box-highlight govuk-box-highlight_blue">
+    <h1 class="heading-xlarge"><%= t(".heading") %></h1>
+    <p class="font-large bold"><%= t(".highlight_text") %><br>
+    <span class="strong" id="reg_identifier"><%= @registration.reg_identifier %></span></p>
+  </div>
+
+  <p><%= t(".paragraph_1", email: @registration.contact_email) %></p>
+  <h2 class="heading-medium"><%= t(".subheading_1") %></h2>
+  <p><%= t(".paragraph_2") %></p>
+
+  <div class="panel">
+    <p><%= t(".paragraph_3") %></p>
+  </div>
+
+  <%= render "shared/contact_environment_agency" %>
+
+  <%= render "shared/registration_checks" %>
+
+  <%= render "shared/link_to_survey" %>
+</div>

--- a/config/locales/forms/registration_received_pending_worldpay_payment_forms/en.yml
+++ b/config/locales/forms/registration_received_pending_worldpay_payment_forms/en.yml
@@ -1,0 +1,11 @@
+en:
+  waste_carriers_engine:
+    registration_received_pending_worldpay_payment_forms:
+      new:
+        title: "We’re processing your payment"
+        heading: "We’re processing your payment"
+        highlight_text: "Please use this registration number if you contact us:"
+        paragraph_1: "We've sent a confirmation email to %{email}."
+        subheading_1: "We have received your application"
+        paragraph_2: "We’re currently processing your payment and will let you know when it has been received."
+        paragraph_3: "Your registration will not be active until we have confirmed your registration"

--- a/config/locales/mailers/new_registration_mailer.en.yml
+++ b/config/locales/mailers/new_registration_mailer.en.yml
@@ -90,6 +90,20 @@ en:
           paragraph_5: "If any of your details change you must update your registration within 28 days."
           paragraph_6: "If you have enquiries please contact the Environment Agency helpline 03708 506506."
           paragraph_7: "This is an automated email, please do not reply."
+      registration_pending_worldpay_payment:
+        subject: "We’re processing your waste carrier registration %{reg_identifier}"
+        section_1:
+          heading: "We’re processing your payment"
+          paragraph_1: "Please use this reference number if you contact us:"
+        dear: "Dear %{name}"
+        section_2:
+          heading: "We have received your application"
+          list_item_1: "We’re currently processing your payment and will let you know when it has been received."
+          list_item_2: "You’re not legally entitled to operate as a waste carrier until we have confirmed your registration."
+          list_item_3: "Contact the Environment Agency on nccc-carrierbroker@environment-agency.gov.uk or 03708 506506 if you have questions."
+          list_item_3_html: "Contact the Environment Agency on <a href=\"mailto:nccc-carrierbroker@environment-agency.gov.uk\">nccc-carrierbroker@environment-agency.gov.uk</a> or 03708 506506 if you have any questions."
+        section_3:
+          paragraph_1: This is an automated email, please do not reply.
       registration_pending_conviction_check:
         subject: "Application received for waste carrier registration %{reg_identifier}"
         section_1:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,11 @@ WasteCarriersEngine::Engine.routes.draw do
               path: "registration-received-pending-payment",
               path_names: { new: "" }
 
+    resources :registration_received_pending_worldpay_payment_forms,
+              only: :new,
+              path: "registration-received-pending-worldpay-payment",
+              path_names: { new: "" }
+
     resources :registration_completed_forms,
               only: :new,
               path: "registration-completed",

--- a/spec/factories/finance_details.rb
+++ b/spec/factories/finance_details.rb
@@ -8,6 +8,12 @@ FactoryBot.define do
       payments { [] }
     end
 
+    trait :has_pending_worldpay_order do
+      has_required_data
+
+      orders { [build(:order, :has_pending_worldpay_status)] }
+    end
+
     trait :has_order do
       orders { [build(:order, :has_required_data)] }
     end

--- a/spec/factories/new_registration.rb
+++ b/spec/factories/new_registration.rb
@@ -26,6 +26,10 @@ FactoryBot.define do
       end
     end
 
+    trait :has_pending_worldpay_status do
+      finance_details { build(:finance_details, :has_pending_worldpay_order) }
+    end
+
     trait :has_required_lower_tier_data do
       location { "england" }
       declared_convictions { "no" }

--- a/spec/factories/order.rb
+++ b/spec/factories/order.rb
@@ -10,6 +10,12 @@ FactoryBot.define do
       total_amount { order_items.sum { |item| item[:amount] } }
     end
 
+    trait :has_pending_worldpay_status do
+      has_required_data
+
+      worldPayStatus { "SENT_FOR_AUTHORISATION" }
+    end
+
     trait :has_copy_cards_item do
       date_created { Time.now }
 

--- a/spec/factories/order.rb
+++ b/spec/factories/order.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
     trait :has_pending_worldpay_status do
       has_required_data
 
-      worldPayStatus { "SENT_FOR_AUTHORISATION" }
+      world_pay_status { "SENT_FOR_AUTHORISATION" }
     end
 
     trait :has_copy_cards_item do

--- a/spec/models/waste_carriers_engine/new_registration_workflow/worldpay_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/worldpay_form_spec.rb
@@ -16,6 +16,12 @@ module WasteCarriersEngine
 
             include_examples "has next transition", next_state: "registration_received_pending_conviction_form"
           end
+
+          context "when there is a pending worldpay payment" do
+            subject { build(:new_registration, :has_pending_worldpay_status, workflow_state: "worldpay_form") }
+
+            include_examples "has next transition", next_state: "registration_received_pending_worldpay_payment_form"
+          end
         end
 
         context "on back" do

--- a/spec/requests/waste_carriers_engine/registration_received_pending_worldpay_payment_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/registration_received_pending_worldpay_payment_forms_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "RegistrationReceivedPendingWorldpayPaymentForm", type: :request do
+    describe "GET new_registration_received_pending_worldpay_payment_form_path" do
+      context "when no new registration exists" do
+        it "redirects to the invalid page" do
+          get new_registration_received_pending_worldpay_payment_form_path("wibblewobblejellyonaplate")
+
+          expect(response).to redirect_to(page_path("invalid"))
+        end
+      end
+
+      context "when a valid new registration exists" do
+        let(:transient_registration) do
+          create(
+            :new_registration,
+            :has_required_data,
+            workflow_state: "registration_received_pending_worldpay_payment_form"
+          )
+        end
+
+        context "when the workflow_state is correct" do
+          it "returns a 200 status, renders the :new template, creates a new registration and deletes the transient registration" do
+            reg_identifier = transient_registration.reg_identifier
+            new_registrations_count = WasteCarriersEngine::NewRegistration.count
+
+            get new_registration_received_pending_worldpay_payment_form_path(transient_registration.token)
+
+            registration = WasteCarriersEngine::Registration.find_by(reg_identifier: reg_identifier)
+
+            expect(response).to have_http_status(200)
+            expect(response).to render_template(:new)
+            expect(registration).to be_valid
+            expect(WasteCarriersEngine::NewRegistration.count).to eq(new_registrations_count - 1)
+          end
+        end
+
+        context "when the workflow_state is not correct" do
+          before do
+            transient_registration.update_attributes(workflow_state: "payment_summary_form")
+          end
+
+          it "redirects to the correct page and does not creates a new registration nor delete the transient object" do
+            new_registrations_count = WasteCarriersEngine::NewRegistration.count
+
+            get new_registration_received_pending_worldpay_payment_form_path(transient_registration.token)
+
+            registration_scope = WasteCarriersEngine::Registration.where(reg_identifier: transient_registration.reg_identifier)
+
+            expect(response).to redirect_to(new_payment_summary_form_path(transient_registration.token))
+            expect(WasteCarriersEngine::NewRegistration.count).to eq(new_registrations_count)
+            expect(registration_scope).to be_empty
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-1013

This adds a new completion screen for when a WorldPay payment is pending

<details> 

<summary> Screen </summary>

<img width="590" alt="Screenshot 2020-05-05 at 12 48 45" src="https://user-images.githubusercontent.com/1385397/81063460-bbe5de80-8ecf-11ea-8e79-13a1c07e09f2.png">

</details>

<details> 

<summary> Email </summary>


<img width="1572" alt="Screenshot 2020-05-05 at 12 37 32" src="https://user-images.githubusercontent.com/1385397/81063452-b8eaee00-8ecf-11ea-916a-3c295a321f0b.png">

</details> 