### PR TITLE
Split up renewal pending payment controllers

### DIFF
--- a/app/controllers/waste_carriers_engine/renewal_received_pending_worldpay_payment_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/renewal_received_pending_worldpay_payment_forms_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class RenewalReceivedPendingWorldpayPaymentFormsController < FormsController
+    helper JourneyLinksHelper
+
+    def new
+      super(RenewalReceivedPendingWorldpayPaymentForm, "renewal_received_pending_worldpay_payment_form")
+    end
+
+    # Overwrite create and go_back as you shouldn't be able to submit or go back
+    def create; end
+
+    def go_back; end
+  end
+end

--- a/app/forms/waste_carriers_engine/renewal_received_pending_worldpay_payment_form.rb
+++ b/app/forms/waste_carriers_engine/renewal_received_pending_worldpay_payment_form.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module WasteCarriersEngine
-  class RenewalReceivedPendingPaymentForm < BaseForm
+  class RenewalReceivedPendingWorldpayPaymentForm < BaseForm
     include CannotSubmit
 
     def self.can_navigate_flexibly?

--- a/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
@@ -60,6 +60,7 @@ module WasteCarriersEngine
         state :renewal_complete_form
         state :renewal_received_pending_conviction_form
         state :renewal_received_pending_payment_form
+        state :renewal_received_pending_worldpay_payment_form
 
         state :cannot_renew_lower_tier_form
         state :cannot_renew_type_change_form
@@ -261,7 +262,7 @@ module WasteCarriersEngine
                       to: :confirm_bank_transfer_form
 
           transitions from: :worldpay_form,
-                      to: :renewal_received_pending_payment_form,
+                      to: :renewal_received_pending_worldpay_payment_form,
                       if: :pending_worldpay_payment?,
                       success: :send_renewal_received_email,
                       # TODO: This don't get triggered if in the `success`

--- a/app/models/waste_carriers_engine/renewing_registration.rb
+++ b/app/models/waste_carriers_engine/renewing_registration.rb
@@ -28,9 +28,10 @@ module WasteCarriersEngine
       remove_invalid_attributes: true
     }.freeze
 
-    SUBMITTED_STATES = %w[renewal_received_pending_payment_form
+    SUBMITTED_STATES = %w[renewal_complete_form
                           renewal_received_pending_conviction_form
-                          renewal_complete_form].freeze
+                          renewal_received_pending_payment_form
+                          renewal_received_pending_worldpay_payment_form].freeze
 
     def registration
       @_registration ||= Registration.find_by(reg_identifier: reg_identifier)

--- a/app/views/waste_carriers_engine/renewal_received_pending_payment_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/renewal_received_pending_payment_forms/new.html.erb
@@ -22,46 +22,29 @@
         </p>
       </div>
 
-      <% if @renewal_received_pending_payment_form.pending_worldpay_payment? %>
+      <div class="panel panel-border-wide">
+        <%= t(".panel_text") %>
+      </div>
 
-        <h2 class="heading-medium"><%= t(".processing_worldpay_payment.subheading") %></h2>
+      <h2 class="heading-medium"><%= t(".subheading") %></h2>
 
-        <p><%= t(".processing_worldpay_payment.paragraph_1",
-                 email: @renewal_received_pending_payment_form.transient_registration.contact_email) %></p>
+      <%= render("waste_carriers_engine/shared/bank_transfer_details",
+          reg_identifier: @renewal_received_pending_payment_form.reg_identifier,
+          payment_due: @renewal_received_pending_payment_form.transient_registration.finance_details.balance) %>
 
-        <p><%= t(".processing_worldpay_payment.paragraph_2") %></p>
+      <%= render("waste_carriers_engine/shared/bank_transfer_email_details",
+          reg_identifier: @renewal_received_pending_payment_form.reg_identifier,
+          amount: @renewal_received_pending_payment_form.transient_registration.finance_details.balance) %>
 
-        <div class="panel panel-border-wide">
-          <p><%= t(".processing_worldpay_payment.paragraph_3") %></p>
-        </div>
+      <p><%= t(".paragraph_1",
+               email: @renewal_received_pending_payment_form.transient_registration.contact_email) %></p>
+      <p><%= t(".paragraph_2") %></p>
 
