### PR TITLE
Fix bug on past registration creation at renewal

### DIFF
--- a/app/models/waste_carriers_engine/past_registration.rb
+++ b/app/models/waste_carriers_engine/past_registration.rb
@@ -11,9 +11,9 @@ module WasteCarriersEngine
 
     embedded_in :registration, class_name: "WasteCarriersEngine::Registration"
 
-    def self.build_past_registration(registration, cause)
+    def self.build_past_registration(registration, cause = nil)
       past_registration = PastRegistration.new
-      past_registration.cause = cause
+      past_registration.cause = cause if cause.present?
 
       return if past_registration.version_already_backed_up?(registration)
 
@@ -31,7 +31,7 @@ module WasteCarriersEngine
       return false if new_version_due_to_edit?
 
       # Collect all expires_on dates from past registrations
-      matching_expires_on = registration.past_registrations.where(cause: :renewal).map(&:expires_on)
+      matching_expires_on = registration.past_registrations.not_in(cause: ["edit"]).map(&:expires_on)
       # Check if the current expires_on is included - this indicates that this version of
       # the registration has already been backed up.
       return true if matching_expires_on.include?(registration.expires_on)

--- a/app/models/waste_carriers_engine/past_registration.rb
+++ b/app/models/waste_carriers_engine/past_registration.rb
@@ -11,9 +11,9 @@ module WasteCarriersEngine
 
     embedded_in :registration, class_name: "WasteCarriersEngine::Registration"
 
-    def self.build_past_registration(registration, cause = nil)
+    def self.build_past_registration(registration, cause)
       past_registration = PastRegistration.new
-      past_registration.cause = cause if cause.present?
+      past_registration.cause = cause
 
       return if past_registration.version_already_backed_up?(registration)
 
@@ -31,7 +31,7 @@ module WasteCarriersEngine
       return false if new_version_due_to_edit?
 
       # Collect all expires_on dates from past registrations
-      matching_expires_on = registration.past_registrations.map(&:expires_on)
+      matching_expires_on = registration.past_registrations.where(cause: :renewal).map(&:expires_on)
       # Check if the current expires_on is included - this indicates that this version of
       # the registration has already been backed up.
       return true if matching_expires_on.include?(registration.expires_on)

--- a/app/services/waste_carriers_engine/renewal_completion_service.rb
+++ b/app/services/waste_carriers_engine/renewal_completion_service.rb
@@ -71,7 +71,7 @@ module WasteCarriersEngine
     end
 
     def create_past_registration
-      PastRegistration.build_past_registration(registration)
+      PastRegistration.build_past_registration(registration, :renewal)
     end
 
     def update_registration

--- a/app/services/waste_carriers_engine/renewal_completion_service.rb
+++ b/app/services/waste_carriers_engine/renewal_completion_service.rb
@@ -71,7 +71,7 @@ module WasteCarriersEngine
     end
 
     def create_past_registration
-      PastRegistration.build_past_registration(registration, :renewal)
+      PastRegistration.build_past_registration(registration)
     end
 
     def update_registration

--- a/spec/models/waste_carriers_engine/past_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/past_registration_spec.rb
@@ -7,7 +7,7 @@ module WasteCarriersEngine
     let(:registration) { create(:registration, :has_required_data, :expires_soon) }
 
     describe "build_past_registration" do
-      let(:past_registration) { PastRegistration.build_past_registration(registration, :renewal) }
+      let(:past_registration) { PastRegistration.build_past_registration(registration) }
 
       it "creates a new past_registration" do
         past_registration_count = registration.past_registrations.count
@@ -43,7 +43,7 @@ module WasteCarriersEngine
         context "if the new version is a renewal" do
           context "if the past registration is a renewal" do
             before do
-              PastRegistration.build_past_registration(registration, :renewal)
+              PastRegistration.build_past_registration(registration)
             end
 
             it "returns nil and does not create a new past_registration" do

--- a/spec/models/waste_carriers_engine/past_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/past_registration_spec.rb
@@ -7,7 +7,7 @@ module WasteCarriersEngine
     let(:registration) { create(:registration, :has_required_data, :expires_soon) }
 
     describe "build_past_registration" do
-      let(:past_registration) { PastRegistration.build_past_registration(registration) }
+      let(:past_registration) { PastRegistration.build_past_registration(registration, :renewal) }
 
       it "creates a new past_registration" do
         past_registration_count = registration.past_registrations.count
@@ -37,18 +37,30 @@ module WasteCarriersEngine
 
       context "if there is already a past_registration with the same expiry date" do
         before do
-          PastRegistration.build_past_registration(registration)
+          PastRegistration.build_past_registration(registration, :edit)
         end
 
-        context "if the new version is not an edit" do
-          it "returns nil" do
-            expect(past_registration).to eq(nil)
+        context "if the new version is a renewal" do
+          context "if the past registration is a renewal" do
+            before do
+              PastRegistration.build_past_registration(registration, :renewal)
+            end
+
+            it "returns nil and does not create a new past_registration" do
+              past_registration_count = registration.past_registrations.count
+
+              expect(past_registration).to eq(nil)
+
+              expect(registration.reload.past_registrations.count).to eq(past_registration_count)
+            end
           end
 
-          it "does not create a new past_registration" do
-            past_registration_count = registration.past_registrations.count
-            past_registration
-            expect(registration.reload.past_registrations.count).to eq(past_registration_count)
+          context "if the past registration is not a renewal" do
+            it "does create a new past_registration" do
+              past_registration_count = registration.past_registrations.count
+              past_registration
+              expect(registration.reload.past_registrations.count).to eq(past_registration_count + 1)
+            end
           end
         end
 


### PR DESCRIPTION
While working on other tasks, I noticed that the current implementation of PastRegistration#version_already_backed_up?
 is such that if an edit as ever been performed on a registration, at the time of renewal we would miss to create a ne
w past registration for that renewal.

This fixes that situation and add relevant test coverage.