### PR TITLE
Update email validation to match wireframe

### DIFF
--- a/app/forms/waste_carriers_engine/contact_email_form.rb
+++ b/app/forms/waste_carriers_engine/contact_email_form.rb
@@ -5,7 +5,7 @@ module WasteCarriersEngine
     delegate :contact_email, to: :transient_registration
     attr_accessor :confirmed_email
 
-    validates :contact_email, :confirmed_email, "defra_ruby/validators/email": true
+    validates :contact_email, "defra_ruby/validators/email": true
     validates :confirmed_email, "waste_carriers_engine/matching_email": { compare_to: :contact_email }
 
     after_initialize :populate_confirmed_email

--- a/config/locales/forms/contact_email_forms/en.yml
+++ b/config/locales/forms/contact_email_forms/en.yml
@@ -21,7 +21,7 @@ en:
             confirmed_email:
               blank: "Enter your email address again to confirm it"
               invalid_format: "Enter a valid confirmed email address - there’s a mistake in that one"
-              does_not_match: "The email addresses you’ve entered don’t match"
+              does_not_match: "Enter your email address again to confirm it"
             reg_identifier:
               invalid_format: "The registration ID is not in a valid format"
               no_registration: "There is no registration matching this ID"


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-923

In order to achieve the wireframe validation, we only validate the confirmed email to be equal to the given email and we don't validate its format. There is no need to do so if the format has to be validated for the original email and the two must match.

This achieve having only one validation message that matches what the wireframe shows to the user.