-      <% else %>
-
-        <div class="panel panel-border-wide">
-          <%= t(".bank_transfer.panel_text") %>
-        </div>
-
-        <h2 class="heading-medium"><%= t(".bank_transfer.subheading") %></h2>
-
-        <%= render("waste_carriers_engine/shared/bank_transfer_details",
-            reg_identifier: @renewal_received_pending_payment_form.reg_identifier,
-            payment_due: @renewal_received_pending_payment_form.transient_registration.finance_details.balance) %>
-
-        <%= render("waste_carriers_engine/shared/bank_transfer_email_details",
-            reg_identifier: @renewal_received_pending_payment_form.reg_identifier,
-            amount: @renewal_received_pending_payment_form.transient_registration.finance_details.balance) %>
-
-        <p><%= t(".bank_transfer.paragraph_1",
-                 email: @renewal_received_pending_payment_form.transient_registration.contact_email) %></p>
-        <p><%= t(".bank_transfer.paragraph_2") %></p>
-
-        <ul class="list list-bullet">
-          <% t(".bank_transfer.list_1").each do |list_item| %>
-            <li><%= list_item %></li>
-          <% end %>
-        </ul>
-
-      <% end %>
+      <ul class="list list-bullet">
+        <% t(".list_1").each do |list_item| %>
+          <li><%= list_item %></li>
+        <% end %>
+      </ul>
 
       <%= render "shared/contact_environment_agency" %>
 

--- a/app/views/waste_carriers_engine/renewal_received_pending_worldpay_payment_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/renewal_received_pending_worldpay_payment_forms/new.html.erb
@@ -1,0 +1,46 @@
+<div class="column-two-thirds">
+  <% if @renewal_received_pending_worldpay_payment_form.errors.any? %>
+
+    <h1 class="heading-large"><%= t(".error_heading") %></h1>
+
+    <ul>
+      <% @renewal_received_pending_worldpay_payment_form.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+
+  <% else %>
+    <%= form_for(@renewal_received_pending_worldpay_payment_form) do |f| %>
+      <%= render("waste_carriers_engine/shared/errors", object: @renewal_received_pending_worldpay_payment_form) %>
+
+      <div class="govuk-box-highlight">
+        <h1 class="heading-xlarge"><%= t(".heading") %></h1>
+        <p class="font-large">
+          <%= t(".highlight_text") %>
+          <br>
+          <span class="strong" id="reg_identifier"><%= @renewal_received_pending_worldpay_payment_form.reg_identifier %></span>
+        </p>
+      </div>
+
+      <h2 class="heading-medium"><%= t(".subheading") %></h2>
+
+      <p><%= t(".paragraph_1",
+               email: @renewal_received_pending_worldpay_payment_form.transient_registration.contact_email) %></p>
+
+      <p><%= t(".paragraph_2") %></p>
+
+      <div class="panel panel-border-wide">
+        <p><%= t(".paragraph_3") %></p>
+      </div>
+
+      <%= render "shared/contact_environment_agency" %>
+
+      <%= render "shared/registration_checks" %>
+
+      <%= render "shared/link_to_survey" %>
+
+      <%= link_to t(".next_button"), renewal_finished_link(reg_identifier: @renewal_received_pending_worldpay_payment_form.reg_identifier), class: 'button' %>
+    <% end %>
+
+  <% end %>
+</div>

--- a/config/locales/forms/renewal_received_pending_payment_forms/en.yml
+++ b/config/locales/forms/renewal_received_pending_payment_forms/en.yml
@@ -5,19 +5,13 @@ en:
         title: Renewal application received
         heading: Application received
         highlight_text: "Your registration number is still"
-        processing_worldpay_payment:
-          subheading: "Processing your payment"
-          paragraph_1: "We have sent a confirmation email to %{email}."
-          paragraph_2: We are currently processing your payment and will let you know when it has been received.
-          paragraph_3: Your registration will not be renewed until we have confirmed your registration.
-        bank_transfer:
-          panel_text: "We cannot register you until your payment clears."
-          subheading: "Next step: pay the renewal charge"
-          paragraph_1: "We’ve sent an email to %{email} with the payment details and instructions."
-          paragraph_2: "We will not register you until your payment clears."
-          list_1:
-            - "Please allow 5 working days for your payment to reach us."
-            - "Alternatively, contact us to pay by credit or debit card."
+        panel_text: "We cannot register you until your payment clears."
+        subheading: "Next step: pay the renewal charge"
+        paragraph_1: "We’ve sent an email to %{email} with the payment details and instructions."
+        paragraph_2: "We will not register you until your payment clears."
+        list_1:
+          - "Please allow 5 working days for your payment to reach us."
+          - "Alternatively, contact us to pay by credit or debit card."
         error_heading: Something is wrong
         next_button: Finished
   activemodel:

