### PR TITLE
Move feature toggle config to engine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,12 @@ gem "secure_headers", "~> 5.0"
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
 gem "turbolinks"
 
+# Use the Defra Ruby Features gem to allow users with the correct permissions to
+# manage feature toggle (create / update / delete) from the back-office.
+gem "defra-ruby-features",
+    git: "https://github.com/DEFRA/defra-ruby-features",
+    branch: "main"
+
 group :development, :test do
   # Call "binding.pry" anywhere in the code to stop execution and get a debugger console
   gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/DEFRA/defra-ruby-features
+  revision: 4d94a5c259067b6e706dbda673d1e035ccd119cf
+  branch: main
+  specs:
+    defra-ruby-features (0.1.0)
+      rails (~> 6.0.3, >= 6.0.3.2)
+
 PATH
   remote: .
   specs:
@@ -380,6 +388,7 @@ PLATFORMS
 DEPENDENCIES
   cancancan (~> 1.10)
   database_cleaner
+  defra-ruby-features!
   defra_ruby_style
   devise (>= 4.4.3)
   dotenv-rails

--- a/lib/waste_carriers_engine.rb
+++ b/lib/waste_carriers_engine.rb
@@ -87,6 +87,14 @@ module WasteCarriersEngine
       end
     end
 
+    # Tell the engine where to find a model to use in order to persist feature
+    # toggles data
+    def feature_toggle_model_name=(value)
+      DefraRubyFeatures.configure do |configuration|
+        configuration.feature_toggle_model_name = "::WasteCarriersEngine::FeatureToggle"
+      end
+    end
+
     private
 
     # If the setting's value is "true", then set to a boolean true. Otherwise,

--- a/lib/waste_carriers_engine.rb
+++ b/lib/waste_carriers_engine.rb
@@ -91,7 +91,7 @@ module WasteCarriersEngine
     # toggles data
     def feature_toggle_model_name=(value)
       DefraRubyFeatures.configure do |configuration|
-        configuration.feature_toggle_model_name = "::WasteCarriersEngine::FeatureToggle"
+        configuration.feature_toggle_model_name = value
       end
     end
 

--- a/lib/waste_carriers_engine/engine.rb
+++ b/lib/waste_carriers_engine/engine.rb
@@ -7,6 +7,7 @@ require "high_voltage"
 require "defra_ruby/address"
 require "defra_ruby/alert"
 require "defra_ruby_email"
+require "defra_ruby_features"
 require "defra_ruby_validators"
 
 module WasteCarriersEngine


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1118

We have created a number of gems to support reuse of functionality across our services. If the functionality is to be used across both host apps, or because of other functionality, we'll incorporate the gem into the engine. [defra-ruby-alert](https://github.com/DEFRA/defra-ruby-alert) is an example of this.

Our typical pattern when we do this is to then control any config for that gem from the engine, and if extra info is needed from the host apps to pass it via the engines config.

[defra-ruby-features](https://github.com/DEFRA/defra-ruby-features) has been implemented by referencing and configuring the gem directly in the host apps. So to make things consistent this change updates the implementation to match our existing pattern of controlling everything from the engine.