### PR TITLE
Add payment email section to payment summary page

### DIFF
--- a/app/controllers/waste_carriers_engine/payment_summary_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/payment_summary_forms_controller.rb
@@ -17,7 +17,7 @@ module WasteCarriersEngine
     private
 
     def transient_registration_attributes
-      params.fetch(:payment_summary_form, {}).permit(:temp_payment_method)
+      params.fetch(:payment_summary_form, {}).permit(:temp_payment_method, :receipt_email)
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/payment_summary_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/payment_summary_forms_controller.rb
@@ -17,7 +17,7 @@ module WasteCarriersEngine
     private
 
     def transient_registration_attributes
-      params.fetch(:payment_summary_form, {}).permit(:temp_payment_method, :receipt_email)
+      params.fetch(:payment_summary_form, {}).permit(:temp_payment_method, :card_confirmation_email)
     end
   end
 end

--- a/app/forms/waste_carriers_engine/payment_summary_form.rb
+++ b/app/forms/waste_carriers_engine/payment_summary_form.rb
@@ -2,7 +2,6 @@
 
 module WasteCarriersEngine
   class PaymentSummaryForm < ::WasteCarriersEngine::BaseForm
-    # delegate :temp_payment_method, to: :transient_registration
 
     attr_accessor :temp_payment_method,
                   :registration_cards,
@@ -18,7 +17,6 @@ module WasteCarriersEngine
     end
 
     def initialize(transient_registration)
-      Rails.logger.debug("----- PAYMENT_SUMMARY_SUBMIT - initialize")
       super
 
       self.temp_payment_method = transient_registration.temp_payment_method
@@ -51,9 +49,6 @@ module WasteCarriersEngine
       self.card_confirmation_email = params[:card_confirmation_email]
     end
 
-    # TODO: This method is duplicated in
-    # app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb.
-    # Consider refactoring to being on the transient_registration itself
     def paying_by_card?
       temp_payment_method == "card"
     end

--- a/app/forms/waste_carriers_engine/payment_summary_form.rb
+++ b/app/forms/waste_carriers_engine/payment_summary_form.rb
@@ -2,39 +2,56 @@
 
 module WasteCarriersEngine
   class PaymentSummaryForm < ::WasteCarriersEngine::BaseForm
-    delegate :temp_payment_method, to: :transient_registration
-    delegate :receipt_email, to: :transient_registration, allow_nil: true
+    # delegate :temp_payment_method, to: :transient_registration
 
-    attr_accessor :type_change, :registration_cards, :registration_card_charge, :total_charge
+    attr_accessor :temp_payment_method, :registration_cards, :registration_card_charge, :total_charge, :card_confirmation_email
 
     validates :temp_payment_method, inclusion: { in: %w[card bank_transfer] }
-    validates :receipt_email, "defra_ruby/validators/email": true, if: :paying_by_card?
-
-    after_initialize :pre_populate_receipt_email
+    validates :card_confirmation_email, "defra_ruby/validators/email": true, if: :paying_by_card?
 
     def self.can_navigate_flexibly?
       false
     end
 
     def initialize(transient_registration)
+      Rails.logger.debug("----- PAYMENT_SUMMARY_SUBMIT - initialize")
       super
 
+      self.temp_payment_method = transient_registration.temp_payment_method
       self.registration_cards = transient_registration.temp_cards || 0
       self.registration_card_charge = transient_registration.total_registration_card_charge
       self.total_charge = transient_registration.total_to_pay
+      self.card_confirmation_email = transient_registration.email_to_send_receipt
+    end
+
+    def submit(params)
+      # Update our attributes. Needed for validation to work as expected
+      assign_params(params)
+
+      # We always want to save the selected payment method in case the user
+      # comes back to the form
+      attributes = {
+        temp_payment_method: self.temp_payment_method
+      }
+
+      # We only want to save the email address if the user is paying by card
+      attributes[:receipt_email] = self.card_confirmation_email if paying_by_card?
+
+      super(attributes)
     end
 
     private
+
+    def assign_params(params)
+      self.temp_payment_method = params[:temp_payment_method]
+      self.card_confirmation_email = params[:card_confirmation_email]
+    end
 
     # TODO: This method is duplicated in
     # app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb.
     # Consider refactoring to being on the transient_registration itself
     def paying_by_card?
