### PR TITLE
Add tiers to data layer

### DIFF
--- a/app/helpers/waste_carriers_engine/data_layer_helper.rb
+++ b/app/helpers/waste_carriers_engine/data_layer_helper.rb
@@ -11,14 +11,15 @@ module WasteCarriersEngine
         output << "'#{key}': '#{value}'"
       end
 
-      output.join(",").html_safe
+      output.join(", ").html_safe
     end
 
     private
 
     def data_layer_hash(transient_registration)
       {
-        journey: data_layer_value_for_journey(transient_registration)
+        journey: data_layer_value_for_journey(transient_registration),
+        tier: data_layer_value_for_tier(transient_registration)
       }
     end
 
@@ -38,6 +39,16 @@ module WasteCarriersEngine
         :renew
       else
         raise UnexpectedSubtypeError, "No user journey found for #{subtype_name}"
+      end
+    end
+
+    def data_layer_value_for_tier(transient_registration)
+      if transient_registration.upper_tier?
+        :upper
+      elsif transient_registration.lower_tier?
+        :lower
+      else
+        :unknown
       end
     end
   end

--- a/spec/helpers/waste_carriers_engine/data_layer_helper_spec.rb
+++ b/spec/helpers/waste_carriers_engine/data_layer_helper_spec.rb
@@ -5,61 +5,106 @@ require "rails_helper"
 module WasteCarriersEngine
   RSpec.describe WasteCarriersEngine::DataLayerHelper, type: :helper do
     describe "data_layer" do
-      let(:transient_registration) { double(:transient_registration) }
+      let(:class_double) { "WasteCarriersEngine::NewRegistration" }
+      let(:upper_tier) { false }
+      let(:lower_tier) { false }
+      let(:transient_registration) do
+        double(:transient_registration,
+               upper_tier?: upper_tier,
+               lower_tier?: lower_tier)
+      end
 
       before do
         expect(transient_registration).to receive_message_chain(:class, :name).and_return(class_double)
       end
 
-      context "when the transient_registration is a CeasedOrRevokedRegistration" do
-        let(:class_double) { "WasteCarriersEngine::CeasedOrRevokedRegistration" }
-        it "returns the correct value" do
-          expected_string = "'journey': 'cease_or_revoke'"
+      it "returns data in the correct format" do
+        expected_string = "'journey': 'new', 'tier': 'unknown'"
 
-          expect(helper.data_layer(transient_registration)).to eq(expected_string)
+        expect(helper.data_layer(transient_registration)).to eq(expected_string)
+      end
+
+      describe "journeys" do
+        context "when the transient_registration is a CeasedOrRevokedRegistration" do
+          let(:class_double) { "WasteCarriersEngine::CeasedOrRevokedRegistration" }
+          it "returns the correct value" do
+            expected_string = "'journey': 'cease_or_revoke'"
+
+            expect(helper.data_layer(transient_registration)).to include(expected_string)
+          end
+        end
+
+        context "when the transient_registration is an EditRegistration" do
+          let(:class_double) { "WasteCarriersEngine::EditRegistration" }
+          it "returns the correct value" do
+            expected_string = "'journey': 'edit'"
+
+            expect(helper.data_layer(transient_registration)).to include(expected_string)
+          end
+        end
+
+        context "when the transient_registration is a NewRegistration" do
+          let(:class_double) { "WasteCarriersEngine::NewRegistration" }
+          it "returns the correct value" do
+            expected_string = "'journey': 'new'"
+
+            expect(helper.data_layer(transient_registration)).to include(expected_string)
+          end
+        end
+
+        context "when the transient_registration is an OrderCopyCardsRegistration" do
+          let(:class_double) { "WasteCarriersEngine::OrderCopyCardsRegistration" }
+          it "returns the correct value" do
+            expected_string = "'journey': 'order_copy_cards'"
+
+            expect(helper.data_layer(transient_registration)).to include(expected_string)
+          end
+        end
+
+        context "when the transient_registration is a RenewingRegistration" do
+          let(:class_double) { "WasteCarriersEngine::RenewingRegistration" }
+          it "returns the correct value" do
+            expected_string = "'journey': 'renew'"
+
+            expect(helper.data_layer(transient_registration)).to include(expected_string)
+          end
+        end
+
+        context "when the transient_registration is not a recognised subtype" do
+          let(:class_double) { "Foo" }
+          it "raises an error" do
+            expect { helper.data_layer(transient_registration) }.to raise_error(DataLayerHelper::UnexpectedSubtypeError)
+          end
         end
       end
 
-      context "when the transient_registration is an EditRegistration" do
-        let(:class_double) { "WasteCarriersEngine::EditRegistration" }
-        it "returns the correct value" do
-          expected_string = "'journey': 'edit'"
+      describe "tiers" do
+        context "when the transient_registration is upper tier" do
+          let(:upper_tier) { true }
 
-          expect(helper.data_layer(transient_registration)).to eq(expected_string)
+          it "returns the correct value" do
+            expected_string = "'tier': 'upper'"
+
+            expect(helper.data_layer(transient_registration)).to include(expected_string)
+          end
         end
-      end
 
-      context "when the transient_registration is a NewRegistration" do
-        let(:class_double) { "WasteCarriersEngine::NewRegistration" }
-        it "returns the correct value" do
-          expected_string = "'journey': 'new'"
+        context "when the transient_registration is lower tier" do
+          let(:lower_tier) { true }
 
-          expect(helper.data_layer(transient_registration)).to eq(expected_string)
+          it "returns the correct value" do
+            expected_string = "'tier': 'lower'"
+
+            expect(helper.data_layer(transient_registration)).to include(expected_string)
+          end
         end
-      end
 
-      context "when the transient_registration is an OrderCopyCardsRegistration" do
-        let(:class_double) { "WasteCarriersEngine::OrderCopyCardsRegistration" }
-        it "returns the correct value" do
-          expected_string = "'journey': 'order_copy_cards'"
+        context "when the transient_registration is neither upper nor lower tier" do
+          it "returns the correct value" do
+            expected_string = "'tier': 'unknown'"
 
-          expect(helper.data_layer(transient_registration)).to eq(expected_string)
-        end
-      end
-
-      context "when the transient_registration is a RenewingRegistration" do
-        let(:class_double) { "WasteCarriersEngine::RenewingRegistration" }
-        it "returns the correct value" do
-          expected_string = "'journey': 'renew'"
-
-          expect(helper.data_layer(transient_registration)).to eq(expected_string)
-        end
-      end
-
-      context "when the transient_registration is not a recognised subtype" do
-        let(:class_double) { "Foo" }
-        it "raises an error" do
-          expect { helper.data_layer(transient_registration) }.to raise_error(DataLayerHelper::UnexpectedSubtypeError)
+            expect(helper.data_layer(transient_registration)).to include(expected_string)
+          end
         end
       end
     end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-857

We were previously able to separate page views for new registrations and renewals in Google Analytics based on their different URL patterns. However, when the new registration journey is moved into the engine, many pages will have the same URLs. But we want to still be able to separate the pageviews for these journeys.

We can do this by adding a custom dimension to the data layer called "Tier" and configuring Google Tag Manager to pass that value to Google Analytics with the pageview. This allows us to filter pageviews by user journey when needed.

Since some early pages in the new registration journey won't yet have a tier, we use `unknown` as the default.