### PR TITLE
Update defra-ruby-alert

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       aasm (~> 4.12)
       countries
       defra_ruby_address
-      defra_ruby_alert (~> 2.0.0)
+      defra_ruby_alert (~> 2.1)
       defra_ruby_email
       defra_ruby_validators
       high_voltage (~> 3.0)
@@ -105,7 +105,7 @@ GEM
     database_cleaner (1.8.5)
     defra_ruby_address (0.1.0)
       rest-client (~> 2.0)
-    defra_ruby_alert (2.0.0)
+    defra_ruby_alert (2.1.1)
       airbrake
     defra_ruby_email (1.0.0)
       rails (~> 6.0.3.1)

--- a/lib/waste_carriers_engine.rb
+++ b/lib/waste_carriers_engine.rb
@@ -74,9 +74,9 @@ module WasteCarriersEngine
       end
     end
 
-    def airbrake_blacklist=(value)
+    def airbrake_blocklist=(value)
       DefraRuby::Alert.configure do |configuration|
-        configuration.blacklist = value
+        configuration.blocklist = value
       end
     end
 

--- a/spec/dummy/config/initializers/waste_carriers_engine.rb
+++ b/spec/dummy/config/initializers/waste_carriers_engine.rb
@@ -12,7 +12,7 @@ WasteCarriersEngine.configure do |config|
   config.airbrake_enabled = false
   config.airbrake_host = "http://localhost"
   config.airbrake_project_key = "abcde12345"
-  config.airbrake_blacklist = [/password/i, /authorization/i]
+  config.airbrake_blocklist = [/password/i, /authorization/i]
 
   # Address lookup config
   config.address_host = ENV["ADDRESSBASE_URL"] || "http://localhost:3002"

--- a/waste_carriers_engine.gemspec
+++ b/waste_carriers_engine.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
   s.add_dependency "uk_postcode"
 
   # defra_ruby_alert is a gem we created to manage airbrake across projects
-  s.add_dependency "defra_ruby_alert", "~> 2.0.0"
+  s.add_dependency "defra_ruby_alert", "~> 2.1"
 
   # Used to handle requests to the address lookup web service used (currently
   # EA Address Facade v1)


### PR DESCRIPTION
DEFRA/defra-ruby-alert#11

The defra-ruby-alert gem was updated to use the latest version of Airbrake at the same time as this project was updated to work with Rails 6 and Ruby 2.7.

What we did not realise is that the Airbrake gem had introduced a performance monitoring feature which is enabled by default. As we log our exceptions to errbit this feature was not supported so our logs are getting spammed with 404 messages from the Airbrake gem.

We've fixed that in defra-ruby-alert and this updates the project to use the latest version.