### PR TITLE
Add 'finished' button to new reg end pages

### DIFF
--- a/app/views/shared/_registration_finished_button.html.erb
+++ b/app/views/shared/_registration_finished_button.html.erb
@@ -1,3 +1,3 @@
 <% if WasteCarriersEngine.configuration.link_from_journeys_to_dashboards == true %>
-  <%= link_to t(".next_button"), main_app.root_path, class: 'button' %>
+  <p><%= link_to t(".next_button"), main_app.root_path, class: 'button' %></p>
 <% end %>

--- a/app/views/shared/_registration_finished_button.html.erb
+++ b/app/views/shared/_registration_finished_button.html.erb
@@ -1,1 +1,3 @@
-<%= link_to t(".next_button"), "#", class: 'button' %>
+<% if WasteCarriersEngine.configuration.link_from_journeys_to_dashboards == true %>
+  <%= link_to t(".next_button"), "#", class: 'button' %>
+<% end %>

--- a/app/views/shared/_registration_finished_button.html.erb
+++ b/app/views/shared/_registration_finished_button.html.erb
@@ -1,0 +1,1 @@
+<%= link_to t(".next_button"), "#", class: 'button' %>

--- a/app/views/shared/_registration_finished_button.html.erb
+++ b/app/views/shared/_registration_finished_button.html.erb
@@ -1,3 +1,3 @@
 <% if WasteCarriersEngine.configuration.link_from_journeys_to_dashboards == true %>
-  <%= link_to t(".next_button"), "#", class: 'button' %>
+  <%= link_to t(".next_button"), main_app.root_path, class: 'button' %>
 <% end %>

--- a/app/views/waste_carriers_engine/registration_completed_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/registration_completed_forms/new.html.erb
@@ -21,5 +21,7 @@
 
   <%= render "shared/registration_checks" %>
 
+  <%= render "shared/registration_finished_button" %>
+
   <%= render "shared/link_to_survey" %>
 </div>

--- a/app/views/waste_carriers_engine/registration_received_pending_conviction_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/registration_received_pending_conviction_forms/new.html.erb
@@ -17,5 +17,7 @@
 
   <%= render "shared/registration_checks" %>
 
+  <%= render "shared/registration_finished_button" %>
+
   <%= render "shared/link_to_survey" %>
 </div>

--- a/app/views/waste_carriers_engine/registration_received_pending_payment_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/registration_received_pending_payment_forms/new.html.erb
@@ -29,5 +29,7 @@
 
   <%= render "shared/registration_checks" %>
 
+  <%= render "shared/registration_finished_button" %>
+
   <%= render "shared/link_to_survey" %>
 </div>

--- a/app/views/waste_carriers_engine/registration_received_pending_worldpay_payment_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/registration_received_pending_worldpay_payment_forms/new.html.erb
@@ -17,5 +17,7 @@
 
   <%= render "shared/registration_checks" %>
 
+  <%= render "shared/registration_finished_button" %>
+
   <%= render "shared/link_to_survey" %>
 </div>

--- a/config/locales/shared/registration_finished_button.en.yml
+++ b/config/locales/shared/registration_finished_button.en.yml
@@ -1,0 +1,4 @@
+en:
+  shared:
+    registration_finished_button:
+      next_button: "Finished"

--- a/lib/waste_carriers_engine.rb
+++ b/lib/waste_carriers_engine.rb
@@ -25,6 +25,8 @@ module WasteCarriersEngine
   class Configuration
     # AD config
     attr_accessor :assisted_digital_email
+    # Link to dashboard from user journeys
+    attr_accessor :link_from_journeys_to_dashboards
     # Companies house API config
     attr_reader :companies_house_host, :companies_house_api_key
     # Address lookup config

--- a/spec/requests/waste_carriers_engine/registration_completed_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/registration_completed_forms_spec.rb
@@ -47,6 +47,26 @@ module WasteCarriersEngine
           end
         end
 
+        context "when link_from_journeys_to_dashboards is enabled" do
+          before { allow(WasteCarriersEngine.configuration).to receive(:link_from_journeys_to_dashboards).and_return(true) }
+
+          it "includes the finished button" do
+            get new_registration_completed_form_path(transient_registration.token)
+
+            expect(response.body).to include("Finished")
+          end
+        end
+
+        context "when link_from_journeys_to_dashboards is disabled" do
+          before { allow(WasteCarriersEngine.configuration).to receive(:link_from_journeys_to_dashboards).and_return(false) }
+
+          it "does not include the finished button" do
+            get new_registration_completed_form_path(transient_registration.token)
+
+            expect(response.body).to_not include("Finished")
+          end
+        end
+
         context "when the workflow_state is correct" do
           before do
             transient_registration.finance_details = build(:finance_details, :has_paid_order_and_payment)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1043

When users reach the end of the new registration journey, there should be a 'finished' button. This will take them back to the dashboard.

This should only appear in the back office, so we'll need a way to toggle it on and off.

---

When the button is enabled:

![image](https://user-images.githubusercontent.com/13369917/83168213-0c381100-a109-11ea-9f77-779ec8b86d6a.png)
