### PR TITLE
Add registration already renewed screen for magic link error

### DIFF
--- a/app/controllers/waste_carriers_engine/renews_controller.rb
+++ b/app/controllers/waste_carriers_engine/renews_controller.rb
@@ -16,9 +16,10 @@ module WasteCarriersEngine
     private
 
     def validate_renew_token
+      return render(:already_renewed) if registration.already_renewed?
+
       # TODO
       # return render(:invalid_magic_link, status: 404) unless registration.present?
-      # return render(:already_renewed) if registration.already_renewed?
       # return render(:past_renewal_window) if registration.past_renewal_window?
     end
 

--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -53,7 +53,10 @@ module WasteCarriersEngine
     end
 
     def already_renewed?
-      check_service.date_can_renew_from > Time.now.in_time_zone("London").to_date
+      period_after_last_window = Rails.configuration.expires_after.years + Rails.configuration.grace_window.months
+      registration_window = expires_on - period_after_last_window + 1.day
+
+      past_registrations.where(cause: nil, :expires_on.gte => registration_window).any?
     end
 
     def expire!

--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -52,6 +52,10 @@ module WasteCarriersEngine
       save!
     end
 
+    def already_renewed?
+      check_service.date_can_renew_from > Time.now.in_time_zone("London").to_date
+    end
+
     def expire!
       metaData.status = "EXPIRED"
 
@@ -73,11 +77,14 @@ module WasteCarriersEngine
     end
 
     def renewable_date?
-      check_service = ExpiryCheckService.new(self)
       return true if check_service.in_expiry_grace_window?
       return false if check_service.expired?
 
       check_service.in_renewal_window?
+    end
+
+    def check_service
+      @_check_service ||= ExpiryCheckService.new(self)
     end
   end
 end

--- a/app/services/waste_carriers_engine/expiry_check_service.rb
+++ b/app/services/waste_carriers_engine/expiry_check_service.rb
@@ -4,7 +4,6 @@ module WasteCarriersEngine
   # Contains methods related to dealing with dates in the service, for example
   # whether a date would be considered as expired.
   class ExpiryCheckService
-    # attr_reader :expiry_date, :registration_date
     attr_reader :registration
 
     delegate :expires_on, to: :registration

--- a/app/services/waste_carriers_engine/expiry_check_service.rb
+++ b/app/services/waste_carriers_engine/expiry_check_service.rb
@@ -4,37 +4,38 @@ module WasteCarriersEngine
   # Contains methods related to dealing with dates in the service, for example
   # whether a date would be considered as expired.
   class ExpiryCheckService
-    attr_reader :expiry_date, :registration_date
+    # attr_reader :expiry_date, :registration_date
+    attr_reader :registration
+
+    delegate :expires_on, to: :registration
 
     def initialize(registration)
       raise "ExpiryCheckService expects a registration" if registration.nil?
 
-      @registration_date = registration.metaData.date_registered
-      @expires_on = registration.expires_on
-      @expiry_date = corrected_expires_on
+      @registration = registration
     end
 
     # For more details about the renewal window check out
     # https://github.com/DEFRA/dst-guides/blob/master/services/wcr/renewal_window.md
     def date_can_renew_from
-      (@expiry_date.to_date - Rails.configuration.renewal_window.months)
+      (expiry_date.to_date - Rails.configuration.renewal_window.months)
     end
 
     def expiry_date_after_renewal
-      @expiry_date.to_date + Rails.configuration.expires_after.years
+      expiry_date.to_date + Rails.configuration.expires_after.years
     end
 
     def expired?
       # Registrations are expired on the date recorded for their expiry date e.g.
       # an expiry date of Mar 25 2018 means the registration was active up till
       # 24:00 on Mar 24 2018.
-      @expiry_date.to_date <= current_day
+      expiry_date.to_date <= current_day
     end
 
     def in_renewal_window?
       # If the registration expires in more than x months from now, its outside
       # the renewal window
-      @expiry_date.to_date < Rails.configuration.renewal_window.months.from_now
+      expiry_date.to_date < Rails.configuration.renewal_window.months.from_now
     end
 
     # Its important to note that a registration is expired on its expires_on date.
