### PR TITLE
Fix missing 'skip to manual entry' link on postcode lookups

### DIFF
--- a/app/validators/concerns/waste_carriers_engine/can_add_validation_errors.rb
+++ b/app/validators/concerns/waste_carriers_engine/can_add_validation_errors.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  module CanAddValidationErrors
+    private
+
+    def add_validation_error(record, attribute, error)
+      record.errors.add(attribute,
+                        error,
+                        message: error_message(record, attribute, error))
+    end
+
+    def error_message(record, attribute, error)
+      class_name = record.class.to_s.underscore
+      I18n.t("activemodel.errors.models.#{class_name}.attributes.#{attribute}.#{error}")
+    end
+  end
+end

--- a/app/validators/waste_carriers_engine/address_validator.rb
+++ b/app/validators/waste_carriers_engine/address_validator.rb
@@ -2,6 +2,8 @@
 
 module WasteCarriersEngine
   class AddressValidator < ActiveModel::EachValidator
+    include CanAddValidationErrors
+
     def validate_each(record, attribute, value)
       return false unless value_is_present?(record, attribute, value)
 
@@ -13,9 +15,7 @@ module WasteCarriersEngine
     def value_is_present?(record, attribute, value)
       return true if value.present?
 
-      record.errors.add(attribute,
-                        :blank,
-                        message: error_message(record, attribute, "blank"))
+      add_validation_error(record, attribute, :blank)
       false
     end
 
@@ -31,24 +31,15 @@ module WasteCarriersEngine
       return true if value.address_mode == "address-results"
       return true if value.address_mode == "manual-uk"
 
-      record.errors.add(attribute,
-                        :should_be_uk,
-                        message: error_message(record, attribute, "should_be_uk"))
+      add_validation_error(record, attribute, :should_be_uk)
       false
     end
 
     def valid_overseas_address?(record, attribute, value)
       return true if value.address_mode == "manual-foreign"
 
-      record.errors.add(attribute,
-                        :should_be_overseas,
-                        message: error_message(record, attribute, "should_be_overseas"))
+      add_validation_error(record, attribute, :should_be_overseas)
       false
-    end
-
-    def error_message(record, attribute, error)
-      class_name = record.class.to_s.underscore
-      I18n.t("activemodel.errors.models.#{class_name}.attributes.#{attribute}.#{error}")
     end
   end
 end

--- a/app/validators/waste_carriers_engine/address_validator.rb
+++ b/app/validators/waste_carriers_engine/address_validator.rb
@@ -13,7 +13,9 @@ module WasteCarriersEngine
     def value_is_present?(record, attribute, value)
       return true if value.present?
 
-      record.errors[attribute] << error_message(record, attribute, "blank")
+      record.errors.add(attribute,
+                        :blank,
+                        message: error_message(record, attribute, "blank"))
       false
     end
 
@@ -29,14 +31,18 @@ module WasteCarriersEngine
       return true if value.address_mode == "address-results"
       return true if value.address_mode == "manual-uk"
 
-      record.errors[attribute] << error_message(record, attribute, "should_be_uk")
+      record.errors.add(attribute,
+                        :should_be_uk,
+                        message: error_message(record, attribute, "should_be_uk"))
       false
     end
 
     def valid_overseas_address?(record, attribute, value)
       return true if value.address_mode == "manual-foreign"
 
-      record.errors[attribute] << error_message(record, attribute, "should_be_overseas")
+      record.errors.add(attribute,
+                        :should_be_overseas,
+                        message: error_message(record, attribute, "should_be_overseas"))
       false
     end
 

--- a/app/validators/waste_carriers_engine/company_name_validator.rb
+++ b/app/validators/waste_carriers_engine/company_name_validator.rb
@@ -13,14 +13,18 @@ module WasteCarriersEngine
     def value_is_present?(record, attribute, value)
       return true if value.present?
 
-      record.errors[attribute] << error_message(record, attribute, "blank")
+      record.errors.add(attribute,
+                        :blank,
+                        message: error_message(record, attribute, "blank"))
       false
     end
 
     def value_is_not_too_long?(record, attribute, value)
       return true if value.length < 256
 
