### PR TITLE
Fix titles rendering on error renew pages

### DIFF
--- a/app/views/waste_carriers_engine/renews/already_renewed.html.erb
+++ b/app/views/waste_carriers_engine/renews/already_renewed.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, t(".title") %>
+
 <div class="text">
   <h1 class="heading-large">
     <%= t(".heading") %>

--- a/app/views/waste_carriers_engine/renews/invalid_magic_link.html.erb
+++ b/app/views/waste_carriers_engine/renews/invalid_magic_link.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, t(".title") %>
+
 <div class="text">
   <h1 class="heading-large">
     <%= t(".heading") %>

--- a/app/views/waste_carriers_engine/renews/past_renewal_window.html.erb
+++ b/app/views/waste_carriers_engine/renews/past_renewal_window.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, t(".title") %>
+
 <div class="text">
   <h1 class="heading-large">
     <%= t(".heading") %>

--- a/config/locales/forms/renews/en.yml
+++ b/config/locales/forms/renews/en.yml
@@ -2,12 +2,14 @@ en:
   waste_carriers_engine:
     renews:
       already_renewed:
+        title: "That registration has already been renewed"
         heading: "That registration has already been renewed"
         paragraph1: "Our records show that registration %{reg_identifier} has already been renewed."
         paragraph2_html: "If you still need to register as a waste carrier, broker or dealer then <a href=\"%{link_to_new_registration}\">make a new registration.</a>"
         paragraph3: "If you want to discuss this registration, contact the Environment Agency. You will need your registration number."
         paragraph4_html: "Environment Agency helpline: 03708 506 506 (Monday to Friday, 8am to 6pm) <a href=\"mailto:nccc-carrierbroker@environment-agency.gov.uk\">nccc-carrierbroker@environment-agency.gov.uk</a>"
       past_renewal_window:
+        title: "This registration has expired"
         heading: "This registration has expired"
         paragraph1: "Your registration has expired so you cannot renew."
         register_again: "Register again"


### PR DESCRIPTION
These pages are rendered using the `new` action but different templates name. For this reason, the usual method of rendering titles which is present in the application helper cannot fetch the correct translation, as it is only based on the action name.
Hence, we decided to explicitely set titles using `content_for`.