-      temp_payment_method == "card"
-    end
-
-    def pre_populate_receipt_email
-      transient_registration.receipt_email ||= transient_registration.email_to_send_receipt
+      self.temp_payment_method == "card"
     end
   end
 end

--- a/app/forms/waste_carriers_engine/payment_summary_form.rb
+++ b/app/forms/waste_carriers_engine/payment_summary_form.rb
@@ -4,7 +4,11 @@ module WasteCarriersEngine
   class PaymentSummaryForm < ::WasteCarriersEngine::BaseForm
     # delegate :temp_payment_method, to: :transient_registration
 
-    attr_accessor :temp_payment_method, :registration_cards, :registration_card_charge, :total_charge, :card_confirmation_email
+    attr_accessor :temp_payment_method,
+                  :registration_cards,
+                  :registration_card_charge,
+                  :total_charge,
+                  :card_confirmation_email
 
     validates :temp_payment_method, inclusion: { in: %w[card bank_transfer] }
     validates :card_confirmation_email, "defra_ruby/validators/email": true, if: :paying_by_card?
@@ -31,11 +35,11 @@ module WasteCarriersEngine
       # We always want to save the selected payment method in case the user
       # comes back to the form
       attributes = {
-        temp_payment_method: self.temp_payment_method
+        temp_payment_method: temp_payment_method
       }
 
       # We only want to save the email address if the user is paying by card
-      attributes[:receipt_email] = self.card_confirmation_email if paying_by_card?
+      attributes[:receipt_email] = card_confirmation_email if paying_by_card?
 
       super(attributes)
     end
@@ -51,7 +55,7 @@ module WasteCarriersEngine
     # app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb.
     # Consider refactoring to being on the transient_registration itself
     def paying_by_card?
-      self.temp_payment_method == "card"
+      temp_payment_method == "card"
     end
   end
 end

--- a/app/forms/waste_carriers_engine/payment_summary_form.rb
+++ b/app/forms/waste_carriers_engine/payment_summary_form.rb
@@ -10,6 +10,8 @@ module WasteCarriersEngine
     validates :temp_payment_method, inclusion: { in: %w[card bank_transfer] }
     validates :receipt_email, "defra_ruby/validators/email": true, if: :paying_by_card?
 
+    after_initialize :pre_populate_receipt_email
+
     def self.can_navigate_flexibly?
       false
     end
@@ -29,6 +31,10 @@ module WasteCarriersEngine
     # Consider refactoring to being on the transient_registration itself
     def paying_by_card?
       temp_payment_method == "card"
+    end
+
+    def pre_populate_receipt_email
+      transient_registration.receipt_email ||= transient_registration.email_to_send_receipt
     end
   end
 end

--- a/app/forms/waste_carriers_engine/payment_summary_form.rb
+++ b/app/forms/waste_carriers_engine/payment_summary_form.rb
@@ -4,7 +4,7 @@ module WasteCarriersEngine
   class PaymentSummaryForm < ::WasteCarriersEngine::BaseForm
     delegate :temp_payment_method, to: :transient_registration
 
-    attr_accessor :type_change, :registration_cards, :registration_card_charge, :total_charge
+    attr_accessor :type_change, :registration_cards, :registration_card_charge, :total_charge, :receipt_email
 
     validates :temp_payment_method, inclusion: { in: %w[card bank_transfer] }
 
@@ -18,6 +18,7 @@ module WasteCarriersEngine
       self.registration_cards = transient_registration.temp_cards || 0
       self.registration_card_charge = transient_registration.total_registration_card_charge
       self.total_charge = transient_registration.total_to_pay
+      self.receipt_email = transient_registration.email_to_send_receipt
     end
   end
 end

--- a/app/forms/waste_carriers_engine/payment_summary_form.rb
+++ b/app/forms/waste_carriers_engine/payment_summary_form.rb
@@ -3,10 +3,12 @@
 module WasteCarriersEngine
   class PaymentSummaryForm < ::WasteCarriersEngine::BaseForm
     delegate :temp_payment_method, to: :transient_registration
+    delegate :receipt_email, to: :transient_registration, allow_nil: true
 
-    attr_accessor :type_change, :registration_cards, :registration_card_charge, :total_charge, :receipt_email
+    attr_accessor :type_change, :registration_cards, :registration_card_charge, :total_charge
 
     validates :temp_payment_method, inclusion: { in: %w[card bank_transfer] }
