### PR TITLE
Fix accidental duplication of paragraph names

### DIFF
--- a/app/views/waste_carriers_engine/renewal_complete_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/renewal_complete_forms/new.html.erb
@@ -27,8 +27,8 @@
       target: "_blank") %></p>
 
       <h2 class="heading-medium"><%= t(".subheading_2") %></h2>
-      <p><%= t(".paragraph_3.#{@renewal_complete_form.registration_type}") %></p>
       <p><%= t(".paragraph_4.#{@renewal_complete_form.registration_type}") %></p>
+      <p><%= t(".paragraph_5.#{@renewal_complete_form.registration_type}") %></p>
 
       <ul class="list list-bullet">
         <% t(".list_1").each do |list_item| %>
@@ -36,7 +36,7 @@
         <% end %>
       </ul>
 
-      <p><%= t(".paragraph_5") %></p>
+      <p><%= t(".paragraph_6") %></p>
 
       <ul class="list list-bullet">
         <% t(".list_2").each do |list_item| %>
@@ -45,11 +45,11 @@
       </ul>
 
       <h2 class="heading-medium"><%= t(".subheading_3") %></h2>
-      <p><%= t(".paragraph_6") %></p>
       <p><%= t(".paragraph_7") %></p>
+      <p><%= t(".paragraph_8") %></p>
 
       <div class="panel panel-border-wide">
-        <p><%= t(".paragraph_8") %></p>
+        <p><%= t(".paragraph_9") %></p>
       </div>
 
       <p><%= link_to(t(".survey_link_text"), t("layouts.application.feedback_url")) %> <%= t(".survey_link_hint") %></p>

--- a/config/locales/forms/renewal_complete_forms/en.yml
+++ b/config/locales/forms/renewal_complete_forms/en.yml
@@ -11,27 +11,27 @@ en:
         subheading_1: Your registration certificate
         certificate_link_text: Download and print your certificate
         subheading_2: What happens next
-        paragraph_3:
+        paragraph_4:
           carrier_dealer: Based on what you told us about your organisation and what it does, we have renewed your registration as an upper tier waste carrier and dealer.
           broker_dealer: Based on what you told us about your organisation and what it does, we have renewed your registration as an upper tier waste broker and dealer.
           carrier_broker_dealer: Based on what you told us about your organisation and what it does, we have renewed your registration as an upper tier waste carrier, broker and dealer.
-        paragraph_4:
+        paragraph_5:
           carrier_dealer: "Being an upper tier waste carrier and dealer means that:"
           broker_dealer: "Being an upper tier waste broker and dealer means that:"
           carrier_broker_dealer: "Being an upper tier waste carrier, broker and dealer means that:"
         list_1:
           - You need to renew your registrations every 3 years (we’ll send you a reminder)
           - You’ll need to pay a registration charge each time you renew
-        paragraph_5: "There are some simple rules you must follow:"
+        paragraph_6: "There are some simple rules you must follow:"
         list_2:
           - If you give your waste to another person or business, you must check they are properly authorised to accept it, e.g. as a permitted site or a registered waste carrier
           - Make sure the correct documentation is completed for each transfer of waste and that it correctly describes the waste
           - Make sure any waste is safely handled and stored
           - Minimise the environmental impact of waste by prioritising waste prevention, reuse, recycling and recovery over disposal
         subheading_3: Updating your details
-        paragraph_6: If any of your details change you must update your registration within 28 days.
-        paragraph_7: You can sign in to view your certificate or make a change to your registration.
-        paragraph_8: Call our helpline on 03708 506 506 if you have any questions about your renewal.
+        paragraph_7: If any of your details change you must update your registration within 28 days.
+        paragraph_8: You can sign in to view your certificate or make a change to your registration.
+        paragraph_9: Call our helpline on 03708 506 506 if you have any questions about your renewal.
         survey_link_text: What do you think of this service?
         survey_link_hint: (takes 30 seconds)
         error_heading: Something is wrong


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1141

A new paragraph_3 was added to this page in a previous PR, but the other paragraphs weren't incremented. This duplication resulted in some wonky text on the page.