### PR TITLE
Add host_is_back_office flag to config

### DIFF
--- a/lib/waste_carriers_engine.rb
+++ b/lib/waste_carriers_engine.rb
@@ -87,6 +87,18 @@ module WasteCarriersEngine
       end
     end
 
+    # Used to determine if engine is running in the back-office rather than the
+    # front-office
+    def host_is_back_office=(value)
+      @host_is_back_office = change_string_to_boolean_for(value)
+    end
+
+    def host_is_back_office?
+      return false unless @host_is_back_office
+
+      @host_is_back_office
+    end
+
     private
 
     # If the setting's value is "true", then set to a boolean true. Otherwise,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1141

We have come across an issue where we need to change behaviour in the journey based on whether a registration or renewal is being carried out in either the front-office app or the back-office app.

We've had to do this previously in the [waste-carriers-frontend](https://github.com/DEFRA/waste-carriers-frontend). But it relied on trying to make assertions based on the current URL.

We wanted to avoid anything too clever. So this change adds a new flag to the engine configuration that allows the host app to tell us, are you the back-office or not. Simple!