+    validates :receipt_email, "defra_ruby/validators/email": true, if: :paying_by_card?
 
     def self.can_navigate_flexibly?
       false
@@ -18,7 +20,15 @@ module WasteCarriersEngine
       self.registration_cards = transient_registration.temp_cards || 0
       self.registration_card_charge = transient_registration.total_registration_card_charge
       self.total_charge = transient_registration.total_to_pay
-      self.receipt_email = transient_registration.email_to_send_receipt
+    end
+
+    private
+
+    # TODO: This method is duplicated in
+    # app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb.
+    # Consider refactoring to being on the transient_registration itself
+    def paying_by_card?
+      temp_payment_method == "card"
     end
   end
 end

--- a/app/views/waste_carriers_engine/payment_summary_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/payment_summary_forms/new.html.erb
@@ -62,9 +62,17 @@
             <%= t(".options.card.label") %>
             <span class='form-hint'><%= t(".options.card.hint") %></span>
           <% end %>
-          <div class="panel panel-border-narrow">
-            <h2 class="heading-medium"><%= t(".payment_confirmation.subheading") %></h2>
-          </div>
+        </div>
+
+        <div class="panel panel-border-narrow">
+          <h2 class="heading-medium"><%= t(".payment_confirmation.subheading") %></h2>
+          <p>
+            <%= t(".payment_confirmation.paragraph_1") %>
+          </p>
+          <fieldset id="receipt_email">
+            <%= f.label :receipt_email, t(".payment_confirmation.label"), class: "form-label" %>
+            <%= f.email_field :receipt_email, value: @payment_summary_form.receipt_email, class: "form-control" %>
+          </fieldset>
         </div>
 
         <div class="multiple-choice">

--- a/app/views/waste_carriers_engine/payment_summary_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/payment_summary_forms/new.html.erb
@@ -62,6 +62,9 @@
             <%= t(".options.card.label") %>
             <span class='form-hint'><%= t(".options.card.hint") %></span>
           <% end %>
+          <div class="panel panel-border-narrow">
+            <h2 class="heading-medium"><%= t(".payment_confirmation.subheading") %></h2>
+          </div>
         </div>
 
         <div class="multiple-choice">

--- a/app/views/waste_carriers_engine/payment_summary_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/payment_summary_forms/new.html.erb
@@ -69,10 +69,15 @@
           <p>
             <%= t(".payment_confirmation.paragraph_1") %>
           </p>
-          <fieldset id="receipt_email">
-            <%= f.label :receipt_email, t(".payment_confirmation.label"), class: "form-label" %>
-            <%= f.email_field :receipt_email, value: @payment_summary_form.receipt_email, class: "form-control" %>
-          </fieldset>
+          <div class="form-group <%= "form-group-error" if @payment_summary_form.errors[:receipt_email].any? %>">
+            <fieldset id="receipt_email">
+              <% if @payment_summary_form.errors[:receipt_email].any? %>
+                <span class="error-message"><%= @payment_summary_form.errors[:receipt_email].join(", ") %></span>
+              <% end %>
+              <%= f.label :receipt_email, t(".payment_confirmation.label"), class: "form-label" %>
+              <%= f.email_field :receipt_email, value: @payment_summary_form.receipt_email, class: "form-control" %>
+            </fieldset>
+          </div>
         </div>
 
         <div class="multiple-choice">

--- a/app/views/waste_carriers_engine/payment_summary_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/payment_summary_forms/new.html.erb
@@ -69,13 +69,13 @@
           <p>
             <%= t(".payment_confirmation.paragraph_1") %>
           </p>
-          <div class="form-group <%= "form-group-error" if @payment_summary_form.errors[:receipt_email].any? %>">
-            <fieldset id="receipt_email">
-              <% if @payment_summary_form.errors[:receipt_email].any? %>
-                <span class="error-message"><%= @payment_summary_form.errors[:receipt_email].join(", ") %></span>
+          <div class="form-group <%= "form-group-error" if @payment_summary_form.errors[:card_confirmation_email].any? %>">
+            <fieldset id="card_confirmation_email">
+              <% if @payment_summary_form.errors[:card_confirmation_email].any? %>
+                <span class="error-message"><%= @payment_summary_form.errors[:card_confirmation_email].join(", ") %></span>
               <% end %>