-      record.errors[attribute] << error_message(record, attribute, "too_long")
+      record.errors.add(attribute,
+                        :too_long,
+                        message: error_message(record, attribute, "too_long"))
       false
     end
 

--- a/app/validators/waste_carriers_engine/company_name_validator.rb
+++ b/app/validators/waste_carriers_engine/company_name_validator.rb
@@ -2,6 +2,8 @@
 
 module WasteCarriersEngine
   class CompanyNameValidator < ActiveModel::EachValidator
+    include CanAddValidationErrors
+
     def validate_each(record, attribute, value)
       return false unless value_is_present?(record, attribute, value)
 
@@ -13,24 +15,15 @@ module WasteCarriersEngine
     def value_is_present?(record, attribute, value)
       return true if value.present?
 
-      record.errors.add(attribute,
-                        :blank,
-                        message: error_message(record, attribute, "blank"))
+      add_validation_error(record, attribute, :blank)
       false
     end
 
     def value_is_not_too_long?(record, attribute, value)
       return true if value.length < 256
 
-      record.errors.add(attribute,
-                        :too_long,
-                        message: error_message(record, attribute, "too_long"))
+      add_validation_error(record, attribute, :too_long)
       false
-    end
-
-    def error_message(record, attribute, error)
-      class_name = record.class.to_s.underscore
-      I18n.t("activemodel.errors.models.#{class_name}.attributes.#{attribute}.#{error}")
     end
   end
 end

--- a/app/validators/waste_carriers_engine/matching_email_validator.rb
+++ b/app/validators/waste_carriers_engine/matching_email_validator.rb
@@ -8,7 +8,9 @@ module WasteCarriersEngine
       email_address_to_confirm = record.send(options[:compare_to])
       return true if value == email_address_to_confirm || value.blank?
 
-      record.errors[attribute] << error_message(record, attribute, "does_not_match")
+      record.errors.add(attribute,
+                        :does_not_match,
+                        message: error_message(record, attribute, "does_not_match"))
       false
     end
 

--- a/app/validators/waste_carriers_engine/matching_email_validator.rb
+++ b/app/validators/waste_carriers_engine/matching_email_validator.rb
@@ -2,23 +2,16 @@
 
 module WasteCarriersEngine
   class MatchingEmailValidator < ActiveModel::EachValidator
+    include CanAddValidationErrors
+
     # Expects to be passed an attribute on the same record to confirm against,
     # for example: validates :confirmed_email, matching_email: { compare_to: :contact_email }
     def validate_each(record, attribute, value)
       email_address_to_confirm = record.send(options[:compare_to])
       return true if value == email_address_to_confirm || value.blank?
 
-      record.errors.add(attribute,
-                        :does_not_match,
-                        message: error_message(record, attribute, "does_not_match"))
+      add_validation_error(record, attribute, :does_not_match)
       false
-    end
-
-    private
-
-    def error_message(record, attribute, error)
-      class_name = record.class.to_s.underscore
-      I18n.t("activemodel.errors.models.#{class_name}.attributes.#{attribute}.#{error}")
     end
   end
 end

--- a/app/validators/waste_carriers_engine/person_name_validator.rb
+++ b/app/validators/waste_carriers_engine/person_name_validator.rb
@@ -2,6 +2,8 @@
 
 module WasteCarriersEngine
   class PersonNameValidator < ActiveModel::EachValidator
+    include CanAddValidationErrors
+
     def validate_each(record, attribute, value)
       return false unless value_is_present?(record, attribute, value)
 
@@ -14,18 +16,14 @@ module WasteCarriersEngine
     def value_is_present?(record, attribute, value)
       return true if value.present?
 
-      record.errors.add(attribute,
-                        :blank,
-                        message: error_message(record, attribute, "blank"))
+      add_validation_error(record, attribute, :blank)
       false
     end
 
     def value_is_not_too_long?(record, attribute, value)
       return true if value.length < 71
 
-      record.errors.add(attribute,
-                        :too_long,
-                        message: error_message(record, attribute, "too_long"))
+      add_validation_error(record, attribute, :too_long)
       false
     end
 
