### PR TITLE
Move .not_cancelled scope to Registration

### DIFF
--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -30,6 +30,7 @@ module WasteCarriersEngine
     scope :expired_at_end_of_today, -> { where(:expires_on.lte => Time.now.in_time_zone("London").end_of_day) }
     scope :upper_tier, -> { where(tier: UPPER_TIER) }
     scope :active_and_expired, -> { where("metaData.status" => { :$in => %w[ACTIVE EXPIRED] }) }
+    scope :not_cancelled, -> { where("metaData.status" => { :$nin => %w[INACTIVE] }) }
 
     field :renew_token, type: String
 

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -27,7 +27,6 @@ module WasteCarriersEngine
     scope :submitted, -> { where(:workflow_state.in => RenewingRegistration::SUBMITTED_STATES) }
     scope :pending_payment, -> { submitted.where(:"financeDetails.balance".gt => 0) }
     scope :pending_approval, -> { submitted.where("conviction_sign_offs.0.confirmed": "no") }
-    scope :not_cancelled, -> { where("metaData.status" => { :$nin => %w[INACTIVE] }) }
 
     def total_to_pay
       charges = registration_type_base_charges

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -131,5 +131,9 @@ FactoryBot.define do
     trait :is_expired do
       metaData { build(:metaData, :has_required_data, status: :EXPIRED) }
     end
+
+    trait :cancelled do
+      metaData { build(:metaData, :cancelled) }
+    end
   end
 end

--- a/spec/factories/transient_registration.rb
+++ b/spec/factories/transient_registration.rb
@@ -10,10 +10,6 @@ FactoryBot.define do
       has_postcode
     end
 
-    trait :cancelled do
-      metaData { build(:metaData, :cancelled) }
-    end
-
     trait :has_addresses do
       addresses { [build(:address, :has_required_data, :registered, :from_os_places), build(:address, :has_required_data, :contact, :from_os_places)] }
     end

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -136,6 +136,18 @@ module WasteCarriersEngine
           expect(result).to_not include(lower_tier_registration)
         end
       end
+
+      describe ".not_cancelled" do
+        it "returns objects that are not in an INACTIVE state" do
+          cancelled_registration = create(:registration, :has_required_data, :cancelled)
+          active_registration = create(:registration, :has_required_data)
+
+          results = described_class.not_cancelled
+
+          expect(results).to include(active_registration)
+          expect(results).to_not include(cancelled_registration)
+        end
+      end
     end
 
     describe "#generate_renew_token" do

--- a/spec/models/waste_carriers_engine/transient_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/transient_registration_spec.rb
@@ -52,18 +52,6 @@ module WasteCarriersEngine
       it_should_behave_like "Can filter conviction status"
     end
 
-    describe ".not_cancelled" do
-      it "returns objects that are not in an INACTIVE state" do
-        cancelled_transient_registration = create(:transient_registration, :cancelled)
-        active_transient_registration = create(:transient_registration)
-
-        results = described_class.not_cancelled
-
-        expect(results).to include(active_transient_registration)
-        expect(results).to_not include(cancelled_transient_registration)
-      end
-    end
-
     describe "#rejected_conviction_checks?" do
       before do
         allow(transient_registration).to receive(:conviction_sign_offs).and_return(conviction_sign_offs)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1041

This scope is designed to catch submitted new registrations which have been cancelled, specifically so they don't show up in the convictions check list. Only Registrations can be cancelled at the moment, so moving this from the TransientRegistration model to the Registration model.