-              <%= f.label :receipt_email, t(".payment_confirmation.label"), class: "form-label" %>
-              <%= f.email_field :receipt_email, value: @payment_summary_form.receipt_email, class: "form-control" %>
+              <%= f.label :card_confirmation_email, t(".payment_confirmation.label"), class: "form-label" %>
+              <%= f.email_field :card_confirmation_email, value: @payment_summary_form.card_confirmation_email, class: "form-control" %>
             </fieldset>
           </div>
         </div>

--- a/config/locales/forms/payment_summary_forms/en.yml
+++ b/config/locales/forms/payment_summary_forms/en.yml
@@ -22,6 +22,8 @@ en:
             hint: We cannot register you until your payment clears.
         payment_confirmation:
           subheading: Where should the card payment confirmation be sent?
+          paragraph_1: WorldPay will send a card payment confirmation to this address, once the payment has been processed.
+          label: Email address
         next_button: Proceed to payment
   activemodel:
     errors:

--- a/config/locales/forms/payment_summary_forms/en.yml
+++ b/config/locales/forms/payment_summary_forms/en.yml
@@ -20,6 +20,8 @@ en:
           bank_transfer:
             label: Pay by bank transfer and then email us to confirm payment
             hint: We cannot register you until your payment clears.
+        payment_confirmation:
+          subheading: Where should the card payment confirmation be sent?
         next_button: Proceed to payment
   activemodel:
     errors:

--- a/spec/forms/waste_carriers_engine/payment_summary_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/payment_summary_forms_spec.rb
@@ -113,5 +113,37 @@ module WasteCarriersEngine
         end
       end
     end
+
+    describe "#receipt_email" do
+      let(:transient_registration) do
+        build(
+          :renewing_registration,
+          :has_required_data,
+          workflow_state: "payment_summary_form",
+          contact_email: contact_email,
+          receipt_email: receipt_email
+        )
+      end
+      # Don't use FactoryBot for this as we need to make sure it initializes with a specific object
+      let(:payment_summary_form) { PaymentSummaryForm.new(transient_registration) }
+
+      context "when initialised with a transient_registration with only contact email set" do
+        let(:contact_email) { "contact@example.com" }
+        let(:receipt_email) { nil }
+
+        it "defaults to the contact email" do
+          expect(payment_summary_form.receipt_email).to eq(contact_email)
+        end
+      end
+
+      context "when initialised with a transient_registration with both contact and receipt email set" do
+        let(:contact_email) { "contact@example.com" }
+        let(:receipt_email) { "receipt@example.com" }
+
+        it "defaults to the receipt email" do
+          expect(payment_summary_form.receipt_email).to eq(receipt_email)
+        end
+      end
+    end
   end
 end

--- a/spec/forms/waste_carriers_engine/payment_summary_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/payment_summary_forms_spec.rb
@@ -10,7 +10,8 @@ module WasteCarriersEngine
         let(:valid_params) do
           {
             token: payment_summary_form.token,
-            temp_payment_method: payment_summary_form.temp_payment_method
+            temp_payment_method: payment_summary_form.temp_payment_method,
+            receipt_email: "foo@example.com"
           }
         end
 
@@ -21,7 +22,13 @@ module WasteCarriersEngine
 
       context "when the form is not valid" do
         let(:payment_summary_form) { build(:payment_summary_form, :has_required_data) }
-        let(:invalid_params) { { temp_payment_method: "foo" } }
+        let(:invalid_params) do
+          {
+            token: payment_summary_form.token,
+            temp_payment_method: "foo",
+            receipt_email: "foo@com"
+          }
+        end
 
         it "should not submit" do
           expect(payment_summary_form.submit(invalid_params)).to eq(false)
@@ -43,6 +50,28 @@ module WasteCarriersEngine
           it "is valid" do
             expect(payment_summary_form).to be_valid
           end
+
+          context "but the receipt email has been set" do
+            before do
+              payment_summary_form.transient_registration.receipt_email = receipt_email
+            end
+
+            context "to something invalid" do
+              let(:receipt_email) { "foo@bar" }
+
+              it "is still valid" do
+                expect(payment_summary_form).to be_valid
+              end
+            end
+
+            context "to nothing" do
+              let(:receipt_email) { "" }
+
+              it "is still valid" do
+                expect(payment_summary_form).to be_valid
+              end
+            end
+          end
         end
 
         context "when a temp_payment_method is card" do
@@ -50,6 +79,28 @@ module WasteCarriersEngine
 
           it "is valid" do
             expect(payment_summary_form).to be_valid
