### PR TITLE
Make sure to include Lower Tier to EPR export

### DIFF
--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -33,7 +33,7 @@ module WasteCarriersEngine
 
     field :renew_token, type: String
 
-    def self.in_grace_window
+    def self.lower_tier_or_in_grace_window
       date = Time.now.in_time_zone("London").beginning_of_day - Rails.configuration.grace_window.days + 1.day
 
       any_of({ :expires_on.gte => date }, { tier: LOWER_TIER })

--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -36,7 +36,7 @@ module WasteCarriersEngine
     def self.in_grace_window
       date = Time.now.in_time_zone("London").beginning_of_day - Rails.configuration.grace_window.days + 1.day
 
-      where(:expires_on.gte => date)
+      any_of({ :expires_on.gte => date }, { tier: LOWER_TIER })
     end
 
     alias pending_manual_conviction_check? conviction_check_required?

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -29,6 +29,10 @@ FactoryBot.define do
       end
     end
 
+    trait :lower_tier do
+      tier { "LOWER" }
+    end
+
     trait :has_addresses do
       addresses { [build(:address, :has_required_data, :registered, :from_os_places), build(:address, :has_required_data, :contact, :from_os_places)] }
     end

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -53,7 +53,7 @@ module WasteCarriersEngine
         end
       end
 
-      describe ".in_grace_window" do
+      describe ".lower_tier_or_in_grace_window" do
         it "returns registrations whose expired date is in the grace window" do
           allow(Rails.configuration).to receive(:grace_window).and_return(3)
 
@@ -63,7 +63,7 @@ module WasteCarriersEngine
           past_not_in_grace_window = create(:registration, :has_required_data, expires_on: 4.day.ago)
           lower_tier = create(:registration, :has_required_data, :lower_tier, expires_on: nil)
 
-          result = described_class.in_grace_window
+          result = described_class.lower_tier_or_in_grace_window
 
           expect(result).to include(future_expire_date)
           expect(result).to include(past_in_grace_window)

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -61,11 +61,13 @@ module WasteCarriersEngine
           past_in_grace_window = create(:registration, :has_required_data, expires_on: 1.day.ago)
           edge_grace_window = create(:registration, :has_required_data, expires_on: 3.day.ago)
           past_not_in_grace_window = create(:registration, :has_required_data, expires_on: 4.day.ago)
+          lower_tier = create(:registration, :has_required_data, :lower_tier, expires_on: nil)
 
           result = described_class.in_grace_window
 
           expect(result).to include(future_expire_date)
           expect(result).to include(past_in_grace_window)
+          expect(result).to include(lower_tier)
           expect(result).to_not include(edge_grace_window)
           expect(result).to_not include(past_not_in_grace_window)
         end


### PR DESCRIPTION
This fixes an issue for which we were excluding lower tier registrations from the EPR export

Fixes: https://eaflood.atlassian.net/browse/RUBY-1027