### PR TITLE
Implement renew via magic link journey happy path

### DIFF
--- a/app/controllers/concerns/waste_carriers_engine/can_redirect_form_to_correct_path.rb
+++ b/app/controllers/concerns/waste_carriers_engine/can_redirect_form_to_correct_path.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  module CanRedirectFormToCorrectPath
+    extend ActiveSupport::Concern
+
+    included do
+      def redirect_to_correct_form
+        redirect_to form_path
+      end
+
+      # Get the path based on the workflow state, with token as params, ie:
+      # new_state_name_path/:token or start_state_name_path?token=:token
+      def form_path
+        send("new_#{@transient_registration.workflow_state}_path".to_sym, token: @transient_registration.token)
+      end
+    end
+  end
+end

--- a/app/controllers/waste_carriers_engine/forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/forms_controller.rb
@@ -3,6 +3,7 @@
 module WasteCarriersEngine
   class FormsController < ApplicationController
     include ActionView::Helpers::UrlHelper
+    include CanRedirectFormToCorrectPath
 
     before_action :back_button_cache_buster
     before_action :validate_token
@@ -78,16 +79,6 @@ module WasteCarriersEngine
           false
         end
       end
-    end
-
-    def redirect_to_correct_form
-      redirect_to form_path
-    end
-
-    # Get the path based on the workflow state, with token as params, ie:
-    # new_state_name_path/:token or start_state_name_path?token=:token
-    def form_path
-      send("new_#{@transient_registration.workflow_state}_path".to_sym, token: @transient_registration.token)
     end
 
     def setup_checks_pass?

--- a/app/controllers/waste_carriers_engine/renew_registration_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/renew_registration_forms_controller.rb
@@ -21,6 +21,8 @@ module WasteCarriersEngine
     def submit_form(form, params)
       respond_to do |format|
         if form.submit(params)
+          reset_magic_link_route
+
           format.html { redirect_to_renewal_journey }
           true
         else
@@ -32,6 +34,16 @@ module WasteCarriersEngine
 
     def redirect_to_renewal_journey
       redirect_to renewal_start_forms_path(token: @renew_registration_form.temp_lookup_number)
+    end
+
+    def reset_magic_link_route
+      renewing_registration = WasteCarriersEngine::RenewingRegistration.where(
+        reg_identifier: @renew_registration_form.temp_lookup_number
+      ).first
+
+      return unless renewing_registration
+
+      renewing_registration.update_attributes(from_magic_link: false)
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/renewal_start_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/renewal_start_forms_controller.rb
@@ -14,11 +14,13 @@ module WasteCarriersEngine
 
     private
 
+    # rubocop:disable Naming/MemoizedInstanceVariableName
     def find_or_initialize_transient_registration(token)
       @transient_registration ||= RenewingRegistration.where(token: token).first ||
                                   RenewingRegistration.where(reg_identifier: token).first ||
                                   RenewingRegistration.new(reg_identifier: token)
     end
+    # rubocop:enable Naming/MemoizedInstanceVariableName
 
     def should_authenticate_user?
       find_or_initialize_transient_registration(params[:token])

--- a/app/controllers/waste_carriers_engine/renewal_start_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/renewal_start_forms_controller.rb
@@ -2,7 +2,7 @@
 
 module WasteCarriersEngine
   class RenewalStartFormsController < FormsController
-    prepend_before_action :authenticate_user!
+    prepend_before_action :authenticate_user!, if: :should_authenticate_user?
 
     def new
       super(RenewalStartForm, "renewal_start_form")
@@ -15,10 +15,17 @@ module WasteCarriersEngine
     private
 
     def find_or_initialize_transient_registration(token)
-      # TODO: Downtime at deploy when releasing token?
-      @transient_registration = RenewingRegistration.where(token: token).first ||
-                                RenewingRegistration.where(reg_identifier: token).first ||
-                                RenewingRegistration.new(reg_identifier: token)
+      @transient_registration ||= RenewingRegistration.where(token: token).first ||
+                                  RenewingRegistration.where(reg_identifier: token).first ||
+                                  RenewingRegistration.new(reg_identifier: token)
+    end
+
+    def should_authenticate_user?
+      find_or_initialize_transient_registration(params[:token])
+
+      return false if @transient_registration.from_magic_link
+
+      true
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/renews_controller.rb
+++ b/app/controllers/waste_carriers_engine/renews_controller.rb
@@ -2,14 +2,15 @@
 
 module WasteCarriersEngine
   class RenewsController < ApplicationController
+    include CanRedirectFormToCorrectPath
+
     before_action :validate_renew_token
 
     def new
-      # TODO: Should create a renewing registation
-      # @transient_registration = RenewingRegistration.create(reg_identifier: registration.reg_identifier)
+      @transient_registration = fetch_transient_renewal
+      @transient_registration.update_attributes(from_magic_link: true)
 
-      # TODO: Should redirect to start renewing registration journey
-      render text: "OK - I am a renew via magic link page - renewing #{registration.reg_identifier}"
+      redirect_to_correct_form
     end
 
     private
@@ -23,6 +24,14 @@ module WasteCarriersEngine
 
     def registration
       @registration ||= Registration.find_by(renew_token: params[:token])
+    end
+
+    def fetch_transient_renewal
+      registration.renewal || new_renewal_from_magic_link
+    end
+
+    def new_renewal_from_magic_link
+      RenewingRegistration.create(reg_identifier: registration.reg_identifier)
     end
   end
 end

