### PR TITLE
Fix issues on renewals via magic link

### DIFF
--- a/app/models/waste_carriers_engine/finance_details.rb
+++ b/app/models/waste_carriers_engine/finance_details.rb
@@ -18,9 +18,10 @@ module WasteCarriersEngine
               presence: true
 
     def self.new_renewal_finance_details(transient_registration, method, current_user)
+      user_email = current_user&.email || transient_registration.contact_email
       finance_details = FinanceDetails.new
       finance_details.transient_registration = transient_registration
-      finance_details[:orders] = [Order.new_order(transient_registration, method, current_user)]
+      finance_details[:orders] = [Order.new_order(transient_registration, method, user_email)]
       finance_details.update_balance
       finance_details.save!
       finance_details

--- a/app/models/waste_carriers_engine/order.rb
+++ b/app/models/waste_carriers_engine/order.rb
@@ -26,8 +26,8 @@ module WasteCarriersEngine
     field :order_item_reference,                     type: String
 
     # TODO: Move to a service
-    def self.new_order(transient_registration, method, current_user)
-      order = new_order_for(current_user.email)
+    def self.new_order(transient_registration, method, user_email)
+      order = new_order_for(user_email)
 
       card_count = transient_registration.temp_cards
 

--- a/app/models/waste_carriers_engine/past_registration.rb
+++ b/app/models/waste_carriers_engine/past_registration.rb
@@ -19,7 +19,13 @@ module WasteCarriersEngine
 
       past_registration.registration = registration
 
-      attributes = registration.attributes.except("_id", "past_registrations", "locking_name", "locked_at", "renew_token")
+      attributes = registration.attributes.except(
+        "_id",
+        "past_registrations",
+        "locking_name",
+        "locked_at",
+        "renew_token"
+      )
       past_registration.assign_attributes(attributes)
 
       past_registration.save!

--- a/app/models/waste_carriers_engine/past_registration.rb
+++ b/app/models/waste_carriers_engine/past_registration.rb
@@ -19,7 +19,7 @@ module WasteCarriersEngine
 
       past_registration.registration = registration
 
-      attributes = registration.attributes.except("_id", "past_registrations", "locking_name", "locked_at")
+      attributes = registration.attributes.except("_id", "past_registrations", "locking_name", "locked_at", "renew_token")
       past_registration.assign_attributes(attributes)
 
       past_registration.save!

--- a/app/services/waste_carriers_engine/renewal_completion_service.rb
+++ b/app/services/waste_carriers_engine/renewal_completion_service.rb
@@ -105,22 +105,29 @@ module WasteCarriersEngine
     end
 
     def copy_data_from_transient_registration
-      registration_attributes = registration.attributes.except("_id", "financeDetails", "past_registrations")
-      renewal_attributes = transient_registration.attributes.except("_id",
-                                                                    "token",
-                                                                    "created_at",
-                                                                    "financeDetails",
-                                                                    "temp_cards",
-                                                                    "temp_company_postcode",
-                                                                    "temp_contact_postcode",
-                                                                    "temp_os_places_error",
-                                                                    "temp_payment_method",
-                                                                    "temp_tier_check",
-                                                                    "from_magic_link",
-                                                                    "_type",
-                                                                    "workflow_state",
-                                                                    "locking_name",
-                                                                    "locked_at")
+      registration_attributes = registration.attributes.except(
+        "_id",
+        "financeDetails",
+        "past_registrations",
+        "renew_token"
+      )
+      renewal_attributes = transient_registration.attributes.except(
+        "_id",
+        "token",
+        "created_at",
+        "financeDetails",
+        "temp_cards",
+        "temp_company_postcode",
+        "temp_contact_postcode",
+        "temp_os_places_error",
+        "temp_payment_method",
+        "temp_tier_check",
+        "from_magic_link",
+        "_type",
+        "workflow_state",
+        "locking_name",
+        "locked_at"
+      )
 
       remove_unused_attributes(registration_attributes, renewal_attributes)
 

--- a/app/services/waste_carriers_engine/renewal_completion_service.rb
+++ b/app/services/waste_carriers_engine/renewal_completion_service.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ClassLength
 module WasteCarriersEngine
   class RenewalCompletionService
     class CannotComplete < StandardError; end
@@ -104,6 +105,7 @@ module WasteCarriersEngine
       Airbrake.notify(e, registration_no: registration.reg_identifier) if defined?(Airbrake)
     end
 
+    # rubocop:disable Metrics/MethodLength
     def copy_data_from_transient_registration
       registration_attributes = registration.attributes.except(
         "_id",
@@ -133,6 +135,7 @@ module WasteCarriersEngine
 
       registration.write_attributes(renewal_attributes)
     end
+    # rubocop:enable Metrics/MethodLength
 
     def remove_unused_attributes(registration_attributes, renewal_attributes)
       registration_attributes.each_key do |old_attribute|
@@ -145,3 +148,4 @@ module WasteCarriersEngine
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/spec/models/waste_carriers_engine/order_spec.rb
+++ b/spec/models/waste_carriers_engine/order_spec.rb
@@ -15,7 +15,7 @@ module WasteCarriersEngine
     let(:current_user) { build(:user) }
 
     describe "new_order" do
-      let(:order) { Order.new_order(transient_registration, :worldpay, current_user) }
+      let(:order) { Order.new_order(transient_registration, :worldpay, current_user.email) }
 
       it "should have a valid order_id" do
         Timecop.freeze(Time.new(2018, 1, 1)) do

--- a/spec/services/waste_carriers_engine/renewal_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/renewal_completion_service_spec.rb
@@ -30,6 +30,8 @@ module WasteCarriersEngine
           :has_outstanding_copy_card
         )
       )
+
+      registration.generate_renew_token!
     end
 
     describe "#complete_renewal" do
@@ -43,6 +45,14 @@ module WasteCarriersEngine
         it "copies attributes from the transient_registration to the registration" do
           renewal_completion_service.complete_renewal
           expect(registration.reload.company_name).to eq(transient_registration.company_name)
+        end
+
+        it "does not update the renew_token" do
+          old_token = registration.renew_token
+          renewal_completion_service.complete_renewal
+
+          registration.reload
+          expect(registration.renew_token).to eq(old_token)
         end
 
         it "copies nested attributes from the transient_registration to the registration" do


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-987

This fixes two issues with renewing via magic link.
- Worldpay expects still a `current_user`, but when renewing via magic link there won't be one. Hence, this have been refactored to be in-line with the rest of the new code and pass around an email rather than a user to the Order class method
- When completing a renewal the completion services was failing for two reason: The PastRegistration could not be created because the object has no knowledge of the `renew_token` attribute, and when renewing the token was removed from the registration.