### PR TITLE
Add mention of payment conf. to bank transfer

### DIFF
--- a/app/views/waste_carriers_engine/confirm_bank_transfer_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/confirm_bank_transfer_forms/new.html.erb
@@ -13,6 +13,10 @@
     </p>
 
     <p>
+      <%= t(".paragraph_3") %>
+    </p>
+
+    <p>
       <%= link_to(t(".link_text"),
                   back_confirm_bank_transfer_forms_path(@confirm_bank_transfer_form.token)) %>
     </p>

--- a/config/locales/forms/confirm_bank_transfer_forms/en.yml
+++ b/config/locales/forms/confirm_bank_transfer_forms/en.yml
@@ -5,6 +5,7 @@ en:
         title: Pay by bank transfer
         heading: Registration takes longer if you pay by bank transfer
         paragraph_1: "In order to pay by bank transfer, you will need to follow the instructions on the next screen and email us to confirm payment. This will take approximately 5 working days."
-        paragraph_2: "In most cases we can provide instant confirmation if you pay by card."
+        paragraph_2: "We do not send a payment confirmation if you pay by bank transfer."
+        paragraph_3: "In most cases we can provide instant confirmation if you pay by card."
         link_text: "Go back to pay by credit or debit card instead"
         next_button: "Confirm you’ll pay by bank transfer"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1141
https://eaflood.atlassian.net/browse/RUBY-1137

Specifically, we now state that you won't receive one if you choose to pay by bank transfer.

<details><summary>Before</summary>

![Screenshot 2020-07-15 at 14 45 52](https://user-images.githubusercontent.com/1789650/87552766-0347d280-c6aa-11ea-8e82-67043b5e43de.png)

</details>

<details><summary>After</summary>

![Screenshot 2020-07-15 at 14 49 18](https://user-images.githubusercontent.com/1789650/87553032-66396980-c6aa-11ea-82fc-1e1c7e154dcf.png)

</details>