@@ -44,9 +45,17 @@ module WasteCarriersEngine
     # till Oct 4 (i.e. 1 + 3) when in fact we need to include the 1st as one of
     # our grace window days.
     def in_expiry_grace_window?
-      last_day_of_grace_window = (@expiry_date.to_date + Rails.configuration.grace_window.days) - 1.day
+      last_day_of_grace_window = (expiry_date.to_date + Rails.configuration.grace_window.days) - 1.day
 
-      current_day >= @expiry_date.to_date && current_day <= last_day_of_grace_window
+      current_day >= expiry_date.to_date && current_day <= last_day_of_grace_window
+    end
+
+    def registration_date
+      @_registration_date ||= registration.metaData.date_registered
+    end
+
+    def expiry_date
+      @_expiry_date ||= corrected_expires_on
     end
 
     private
@@ -57,11 +66,11 @@ module WasteCarriersEngine
     # not be the same as the UK date. So compensate to avoid flagging something
     # as expired on the wrong date.
     def corrected_expires_on
-      return Date.new(1970, 1, 1) if @expires_on.nil?
-      return @expires_on + 1.hour if registered_in_bst_and_expires_in_gmt?
-      return @expires_on - 1.hour if registered_in_gmt_and_expires_in_bst?
+      return Date.new(1970, 1, 1) if expires_on.nil?
+      return expires_on + 1.hour if registered_in_bst_and_expires_in_gmt?
+      return expires_on - 1.hour if registered_in_gmt_and_expires_in_bst?
 
-      @expires_on
+      expires_on
     end
 
     def registered_in_bst_and_expires_in_gmt?
@@ -73,11 +82,11 @@ module WasteCarriersEngine
     end
 
     def registered_in_daylight_savings?
-      @registration_date.in_time_zone("London").dst?
+      registration_date.in_time_zone("London").dst?
     end
 
     def expires_on_in_daylight_savings?
-      @expires_on.in_time_zone("London").dst?
+      expires_on.in_time_zone("London").dst?
     end
 
     # We store dates and times in UTC, but want to use the current date in the

--- a/app/views/waste_carriers_engine/renews/already_renewed.html.erb
+++ b/app/views/waste_carriers_engine/renews/already_renewed.html.erb
@@ -1,0 +1,21 @@
+<div class="text">
+  <h1 class="heading-large">
+    <%= t(".heading") %>
+  </h1>
+
+  <p>
+    <%= t(".paragraph1", reg_identifier: @registration.reg_identifier) %>
+  </p>
+
+  <p>
+    <%= t(".paragraph2_html", link_to_new_registration: new_start_form_path) %>
+  </p>
+
+  <p>
+    <%= t(".paragraph3") %>
+  </p>
+
+  <p>
+    <%= t(".paragraph4_html") %>
+  </p>
+</div>

--- a/config/locales/forms/renews/en.yml
+++ b/config/locales/forms/renews/en.yml
@@ -4,6 +4,6 @@ en:
       already_renewed:
         heading: "That registration has already been renewed"
         paragraph1: "Our records show that registration %{reg_identifier} has already been renewed."
-        paragraph2_html: "If you need to register other waste exemptions you should <a href=\"%{link_to_new_registration}\">make a new registration.</a>"
+        paragraph2_html: "If you still need to register as a waste carrier, broker or dealer then <a href=\"%{link_to_new_registration}\">make a new registration.</a>"
         paragraph3: "If you want to discuss this registration, contact the Environment Agency. You will need your registration number."
-        paragraph4_html: "Environment Agency helpline: 03708 506 506 (Monday to Friday, 8am to 6pm) <a href=\"mailto:enquiries@environment-agency.gov.uk\">enquiries@environment-agency.gov.uk</a>"
+        paragraph4_html: "Environment Agency helpline: 03708 506 506 (Monday to Friday, 8am to 6pm) <a href=\"mailto:nccc-carrierbroker@environment-agency.gov.uk\">nccc-carrierbroker@environment-agency.gov.uk</a>"

