### PR TITLE
Add DataLayerHelper for tracking different journeys

### DIFF
--- a/app/helpers/waste_carriers_engine/data_layer_helper.rb
+++ b/app/helpers/waste_carriers_engine/data_layer_helper.rb
@@ -2,6 +2,8 @@
 
 module WasteCarriersEngine
   module DataLayerHelper
+    class UnexpectedSubtypeError < StandardError; end
+
     def data_layer(transient_registration)
       output = []
 
@@ -21,7 +23,9 @@ module WasteCarriersEngine
     end
 
     def data_layer_value_for_journey(transient_registration)
-      case transient_registration.class.name
+      subtype_name = transient_registration.class.name
+
+      case subtype_name
       when "WasteCarriersEngine::CeasedOrRevokedRegistration"
         :cease_or_revoke
       when "WasteCarriersEngine::EditRegistration"
@@ -32,6 +36,8 @@ module WasteCarriersEngine
         :order_copy_cards
       when "WasteCarriersEngine::RenewingRegistration"
         :renew
+      else
+        raise UnexpectedSubtypeError, "No user journey found for #{subtype_name}"
       end
     end
   end

--- a/app/helpers/waste_carriers_engine/data_layer_helper.rb
+++ b/app/helpers/waste_carriers_engine/data_layer_helper.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  module DataLayerHelper
+    def data_layer(transient_registration)
+      output = []
+
+      data_layer_hash(transient_registration).each do |key, value|
+        output << "'#{key}': '#{value}'"
+      end
+
+      output.join(",").html_safe
+    end
+
+    private
+
+    def data_layer_hash(transient_registration)
+      {
+        journey: data_layer_value_for_journey(transient_registration)
+      }
+    end
+
+    def data_layer_value_for_journey(transient_registration)
+      case transient_registration.class.name
+      when "WasteCarriersEngine::CeasedOrRevokedRegistration"
+        :cease_or_revoke
+      when "WasteCarriersEngine::EditRegistration"
+        :edit
+      when "WasteCarriersEngine::NewRegistration"
+        :new
+      when "WasteCarriersEngine::OrderCopyCardsRegistration"
+        :order_copy_cards
+      when "WasteCarriersEngine::RenewingRegistration"
+        :renew
+      end
+    end
+  end
+end

--- a/spec/helpers/waste_carriers_engine/data_layer_helper_spec.rb
+++ b/spec/helpers/waste_carriers_engine/data_layer_helper_spec.rb
@@ -55,6 +55,13 @@ module WasteCarriersEngine
           expect(helper.data_layer(transient_registration)).to eq(expected_string)
         end
       end
+
+      context "when the transient_registration is not a recognised subtype" do
+        let(:class_double) { "Foo" }
+        it "raises an error" do
+          expect { helper.data_layer(transient_registration) }.to raise_error(DataLayerHelper::UnexpectedSubtypeError)
+        end
+      end
     end
   end
 end

--- a/spec/helpers/waste_carriers_engine/data_layer_helper_spec.rb
+++ b/spec/helpers/waste_carriers_engine/data_layer_helper_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe WasteCarriersEngine::DataLayerHelper, type: :helper do
+    describe "data_layer" do
+      let(:transient_registration) { double(:transient_registration) }
+
+      before do
+        expect(transient_registration).to receive_message_chain(:class, :name).and_return(class_double)
+      end
+
+      context "when the transient_registration is a CeasedOrRevokedRegistration" do
+        let(:class_double) { "WasteCarriersEngine::CeasedOrRevokedRegistration" }
+        it "returns the correct value" do
+          expected_string = "'journey': 'cease_or_revoke'"
+
+          expect(helper.data_layer(transient_registration)).to eq(expected_string)
+        end
+      end
+
+      context "when the transient_registration is an EditRegistration" do
+        let(:class_double) { "WasteCarriersEngine::EditRegistration" }
+        it "returns the correct value" do
+          expected_string = "'journey': 'edit'"
+
+          expect(helper.data_layer(transient_registration)).to eq(expected_string)
+        end
+      end
+
+      context "when the transient_registration is a NewRegistration" do
+        let(:class_double) { "WasteCarriersEngine::NewRegistration" }
+        it "returns the correct value" do
+          expected_string = "'journey': 'new'"
+
+          expect(helper.data_layer(transient_registration)).to eq(expected_string)
+        end
+      end
+
+      context "when the transient_registration is an OrderCopyCardsRegistration" do
+        let(:class_double) { "WasteCarriersEngine::OrderCopyCardsRegistration" }
+        it "returns the correct value" do
+          expected_string = "'journey': 'order_copy_cards'"
+
+          expect(helper.data_layer(transient_registration)).to eq(expected_string)
+        end
+      end
+
+      context "when the transient_registration is a RenewingRegistration" do
+        let(:class_double) { "WasteCarriersEngine::RenewingRegistration" }
+        it "returns the correct value" do
+          expected_string = "'journey': 'renew'"
+
+          expect(helper.data_layer(transient_registration)).to eq(expected_string)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-950

We want to be able to track the performance of the new registration journey and the renewals journey. Because they use the same pages, we'll need a way to differentiate other than just using the URLs.

This PR will add a `data_layer` method that we will use in the front office header. This will be used by Google Tag Manager to send pageviews with the journey as a custom dimension to Google Analytics.

The initial plan was to put this helper in the front office as we do with WEX - however due to changes in the engines' ApplicationControllers, we've decided to put it in the engine instead.