### PR TITLE
Fix reliance on defunct renewal_submitted_form state

### DIFF
--- a/app/models/waste_carriers_engine/renewing_registration.rb
+++ b/app/models/waste_carriers_engine/renewing_registration.rb
@@ -28,6 +28,10 @@ module WasteCarriersEngine
       remove_invalid_attributes: true
     }.freeze
 
+    SUBMITTED_STATES = %w[renewal_received_pending_payment_form
+                          renewal_received_pending_conviction_form
+                          renewal_complete_form].freeze
+
     def registration
       @_registration ||= Registration.find_by(reg_identifier: reg_identifier)
     end
@@ -80,8 +84,7 @@ module WasteCarriersEngine
     end
 
     def renewal_application_submitted?
-      not_in_progress_states = %w[renewal_received_form renewal_complete_form]
-      not_in_progress_states.include?(workflow_state)
+      SUBMITTED_STATES.include?(workflow_state)
     end
 
     def can_be_renewed?

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -23,8 +23,8 @@ module WasteCarriersEngine
     field :temp_payment_method, type: String
     field :temp_tier_check, type: String # 'yes' or 'no' - should refactor to boolean
 
-    scope :in_progress, -> { where(:workflow_state.nin => %w[renewal_complete_form renewal_received_form]) }
-    scope :submitted, -> { where(:workflow_state.in => %w[renewal_complete_form renewal_received_form]) }
+    scope :in_progress, -> { where(:workflow_state.nin => RenewingRegistration::SUBMITTED_STATES) }
+    scope :submitted, -> { where(:workflow_state.in => RenewingRegistration::SUBMITTED_STATES) }
     scope :pending_payment, -> { submitted.where(:"financeDetails.balance".gt => 0) }
     scope :pending_approval, -> { submitted.where("conviction_sign_offs.0.confirmed": "no") }
 

--- a/spec/factories/renewing_registration.rb
+++ b/spec/factories/renewing_registration.rb
@@ -34,7 +34,7 @@ FactoryBot.define do
     end
 
     trait :is_submitted do
-      workflow_state { "renewal_received_form" }
+      workflow_state { "renewal_received_pending_payment_form" }
     end
 
     trait :has_finance_details do

--- a/spec/mailers/waste_carriers_engine/renewal_mailer_spec.rb
+++ b/spec/mailers/waste_carriers_engine/renewal_mailer_spec.rb
@@ -88,7 +88,7 @@ module WasteCarriersEngine
                :has_required_data,
                :has_addresses,
                :has_paid_balance,
-               workflow_state: "renewal_received_form")
+               workflow_state: "renewal_received_pending_payment_form")
       end
       let(:mail) { RenewalMailer.send_renewal_received_email(transient_registration) }
 

--- a/spec/models/waste_carriers_engine/renewing_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_spec.rb
@@ -133,23 +133,17 @@ module WasteCarriersEngine
         end
       end
 
-      context "when the workflow_state is renewal_received" do
-        before do
-          renewing_registration.workflow_state = "renewal_received_form"
-        end
+      %w[renewal_received_pending_payment_form
+         renewal_received_pending_conviction_form
+         renewal_complete_form].each do |valid_state|
+        context "when the workflow_state is #{valid_state}" do
+          before do
+            renewing_registration.workflow_state = valid_state
+          end
 
-        it "returns true" do
-          expect(renewing_registration.renewal_application_submitted?).to eq(true)
-        end
-      end
-
-      context "when the workflow_state is renewal_complete" do
-        before do
-          renewing_registration.workflow_state = "renewal_complete_form"
-        end
-
-        it "returns true" do
-          expect(renewing_registration.renewal_application_submitted?).to eq(true)
+          it "returns true" do
+            expect(renewing_registration.renewal_application_submitted?).to eq(true)
+          end
         end
       end
     end
@@ -318,7 +312,7 @@ module WasteCarriersEngine
 
       context "when the renewal is in a completed workflow_state" do
         before do
-          renewing_registration.workflow_state = "renewal_received_form"
+          renewing_registration.workflow_state = "renewal_received_pending_payment_form"
         end
 
         context "when there is no unpaid balance" do
@@ -399,7 +393,7 @@ module WasteCarriersEngine
 
       context "when the renewal is in a completed workflow_state" do
         before do
-          renewing_registration.workflow_state = "renewal_received_form"
+          renewing_registration.workflow_state = "renewal_received_pending_payment_form"
         end
 
         context "when conviction_check_required? is false" do

--- a/spec/support/shared_examples/transient_registration_named_scopes.rb
+++ b/spec/support/shared_examples/transient_registration_named_scopes.rb
@@ -8,21 +8,21 @@ RSpec.shared_examples "TransientRegistration named scopes" do
   let(:submitted_renewal) do
     create(:renewing_registration,
            :has_required_data,
-           workflow_state: :renewal_received_form)
+           workflow_state: :renewal_received_pending_conviction_form)
   end
 
   let(:pending_payment_renewal) do
     create(:renewing_registration,
            :has_required_data,
            :has_unpaid_balance,
-           workflow_state: :renewal_received_form)
+           workflow_state: :renewal_received_pending_payment_form)
   end
 
   let(:pending_approval_renewal) do
     create(:renewing_registration,
            :has_required_data,
            :requires_conviction_check,
-           workflow_state: :renewal_received_form)
+           workflow_state: :renewal_received_pending_conviction_form)
   end
 
   describe "#in_progress" do


### PR DESCRIPTION
https://github.com/DEFRA/waste-carriers-engine/pull/822 got rid of the old `renewal_submitted_form` state as we split it into two new ones.

However, there were still some bits of the engine that relied on checking for that old state. This was resulting in some weird bugs, like inaccurate emails being sent.