--- a/config/locales/forms/renews/en.yml
+++ b/config/locales/forms/renews/en.yml
@@ -1,0 +1,9 @@
+en:
+  waste_carriers_engine:
+    renews:
+      already_renewed:
+        heading: "That registration has already been renewed"
+        paragraph1: "Our records show that registration %{reg_identifier} has already been renewed."
+        paragraph2_html: "If you need to register other waste exemptions you should <a href=\"%{link_to_new_registration}\">make a new registration.</a>"
+        paragraph3: "If you want to discuss this registration, contact the Environment Agency. You will need your registration number."
+        paragraph4_html: "Environment Agency helpline: 03708 506 506 (Monday to Friday, 8am to 6pm) <a href=\"mailto:enquiries@environment-agency.gov.uk\">enquiries@environment-agency.gov.uk</a>"

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -30,7 +30,11 @@ FactoryBot.define do
     end
 
     trait :already_renewed do
-      expires_on { Rails.configuration.expires_after.years.from_now.to_date }
+      expires_soon
+
+      after :create do |registration|
+        WasteCarriersEngine::PastRegistration.build_past_registration(registration)
+      end
     end
 
     trait :lower_tier do

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -29,6 +29,10 @@ FactoryBot.define do
       end
     end
 
+    trait :already_renewed do
+      expires_on { Rails.configuration.expires_after.years.from_now.to_date }
+    end
+
     trait :lower_tier do
       tier { "LOWER" }
     end

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -26,6 +26,26 @@ module WasteCarriersEngine
       end
     end
 
+    describe "#already_renewed?" do
+      let(:registration) { build(:registration, :has_required_data, expires_on: expires_on) }
+
+      context "when the renewal start date is in the future" do
+        let(:expires_on) { 10.years.from_now }
+
+        it "returns true" do
+          expect(registration).to be_already_renewed
+        end
+      end
+
+      context "when the renewal start date is not in the future" do
+        let(:expires_on) { Time.now }
+
+        it "returns false" do
+          expect(registration).to_not be_already_renewed
+        end
+      end
+    end
+
     describe "scopes" do
       describe ".active" do
         it "returns active registrations" do

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -27,19 +27,19 @@ module WasteCarriersEngine
     end
 
     describe "#already_renewed?" do
-      let(:registration) { build(:registration, :has_required_data, expires_on: expires_on) }
+      let(:registration) { create(:registration, :has_required_data, :expires_soon) }
 
-      context "when the renewal start date is in the future" do
-        let(:expires_on) { 10.years.from_now }
+      context "when the registraiton has already renewed" do
+        before do
+          PastRegistration.build_past_registration(registration)
+        end
 
         it "returns true" do
           expect(registration).to be_already_renewed
         end
       end
 
-      context "when the renewal start date is not in the future" do
-        let(:expires_on) { Time.now }
-
+      context "when the registraiton has not already renewed" do
         it "returns false" do
           expect(registration).to_not be_already_renewed
         end

--- a/spec/requests/waste_carriers_engine/renews_spec.rb
+++ b/spec/requests/waste_carriers_engine/renews_spec.rb
@@ -41,6 +41,21 @@ module WasteCarriersEngine
           end
         end
       end
+
+      context "when the registration has already been renewed" do
+        let(:registration) { create(:registration, :has_required_data, :already_renewed) }
+
+        it "returns a 200 response code and the correct template" do
+          allow(Rails.configuration).to receive(:renewal_window).and_return(3)
+
+          registration.generate_renew_token!
+
+          get renew_path(token: registration.renew_token)
+
+          expect(response).to have_http_status(200)
+          expect(response).to render_template(:already_renewed)
+        end
+      end
     end
   end
 end

--- a/spec/requests/waste_carriers_engine/renews_spec.rb
+++ b/spec/requests/waste_carriers_engine/renews_spec.rb
@@ -9,7 +9,7 @@ module WasteCarriersEngine
 
     describe "GET renew_path" do
       context "when the renew token is valid" do
-        let(:registration) { create(:registration, :has_required_data) }
+        let(:registration) { create(:registration, :has_required_data, :expires_soon) }
 
         it "returns a 302 response, creates a new renewal registration and redirect to the renewal start form" do
           registration.generate_renew_token!


### PR DESCRIPTION
From:https://eaflood.atlassian.net/browse/RUBY-1001

This adds an ad-hoc screen when the renewal link is hit after a registration has already been renewed

<img width="864" alt="Screenshot 2020-05-14 at 13 56 15" src="https://user-images.githubusercontent.com/1385397/81939445-41fbd680-95ee-11ea-846f-fa093146fb6c.png">