+          end
+
+          context "and the receipt email has been set" do
+            before do
+              payment_summary_form.transient_registration.receipt_email = receipt_email
+            end
+
+            context "to something invalid" do
+              let(:receipt_email) { "foo@bar" }
+
+              it "is is not valid" do
+                expect(payment_summary_form).not_to be_valid
+              end
+            end
+
+            context "to nothing" do
+              let(:receipt_email) { "" }
+
+              it "is is not valid" do
+                expect(payment_summary_form).not_to be_valid
+              end
+            end
           end
         end
 

--- a/spec/forms/waste_carriers_engine/payment_summary_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/payment_summary_forms_spec.rb
@@ -145,5 +145,7 @@ module WasteCarriersEngine
         end
       end
     end
+
+    include_examples "validate email", :payment_summary_form, :receipt_email
   end
 end

--- a/spec/forms/waste_carriers_engine/payment_summary_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/payment_summary_forms_spec.rb
@@ -11,7 +11,7 @@ module WasteCarriersEngine
           {
             token: payment_summary_form.token,
             temp_payment_method: payment_summary_form.temp_payment_method,
-            receipt_email: "foo@example.com"
+            card_confirmation_email: "foo@example.com"
           }
         end
 
@@ -26,7 +26,7 @@ module WasteCarriersEngine
           {
             token: payment_summary_form.token,
             temp_payment_method: "foo",
-            receipt_email: "foo@com"
+            card_confirmation_email: "foo@com"
           }
         end
 
@@ -38,7 +38,14 @@ module WasteCarriersEngine
 
     describe "#valid?" do
       context "when a valid transient registration exists" do
-        let(:payment_summary_form) { build(:payment_summary_form, :has_required_data) }
+        let(:payment_summary_form) do
+          build(
+            :payment_summary_form,
+            :has_required_data,
+            temp_payment_method: temp_payment_method,
+            card_confirmation_email: card_confirmation_email
+          )
+        end
 
         before do
           payment_summary_form.transient_registration.temp_payment_method = temp_payment_method
@@ -46,18 +53,15 @@ module WasteCarriersEngine
 
         context "when a temp_payment_method is bank_transfer" do
           let(:temp_payment_method) { "bank_transfer" }
+          let(:card_confirmation_email) { "hello@example.com" }
 
           it "is valid" do
             expect(payment_summary_form).to be_valid
           end
 
-          context "but the receipt email has been set" do
-            before do
-              payment_summary_form.transient_registration.receipt_email = receipt_email
-            end
-
+          context "but the card_confirmation_email has been set" do
             context "to something invalid" do
-              let(:receipt_email) { "foo@bar" }
+              let(:card_confirmation_email) { "foo@bar" }
 
               it "is still valid" do
                 expect(payment_summary_form).to be_valid
@@ -65,7 +69,7 @@ module WasteCarriersEngine
             end
 
             context "to nothing" do
-              let(:receipt_email) { "" }
+              let(:card_confirmation_email) { "" }
 
               it "is still valid" do
                 expect(payment_summary_form).to be_valid
@@ -76,28 +80,25 @@ module WasteCarriersEngine
 
         context "when a temp_payment_method is card" do
           let(:temp_payment_method) { "card" }
+          let(:card_confirmation_email) { "hello@example.com" }
 
           it "is valid" do
             expect(payment_summary_form).to be_valid
           end
 
           context "and the receipt email has been set" do
-            before do
-              payment_summary_form.transient_registration.receipt_email = receipt_email
-            end
-
             context "to something invalid" do
-              let(:receipt_email) { "foo@bar" }
+              let(:card_confirmation_email) { "foo@bar" }
 
-              it "is is not valid" do
+              it "is not valid" do
                 expect(payment_summary_form).not_to be_valid
               end
             end
 
             context "to nothing" do
-              let(:receipt_email) { "" }
+              let(:card_confirmation_email) { "" }
 
-              it "is is not valid" do
+              it "is not valid" do
                 expect(payment_summary_form).not_to be_valid
               end
             end
@@ -106,6 +107,7 @@ module WasteCarriersEngine
 
         context "when a temp_payment_method is anything else" do
           let(:temp_payment_method) { "I am a payment method, don't you know?" }
+          let(:card_confirmation_email) { "hello@example.com" }
 
           it "is not valid" do
             expect(payment_summary_form).to_not be_valid