--- a/app/models/waste_carriers_engine/edit_registration.rb
+++ b/app/models/waste_carriers_engine/edit_registration.rb
@@ -13,6 +13,7 @@ module WasteCarriersEngine
       ignorable_attributes: %w[_id
                                account_email
                                addresses
+                               renew_token
                                key_people
                                financeDetails
                                conviction_search_result

--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -58,6 +58,10 @@ module WasteCarriersEngine
       save!
     end
 
+    def renewal
+      RenewingRegistration.where(reg_identifier: reg_identifier).first
+    end
+
     private
 
     def renewable_tier?

--- a/app/models/waste_carriers_engine/renewing_registration.rb
+++ b/app/models/waste_carriers_engine/renewing_registration.rb
@@ -10,9 +10,12 @@ module WasteCarriersEngine
     validate :no_renewal_in_progress?, on: :create
     validates :reg_identifier, "waste_carriers_engine/reg_identifier": true
 
+    field :from_magic_link, type: Boolean
+
     COPY_DATA_OPTIONS = {
       ignorable_attributes: %w[_id
                                otherBusinesses
+                               renew_token
                                isMainService
                                constructionWaste
                                onlyAMF

--- a/app/services/waste_carriers_engine/renewal_completion_service.rb
+++ b/app/services/waste_carriers_engine/renewal_completion_service.rb
@@ -116,6 +116,7 @@ module WasteCarriersEngine
                                                                     "temp_os_places_error",
                                                                     "temp_payment_method",
                                                                     "temp_tier_check",
+                                                                    "from_magic_link",
                                                                     "_type",
                                                                     "workflow_state",
                                                                     "locking_name",

--- a/app/services/waste_carriers_engine/renewing_registration_permission_checks_service.rb
+++ b/app/services/waste_carriers_engine/renewing_registration_permission_checks_service.rb
@@ -10,6 +10,7 @@ module WasteCarriersEngine
     end
 
     def user_has_permission?
+      return true if transient_registration.from_magic_link
       return true if can?(:update, transient_registration)
 
       permission_check_result.needs_permissions!

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -582,6 +582,15 @@ module WasteCarriersEngine
                             factory: :registration
     end
 
+    describe "#renewal" do
+      it "returns a transient renewal" do
+        renewing_registration = create(:renewing_registration)
+        registration = renewing_registration.registration
+
+        expect(registration.renewal).to eq(renewing_registration)
+      end
+    end
+
     describe "#can_start_renewal?" do
       let(:registration) { build(:registration, :has_required_data) }
 

--- a/spec/requests/waste_carriers_engine/renew_registration_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/renew_registration_forms_spec.rb
@@ -106,17 +106,22 @@ module WasteCarriersEngine
 
         context "when the transient registration is in the wrong state" do
           let(:transient_registration) do
-            create(:new_registration,
-                   workflow_state: "contact_name_form")
+            create(:renewing_registration,
+                   workflow_state: "contact_name_form",
+                   account_email: user.email)
           end
 
           let(:valid_params) { { company_no: "01234567" } }
 
-          it "returns a 302 response and redirects to the correct form for the state" do
+          it "returns a 302 response, redirects to the correct form for the state and set magic link route to false" do
             post renew_registration_forms_path(transient_registration[:token]), renew_registration_form: valid_params
+
+            transient_registration.reload
 
             expect(response).to have_http_status(302)
             expect(response).to redirect_to(new_contact_name_form_path(transient_registration[:token]))
+
+            expect(transient_registration.from_magic_link).to be_falsey
           end
         end
       end

--- a/spec/services/waste_carriers_engine/renewing_registration_permission_checks_service_spec.rb
+++ b/spec/services/waste_carriers_engine/renewing_registration_permission_checks_service_spec.rb
@@ -33,8 +33,8 @@ module WasteCarriersEngine
         before do
           allow(transient_registration).to receive(:registration).and_return(registration)
 
-          expect(Ability).to receive(:new).with(user).and_return(ability)
-          expect(ability).to receive(:can?).with(:update, transient_registration).and_return(can)
+          allow(Ability).to receive(:new).with(user).and_return(ability)
+          allow(ability).to receive(:can?).with(:update, transient_registration).and_return(can)
         end
 
         context "when the user does not have the correct permissions" do

--- a/spec/services/waste_carriers_engine/renewing_registration_permission_checks_service_spec.rb
+++ b/spec/services/waste_carriers_engine/renewing_registration_permission_checks_service_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe RenewingRegistrationPermissionChecksService do
-    let(:transient_registration) { double(:transient_registration) }
+    let(:transient_registration) { double(:transient_registration, from_magic_link: false) }
     let(:user) { double(:user) }
     let(:result) { double(:result) }
     let(:params) { { transient_registration: transient_registration, user: user } }
@@ -69,6 +69,16 @@ module WasteCarriersEngine
 
           context "when the transient_registration is renewable" do
             let(:renewable) { true }
+
+            context "when the transient registration is accessed through a magic link" do
+              let(:transient_registration) { double(:transient_registration, from_magic_link: true) }
+
+              it "returns a pass result" do
+                expect(result).to receive(:pass!)
+
+                expect(described_class.run(params)).to eq(result)
+              end
+            end
 
             it "returns a pass result" do
               expect(result).to receive(:pass!)


### PR DESCRIPTION
From:  https://eaflood.atlassian.net/browse/RUBY-987

This implements the redirect from the renew controller for magic link to the renewal journey.
It also address issues with login, since we do not want a user to login if they have started from the magic link, but we do want them to login if they then pick the journey app again from the normal flow. A flag on the renewing registration has been added to achieve that.