--- a/config/locales/forms/renewal_received_pending_worldpay_payment_forms/en.yml
+++ b/config/locales/forms/renewal_received_pending_worldpay_payment_forms/en.yml
@@ -1,0 +1,22 @@
+en:
+  waste_carriers_engine:
+    renewal_received_pending_worldpay_payment_forms:
+      new:
+        title: Renewal application received
+        heading: Application received
+        highlight_text: "Your registration number is still"
+        subheading: "Processing your payment"
+        paragraph_1: "We have sent a confirmation email to %{email}."
+        paragraph_2: We are currently processing your payment and will let you know when it has been received.
+        paragraph_3: Your registration will not be renewed until we have confirmed your registration.
+        error_heading: Something is wrong
+        next_button: Finished
+  activemodel:
+    errors:
+      models:
+        waste_carriers_engine/renewal_received_pending_worldpay_payment_form:
+          attributes:
+            reg_identifier:
+              invalid_format: "The registration ID is not in a valid format"
+              no_registration: "There is no registration matching this ID"
+              renewal_in_progress: "This renewal is already in progress"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -596,6 +596,11 @@ WasteCarriersEngine::Engine.routes.draw do
               path: "renewal-received-pending-payment",
               path_names: { new: "" }
 
+    resources :renewal_received_pending_worldpay_payment_forms,
+              only: %i[new create],
+              path: "renewal-received-pending-worldpay-payment",
+              path_names: { new: "" }
+
     resources :cannot_renew_lower_tier_forms,
               only: %i[new create],
               path: "cannot-renew-lower-tier",

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/renewal_received_pending_worldpay_payment_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/renewal_received_pending_worldpay_payment_form_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe RenewingRegistration, type: :model do
+    describe "#workflow_state" do
+      it_behaves_like "a fixed final state",
+                      current_state: :renewal_received_pending_worldpay_payment_form,
+                      factory: :renewing_registration
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/worldpay_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/worldpay_form_spec.rb
@@ -38,7 +38,7 @@ module WasteCarriersEngine
                 allow(subject).to receive(:pending_worldpay_payment?).and_return(true)
               end
 
-              include_examples "has next transition", next_state: "renewal_received_pending_payment_form"
+              include_examples "has next transition", next_state: "renewal_received_pending_worldpay_payment_form"
 
               it "sends a confirmation email after the 'next' event" do
                 expect { subject.next! }.to change { ActionMailer::Base.deliveries.count }.by(1)

--- a/spec/requests/waste_carriers_engine/renewal_received_pending_worldpay_payment_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/renewal_received_pending_worldpay_payment_forms_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "RenewalReceivedPendingWorldpayPaymentForms", type: :request do
+    describe "GET new_renewal_received_pending_worldpay_payment_form_path" do
+      context "when a valid user is signed in" do
+        let(:user) { create(:user) }
+        before(:each) do
+          sign_in(user)
+        end
+
+        context "when no renewing registration exists" do
+          it "redirects to the invalid page" do
+            get new_renewal_received_pending_worldpay_payment_form_path("wibblewobblejellyonaplate")
+
+            expect(response).to redirect_to(page_path("invalid"))
+          end
+        end
+
+        context "when a valid renewing registration exists" do
+          let(:transient_registration) do
+            create(
+              :renewing_registration,
+              :has_unpaid_balance,
+              workflow_state: "renewal_received_pending_worldpay_payment_form",
+              account_email: user.email
+            )
+          end
+
+          context "when the workflow_state is correct" do
+            it "returns a 200 status and renders the :new template" do
+              get new_renewal_received_pending_worldpay_payment_form_path(transient_registration.token)
+
+              expect(response).to have_http_status(200)
+              expect(response).to render_template(:new)
+            end
+          end
+
+          context "when the workflow_state is not correct" do
+            before do
+              transient_registration.update_attributes(workflow_state: "payment_summary_form")
+            end
+
+            it "redirects to the correct page" do
+              get new_renewal_received_pending_worldpay_payment_form_path(transient_registration.token)
+              expect(response).to redirect_to(new_payment_summary_form_path(transient_registration.token))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
@@ -216,7 +216,7 @@ module WasteCarriersEngine
 
             it "redirects to renewal_received_pending_payment_form" do
               get pending_worldpay_forms_path(token), params
-              expect(response).to redirect_to(new_renewal_received_pending_payment_form_path(token))
+              expect(response).to redirect_to(new_renewal_received_pending_worldpay_payment_form_path(token))
             end
           end
 


### PR DESCRIPTION
We used to have one "renewal received" controller. Then https://github.com/DEFRA/waste-carriers-engine/pull/822 split it into one controller for pending payments and another for pending convictions.

Since we made a separate controller in the new registration journey for pending Worldpay payments (as opposed to bank transfer payments, we've decided to split this up in the renewal journey as well.

So this PR creates a new RenewalReceivedPendingWorldpayPaymentForm controller, adds the relevant routes, views, etc, and updates the workflow to use it.