### PR TITLE
Add payment confirmation email to Edit

### DIFF
--- a/app/presenters/waste_carriers_engine/edit_form_presenter.rb
+++ b/app/presenters/waste_carriers_engine/edit_form_presenter.rb
@@ -81,6 +81,10 @@ module WasteCarriersEngine
       I18n.t("#{LOCALES_KEY}.tier.#{transient_registration.tier}")
     end
 
+    def receipt_email
+      transient_registration.receipt_email
+    end
+
     private
 
     def format_main_person(person)

--- a/app/views/waste_carriers_engine/edit_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/edit_forms/new.html.erb
@@ -264,6 +264,25 @@
           </tr>
         </tbody>
       </table>
+
+      <table class="edit_table">
+        <caption>
+          <h2 class="heading-medium"><%= t(".sections.receipt.heading") %></h2>
+        </caption>
+        <tbody>
+          <tr>
+            <td class="label_column">
+              <%= t(".sections.receipt.labels.email") %>
+            </td>
+            <td>
+              <%= @presenter.receipt_email %>
+            </td>
+            <td class="change_link_column">
+              <%= t(".edit_links.no_edit") %>
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </div>
 

--- a/app/views/waste_carriers_engine/edit_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/edit_forms/new.html.erb
@@ -262,7 +262,8 @@
               <%= t(".edit_links.no_edit") %>
             </td>
           </tr>
-        </table>
+        </tbody>
+      </table>
     </div>
   </div>
 

--- a/config/locales/forms/edit_forms/en.yml
+++ b/config/locales/forms/edit_forms/en.yml
@@ -34,6 +34,10 @@ en:
             heading: Principal place of business
             labels:
               location: Location
+          receipt:
+            heading: Card payment confirmation
+            labels:
+              email: Email
         edit_links:
           default: Change
           no_edit: Cannot edit

--- a/spec/presenters/waste_carriers_engine/edit_form_presenter_spec.rb
+++ b/spec/presenters/waste_carriers_engine/edit_form_presenter_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe EditFormPresenter do
+    subject { described_class.new(form, view) }
+
+    let(:form) { double(:form, transient_registration: transient_registration) }
+
+    describe "#receipt_email" do
+      context "when the field does not exist" do
+        let(:transient_registration) { double(:transient_registration) }
+
+        it "returns nothing" do
+          allow(transient_registration).to receive(:receipt_email)
+
+          expect(subject.receipt_email).to be_nil
+        end
+      end
+
+      context "when the field exists" do
+        let(:transient_registration) { double(:transient_registration, receipt_email: receipt_email) }
+        let(:receipt_email) { "foo@example.com" }
+
+        it "returns the value in receipt email" do
+          expect(subject.receipt_email).to eq(receipt_email)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1160

Now we have the new `receipt_email` field which we are capturing during new registrations and renewals we need to allow users to edit the value. Else once set (or not) it can never be changed which will cause issues for users who need to change it for subsequent Worldpay payments, for example, copy card orders.