### PR TITLE
Send finished button to /bo instead of root

### DIFF
--- a/app/views/shared/_registration_finished_button.html.erb
+++ b/app/views/shared/_registration_finished_button.html.erb
@@ -1,3 +1,3 @@
 <% if WasteCarriersEngine.configuration.link_from_journeys_to_dashboards == true %>
-  <p><%= link_to t(".next_button"), main_app.root_path, class: 'button' %></p>
+  <p><%= link_to t(".next_button"), "/bo", class: 'button' %></p>
 <% end %>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1043

I'd assumed we were redirecting the root of the old backend to /bo but that's not the case. So this makes the finished button more specific.

Not great to hardcode in /bo, I know, but we have done it elsewhere in the engine already.