### PR TITLE
Promote little FeatureToggle to be a proper Model

### DIFF
--- a/app/models/waste_carriers_engine/feature_toggle.rb
+++ b/app/models/waste_carriers_engine/feature_toggle.rb
@@ -5,11 +5,20 @@ require "erb"
 
 module WasteCarriersEngine
   class FeatureToggle
+    include Mongoid::Document
+
+    # Use the FeatureToggles database
+    store_in collection: "feature_toggles"
+
+    field :key, type: String
+    field :active, type: Boolean, default: false
+
     def self.active?(feature_name)
-      feature_toggles[feature_name] && (
-        feature_toggles[feature_name][:active] == true ||
-        feature_toggles[feature_name][:active] == "true"
-      )
+      from_database = where(key: feature_name).first
+
+      return from_file(feature_name) unless from_database.present?
+
+      from_database.active
     end
 
     class << self
@@ -20,6 +29,13 @@ module WasteCarriersEngine
         @@feature_toggles ||= load_feature_toggles
       end
       # rubocop:enable Style/ClassVars
+
+      def from_file(feature_name)
+        feature_toggles[feature_name] && (
+          feature_toggles[feature_name][:active] == true ||
+          feature_toggles[feature_name][:active] == "true"
+        )
+      end
 
       def load_feature_toggles
         HashWithIndifferentAccess.new(YAML.safe_load(ERB.new(File.read(file_path)).result))

--- a/spec/factories/feature_toggle.rb
+++ b/spec/factories/feature_toggle.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :feature_toggle do
+    key { "test-feature" }
+
+    active { false }
+  end
+end

--- a/spec/factories/feature_toggle.rb
+++ b/spec/factories/feature_toggle.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :feature_toggle do
+  factory :feature_toggle, class: WasteCarriersEngine::FeatureToggle do
     key { "test-feature" }
 
     active { false }

--- a/spec/models/waste_carriers_engine/feature_toggle_spec.rb
+++ b/spec/models/waste_carriers_engine/feature_toggle_spec.rb
@@ -5,53 +5,79 @@ require "rails_helper"
 module WasteCarriersEngine
   RSpec.describe FeatureToggle do
     describe ".active?" do
-      context "when a feature toggle config exist" do
-        context "when it is configured as active" do
+      context "when a record exist with the given key" do
+        let(:key) { "toggle_1" }
+
+        before do
+          create(:feature_toggle, key: key, active: active)
+        end
+
+        context "when the toggle is active" do
+          let(:active) { true }
+
           it "returns true" do
-            expect(described_class.active?("active_test_feature")).to be_truthy
-          end
-
-          it "accept either strings or syms" do
-            expect(described_class.active?(:active_test_feature)).to be_truthy
+            expect(described_class.active?(key)).to eq(true)
           end
         end
 
-        context "when it is configured as not active" do
+        context "when the toggle is not active" do
+          let(:active) { false }
+
           it "returns false" do
-            expect(described_class.active?("not_active_test_feature")).to be_falsey
-          end
-        end
-
-        context "when the feature toggle contains a typo in the return value" do
-          it "returns false" do
-            expect(described_class.active?("broken_test_feature")).to be_falsey
-          end
-        end
-
-        context "when the feature toggle contains a typo in the structure level" do
-          it "returns false" do
-            expect(described_class.active?("broken_test_feature_2")).to be_falsey
-          end
-        end
-
-        context "when the feature toggle is a string containing 'true'" do
-          it "returns true" do
-            expect(described_class.active?("string_true_test_feature")).to be_truthy
-          end
-        end
-
-        context "when the feature toggle is an environment variable" do
-          it "returns true" do
-            ENV["ENV_VARIABLE_TEST_FEATURE"] = "true"
-
-            expect(described_class.active?("env_variable_test_feature")).to be_truthy
+            expect(described_class.active?(key)).to eq(false)
           end
         end
       end
 
-      context "when a feature toggle config does not exist" do
-        it "returns false" do
-          expect(described_class.active?("i_do_not_exist")).to be_falsey
+      context "when a record does not exist with the given key" do
+        context "when a feature toggle config exist" do
+          context "when it is configured as active" do
+            it "returns true" do
+              expect(described_class.active?("active_test_feature")).to be_truthy
+            end
+
+            it "accept either strings or syms" do
+              expect(described_class.active?(:active_test_feature)).to be_truthy
+            end
+          end
+
+          context "when it is configured as not active" do
+            it "returns false" do
+              expect(described_class.active?("not_active_test_feature")).to be_falsey
+            end
+          end
+
+          context "when the feature toggle contains a typo in the return value" do
+            it "returns false" do
+              expect(described_class.active?("broken_test_feature")).to be_falsey
+            end
+          end
+
+          context "when the feature toggle contains a typo in the structure level" do
+            it "returns false" do
+              expect(described_class.active?("broken_test_feature_2")).to be_falsey
+            end
+          end
+
+          context "when the feature toggle is a string containing 'true'" do
+            it "returns true" do
+              expect(described_class.active?("string_true_test_feature")).to be_truthy
+            end
+          end
+
+          context "when the feature toggle is an environment variable" do
+            it "returns true" do
+              ENV["ENV_VARIABLE_TEST_FEATURE"] = "true"
+
+              expect(described_class.active?("env_variable_test_feature")).to be_truthy
+            end
+          end
+        end
+
+        context "when a feature toggle config does not exist" do
+          it "returns false" do
+            expect(described_class.active?("i_do_not_exist")).to be_falsey
+          end
         end
       end
     end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-1118

Given that little FeatureToggle has behaved very well in the past few months, we decided to upgrade him to be a proper Model. XD

This model will be used by the new defra-ruby-features engine. Toggles will be persisted in the database.

Things to notice is, in order to handle the fact that the model won't have persisted data about existing toggles, previously persisted in a yml file for read-only, the code will handle that case by redirecting the query for a toggle status to the content of the yml file.
By doing this we will just need to deploy and then take our time creating the toggles through the back office interface. In the meantime, everything will work just fine.

There will need some cleanup to be done at the subsequent deploy, but this still looks like a cleaner solution than a rake task, so that we don't need to cleanup places like Jenkins.