### PR TITLE
Remove link to certificate from renewal complete

### DIFF
--- a/app/views/waste_carriers_engine/renewal_complete_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/renewal_complete_forms/new.html.erb
@@ -22,10 +22,6 @@
       <p><%= t(".paragraph_2", email: @renewal_complete_form.contact_email) %></p>
       <p><%= t(".paragraph_3", email: @renewal_complete_form.transient_registration.email_to_send_receipt) %></p>
 
-      <h2 class="heading-medium"><%= t(".subheading_1") %></h2>
-      <p><%= link_to(t(".certificate_link_text"), @renewal_complete_form.certificate_link,
-      target: "_blank") %></p>
-
       <h2 class="heading-medium"><%= t(".subheading_2") %></h2>
       <p><%= t(".paragraph_4.#{@renewal_complete_form.registration_type}") %></p>
       <p><%= t(".paragraph_5.#{@renewal_complete_form.registration_type}") %></p>

--- a/config/locales/forms/renewal_complete_forms/en.yml
+++ b/config/locales/forms/renewal_complete_forms/en.yml
@@ -8,8 +8,6 @@ en:
         paragraph_1: "Your registration has been renewed until %{date}."
         paragraph_2: "We have sent a confirmation email to %{email}."
         paragraph_3: "We'll email a receipt to %{email} after we process your payment."
-        subheading_1: Your registration certificate
-        certificate_link_text: Download and print your certificate
         subheading_2: What happens next
         paragraph_4:
           carrier_dealer: Based on what you told us about your organisation and what it does, we have renewed your registration as an upper tier waste carrier and dealer.


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1154

The link in the page takes you to the frontend where if you are not signed in, you then have to in order to access the link. We don't provide this link on the new 'new registration' done page. It is also our intention to remove accounts in the near future so access to this will be removed anyway.

So this change is just about removing the link in the page to make it consistent with the new registration complete page, and with our future intentions.

<details><summary>Before</summary>

![Screenshot 2020-07-14 at 11 26 59](https://user-images.githubusercontent.com/1789650/87416104-1ed9ad00-c5c6-11ea-8d49-30745cc58278.png)

</details>

<details><summary>After</summary>

![Screenshot 2020-07-14 at 11 33 37](https://user-images.githubusercontent.com/1789650/87416142-2ef18c80-c5c6-11ea-903f-9dd3a0abc8f3.png)

</details>
