### PR TITLE
Don't copy expires_on around when editing

### DIFF
--- a/app/models/waste_carriers_engine/edit_registration.rb
+++ b/app/models/waste_carriers_engine/edit_registration.rb
@@ -13,6 +13,7 @@ module WasteCarriersEngine
       ignorable_attributes: %w[_id
                                account_email
                                addresses
+                               expires_on
                                renew_token
                                key_people
                                financeDetails

--- a/app/services/waste_carriers_engine/edit_completion_service.rb
+++ b/app/services/waste_carriers_engine/edit_completion_service.rb
@@ -43,6 +43,7 @@ module WasteCarriersEngine
                                                                      "token",
                                                                      "account_email",
                                                                      "created_at",
+                                                                     "expires_on",
                                                                      "financeDetails",
                                                                      "temp_cards",
                                                                      "temp_company_postcode",

--- a/spec/models/waste_carriers_engine/edit_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/edit_registration_spec.rb
@@ -40,6 +40,7 @@ module WasteCarriersEngine
         copyable_properties = Registration.attribute_names - %w[_id
                                                                 account_email
                                                                 addresses
+                                                                expires_on
                                                                 key_people
                                                                 financeDetails
                                                                 conviction_search_result

--- a/spec/requests/waste_carriers_engine/edit_complete_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/edit_complete_forms_spec.rb
@@ -19,6 +19,7 @@ module WasteCarriersEngine
         end
 
         context "when a valid edit registration exists" do
+          let(:different_expires_on) { 3.days.ago }
           let(:updated_email) { "updated@example.com" }
           let(:updated_registered_address) { build(:address, :registered, postcode: "UP1 2DT") }
           let(:updated_contact_address) { build(:address, :contact, postcode: "D1 1FF") }
@@ -27,6 +28,7 @@ module WasteCarriersEngine
           let(:transient_registration) do
             create(:edit_registration,
                    contact_email: updated_email,
+                   expires_on: different_expires_on,
                    addresses: [updated_registered_address, updated_contact_address],
                    key_people: [updated_person],
                    workflow_state: "edit_complete_form")
@@ -36,6 +38,7 @@ module WasteCarriersEngine
           context "when the workflow_state is correct" do
             it "updates the registration with the new data and deletes the transient object" do
               old_account_email = registration.account_email
+              old_expires_on = registration.expires_on
               old_finance_details = registration.finance_details
               old_relevant_people = registration.relevant_people
 
@@ -56,6 +59,8 @@ module WasteCarriersEngine
 
               # But don't modify finance details or other non-editable attributes
               expect(registration.account_email).to eq(old_account_email)
+              expect(registration.expires_on).to eq(old_expires_on)
+              expect(registration.expires_on).to_not eq(different_expires_on)
               expect(registration.finance_details).to eq(old_finance_details)
               expect(registration.relevant_people).to eq(old_relevant_people)
 

--- a/spec/services/waste_carriers_engine/edit_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/edit_completion_service_spec.rb
@@ -18,6 +18,7 @@ module WasteCarriersEngine
         "token" => nil,
         "account_email" => nil,
         "created_at" => nil,
+        "expires_on" => nil,
         "financeDetails" => nil,
         "temp_cards" => nil,
         "temp_company_postcode" => nil,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1151

Previously during an edit, the value of expires_on was copied from the registration to the transient_registration, and then copied back again when the edit was completed.

If the registration was renewed between the edit being started and completed, this resulted in a bug where the expires_on date was "reset" to its previous value.

This PR stops us from copying the value of expires_on into or out of edit_registrations.