@@ -33,15 +31,8 @@ module WasteCarriersEngine
       # Name fields must contain only letters, spaces, commas, full stops, hyphens and apostrophes
       return true if value.match?(/\A[-a-z\s,.']+\z/i)
 
-      record.errors.add(attribute,
-                        :invalid,
-                        message: error_message(record, attribute, "invalid"))
+      add_validation_error(record, attribute, :invalid)
       false
-    end
-
-    def error_message(record, attribute, error)
-      class_name = record.class.to_s.underscore
-      I18n.t("activemodel.errors.models.#{class_name}.attributes.#{attribute}.#{error}")
     end
   end
 end

--- a/app/validators/waste_carriers_engine/person_name_validator.rb
+++ b/app/validators/waste_carriers_engine/person_name_validator.rb
@@ -14,14 +14,18 @@ module WasteCarriersEngine
     def value_is_present?(record, attribute, value)
       return true if value.present?
 
-      record.errors[attribute] << error_message(record, attribute, "blank")
+      record.errors.add(attribute,
+                        :blank,
+                        message: error_message(record, attribute, "blank"))
       false
     end
 
     def value_is_not_too_long?(record, attribute, value)
       return true if value.length < 71
 
-      record.errors[attribute] << error_message(record, attribute, "too_long")
+      record.errors.add(attribute,
+                        :too_long,
+                        message: error_message(record, attribute, "too_long"))
       false
     end
 
@@ -29,7 +33,9 @@ module WasteCarriersEngine
       # Name fields must contain only letters, spaces, commas, full stops, hyphens and apostrophes
       return true if value.match?(/\A[-a-z\s,.']+\z/i)
 
-      record.errors[attribute] << error_message(record, attribute, "invalid")
+      record.errors.add(attribute,
+                        :invalid,
+                        message: error_message(record, attribute, "invalid"))
       false
     end
 

--- a/app/validators/waste_carriers_engine/postcode_validator.rb
+++ b/app/validators/waste_carriers_engine/postcode_validator.rb
@@ -16,14 +16,18 @@ module WasteCarriersEngine
     def value_is_present?(record, attribute, value)
       return true if value.present?
 
-      record.errors[attribute] << error_message(record, attribute, "blank")
+      record.errors.add(attribute,
+                        :blank,
+                        message: error_message(record, attribute, "blank"))
       false
     end
 
     def value_uses_correct_format?(record, attribute, value)
       return true if UKPostcode.parse(value).full_valid?
 
-      record.errors[attribute] << error_message(record, attribute, "wrong_format")
+      record.errors.add(attribute,
+                        :wrong_format,
+                        message: error_message(record, attribute, "wrong_format"))
       false
     end
 
@@ -33,7 +37,9 @@ module WasteCarriersEngine
       return true if response.successful?
 
       if response.error.is_a?(DefraRuby::Address::NoMatchError)
-        record.errors[attribute] << error_message(record, attribute, "no_results")
+        record.errors.add(attribute,
+                          :no_results,
+                          message: error_message(record, attribute, "no_results"))
         false
       else
         record.transient_registration.temp_os_places_error = true

--- a/app/validators/waste_carriers_engine/reg_identifier_validator.rb
+++ b/app/validators/waste_carriers_engine/reg_identifier_validator.rb
@@ -2,6 +2,8 @@
 
 module WasteCarriersEngine
   class RegIdentifierValidator < ActiveModel::EachValidator
+    include CanAddValidationErrors
+
     def validate_each(record, attribute, value)
       valid_format?(record, attribute, value)
       matches_existing_registration?(record, attribute, value)
@@ -14,24 +16,15 @@ module WasteCarriersEngine
       # Format should be CBDU or CBDL, followed by at least one digit
       return true if value.present? && value.match?(/^CBD[U|L][0-9]+$/)
 
-      record.errors.add(attribute,
-                        :invalid_format,
-                        message: error_message(record, attribute, "invalid_format"))
+      add_validation_error(record, attribute, :invalid_format)
       false
     end
 
     def matches_existing_registration?(record, attribute, value)
       return true if Registration.where(reg_identifier: value).exists?
 
-      record.errors.add(attribute,
-                        :no_registration,
-                        message: error_message(record, attribute, "no_registration"))
+      add_validation_error(record, attribute, :no_registration)
       false
-    end
-
-    def error_message(record, attribute, error)
-      class_name = record.class.to_s.underscore
-      I18n.t("activemodel.errors.models.#{class_name}.attributes.#{attribute}.#{error}")
     end
   end
 end

--- a/app/validators/waste_carriers_engine/reg_identifier_validator.rb
+++ b/app/validators/waste_carriers_engine/reg_identifier_validator.rb
@@ -14,14 +14,18 @@ module WasteCarriersEngine
       # Format should be CBDU or CBDL, followed by at least one digit
       return true if value.present? && value.match?(/^CBD[U|L][0-9]+$/)
 
-      record.errors[attribute] << error_message(record, attribute, "invalid_format")
+      record.errors.add(attribute,
+                        :invalid_format,
+                        message: error_message(record, attribute, "invalid_format"))
       false
     end
 
     def matches_existing_registration?(record, attribute, value)
       return true if Registration.where(reg_identifier: value).exists?
 
-      record.errors[attribute] << error_message(record, attribute, "no_registration")
+      record.errors.add(attribute,
+                        :no_registration,
+                        message: error_message(record, attribute, "no_registration"))
       false
     end
 

--- a/app/validators/waste_carriers_engine/registration_type_validator.rb
+++ b/app/validators/waste_carriers_engine/registration_type_validator.rb
@@ -8,7 +8,9 @@ module WasteCarriersEngine
                        carrier_broker_dealer]
       return true if value.present? && valid_types.include?(value)
 
-      record.errors[attribute] << error_message(record, attribute, "inclusion")
+      record.errors.add(attribute,
+                        :inclusion,
+                        message: error_message(record, attribute, "inclusion"))
       false
     end
 

--- a/app/validators/waste_carriers_engine/registration_type_validator.rb
+++ b/app/validators/waste_carriers_engine/registration_type_validator.rb
@@ -2,23 +2,16 @@
 
 module WasteCarriersEngine
   class RegistrationTypeValidator < ActiveModel::EachValidator
+    include CanAddValidationErrors
+
     def validate_each(record, attribute, value)
       valid_types = %w[carrier_dealer
                        broker_dealer
                        carrier_broker_dealer]
       return true if value.present? && valid_types.include?(value)
 
-      record.errors.add(attribute,
-                        :inclusion,
-                        message: error_message(record, attribute, "inclusion"))
+      add_validation_error(record, attribute, :inclusion)
       false
-    end
-
-    private
-
-    def error_message(record, attribute, error)
-      class_name = record.class.to_s.underscore
-      I18n.t("activemodel.errors.models.#{class_name}.attributes.#{attribute}.#{error}")
     end
   end
 end

--- a/app/validators/waste_carriers_engine/yes_no_validator.rb
+++ b/app/validators/waste_carriers_engine/yes_no_validator.rb
@@ -2,21 +2,14 @@
 
 module WasteCarriersEngine
   class YesNoValidator < ActiveModel::EachValidator
+    include CanAddValidationErrors
+
     def validate_each(record, attribute, value)
       valid_values = %w[yes no]
       return true if valid_values.include?(value)
 
-      record.errors.add(attribute,
-                        :inclusion,
-                        message: error_message(record, attribute, "inclusion"))
+      add_validation_error(record, attribute, :inclusion)
       false
-    end
-
-    private
-
-    def error_message(record, attribute, error)
-      class_name = record.class.to_s.underscore
-      I18n.t("activemodel.errors.models.#{class_name}.attributes.#{attribute}.#{error}")
     end
   end
 end

--- a/app/validators/waste_carriers_engine/yes_no_validator.rb
+++ b/app/validators/waste_carriers_engine/yes_no_validator.rb
@@ -6,7 +6,9 @@ module WasteCarriersEngine
       valid_values = %w[yes no]
       return true if valid_values.include?(value)
 
-      record.errors[attribute] << error_message(record, attribute, "inclusion")
+      record.errors.add(attribute,
+                        :inclusion,
+                        message: error_message(record, attribute, "inclusion"))
       false
     end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1138

We spotted that this link was no longer appearing after the Rails 6 upgrade. The solution is updating the syntax used for adding errors so that our check for this specific error in the view works again.