### PR TITLE
Hide payment confirmation in bank transfer page

### DIFF
--- a/app/views/waste_carriers_engine/confirm_bank_transfer_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/confirm_bank_transfer_forms/new.html.erb
@@ -5,16 +5,18 @@
     <h1 class="heading-large"><%= t(".heading") %></h1>
 
     <p>
-      <%= t(".paragraph_1") %>
+      <%= t(".paragraphs.instructions") %>
     </p>
 
-    <p>
-      <%= t(".paragraph_2") %>
-    </p>
+    <% unless WasteCarriersEngine.configuration.host_is_back_office? %>
+      <p>
+        <%= t(".paragraphs.payment_confirmation") %>
+      </p>
 
-    <p>
-      <%= t(".paragraph_3") %>
-    </p>
+      <p>
+        <%= t(".paragraphs.instant_confirmation") %>
+      </p>
+    <% end %>
 
     <p>
       <%= link_to(t(".link_text"),

--- a/config/locales/forms/confirm_bank_transfer_forms/en.yml
+++ b/config/locales/forms/confirm_bank_transfer_forms/en.yml
@@ -4,8 +4,9 @@ en:
       new:
         title: Pay by bank transfer
         heading: Registration takes longer if you pay by bank transfer
-        paragraph_1: "In order to pay by bank transfer, you will need to follow the instructions on the next screen and email us to confirm payment. This will take approximately 5 working days."
-        paragraph_2: "We do not send a payment confirmation if you pay by bank transfer."
-        paragraph_3: "In most cases we can provide instant confirmation if you pay by card."
+        paragraphs:
+          instructions: "In order to pay by bank transfer, you will need to follow the instructions on the next screen and email us to confirm payment. This will take approximately 5 working days."
+          instant_confirmation: "We do not send a payment confirmation if you pay by bank transfer."
+          payment_confirmation: "In most cases we can provide instant confirmation if you pay by card."
         link_text: "Go back to pay by credit or debit card instead"
         next_button: "Confirm you’ll pay by bank transfer"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1141

We have come across an issue where we need to change behaviour in the journey based on whether a registration or renewal is being carried out in either the front-office app or the back-office app.

We should have known, but have just realised that Worldpay does not send payment confirmation emails if the merchant code used is MOTO.

So we shouldn't show content in the back-office that suggests a payment confirmation email will be sent. This change hides this content in the confirm bank transfer if the engine is hosted in the back-office (and the config flag telling the engine this has been set!)