@@ -114,7 +116,7 @@ module WasteCarriersEngine
       end
     end
 
-    describe "#receipt_email" do
+    describe "#card_confirmation_email" do
       let(:transient_registration) do
         build(
           :renewing_registration,
@@ -132,7 +134,7 @@ module WasteCarriersEngine
         let(:receipt_email) { nil }
 
         it "defaults to the contact email" do
-          expect(payment_summary_form.receipt_email).to eq(contact_email)
+          expect(payment_summary_form.card_confirmation_email).to eq(contact_email)
         end
       end
 
@@ -141,11 +143,11 @@ module WasteCarriersEngine
         let(:receipt_email) { "receipt@example.com" }
 
         it "defaults to the receipt email" do
-          expect(payment_summary_form.receipt_email).to eq(receipt_email)
+          expect(payment_summary_form.card_confirmation_email).to eq(receipt_email)
         end
       end
     end
 
-    include_examples "validate email", :payment_summary_form, :receipt_email
+    include_examples "validate email", :payment_summary_form, :card_confirmation_email
   end
 end

--- a/spec/requests/waste_carriers_engine/payment_summary_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/payment_summary_forms_spec.rb
@@ -9,7 +9,7 @@ module WasteCarriersEngine
     describe "POST payment_summary_form_path" do
       include_examples "POST renewal form",
                        "payment_summary_form",
-                       valid_params: { temp_payment_method: "card" },
+                       valid_params: { temp_payment_method: "card", receipt_email: "foo@example.com" },
                        invalid_params: { temp_payment_method: "foo" },
                        test_attribute: :temp_payment_method
 
@@ -20,7 +20,7 @@ module WasteCarriersEngine
 
         include_examples "POST form",
                          "payment_summary_form",
-                         valid_params: { temp_payment_method: "card" },
+                         valid_params: { temp_payment_method: "card", receipt_email: "foo@example.com" },
                          invalid_params: { temp_payment_method: "foo" }
       end
     end

--- a/spec/requests/waste_carriers_engine/payment_summary_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/payment_summary_forms_spec.rb
@@ -9,7 +9,7 @@ module WasteCarriersEngine
     describe "POST payment_summary_form_path" do
       include_examples "POST renewal form",
                        "payment_summary_form",
-                       valid_params: { temp_payment_method: "card", receipt_email: "foo@example.com" },
+                       valid_params: { temp_payment_method: "card", card_confirmation_email: "foo@example.com" },
                        invalid_params: { temp_payment_method: "foo" },
                        test_attribute: :temp_payment_method
 
@@ -20,7 +20,7 @@ module WasteCarriersEngine
 
         include_examples "POST form",
                          "payment_summary_form",
-                         valid_params: { temp_payment_method: "card", receipt_email: "foo@example.com" },
+                         valid_params: { temp_payment_method: "card", card_confirmation_email: "foo@example.com" },
                          invalid_params: { temp_payment_method: "foo" }
       end
     end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1141
https://eaflood.atlassian.net/browse/RUBY-1137

Having removed our first design for solving the problem of capturing a user's preferred Worldpay payment confirmation email address (see [PR #889](https://github.com/DEFRA/waste-carriers-engine/pull/889)) this implements our second version!

That is to show a hidden section in the payment summary screen which will appear when a user selects 'Pay by credit or debit card'. Along with a header and some content, it will display a field, pre-populated with the contact email address. Whatever is in there when submitted will be saved as the `receipt_email`.

This is based on example used by the [Get a fishing licence service](https://get-fishing-licence.service.gov.uk/). In its **How can we send you your licence details?** if the user selects 'Email or text message' a hidden section with those fields will appear.

<details><summary>Get a fishing licence example</summary>

![Screenshot 2020-07-15 at 16 45 18](https://user-images.githubusercontent.com/1789650/87608417-cc001280-c6f7-11ea-807e-9e06e28eb597.png)

</details>

This change focuses on adding the section and validating it correctly. For example, we only care about the field being populated correctly if the user is paying by card. If they are not then we shouldn't be forcing them to correct any invalid changes they have made to the field.

A subsequent change will focus on the logic of hiding and showing the section at the appropriate times.

<details><summary>Screenshot of the change</summary>

<img width="976" alt="Screenshot 2020-07-16 at 00 06 38" src="https://user-images.githubusercontent.com/1789650/87608595-4466d380-c6f8-11ea-9ca5-350beccc246b.png">

</details>