### PR TITLE
Hide payment confirmation in 'end' pages

### DIFF
--- a/app/views/waste_carriers_engine/registration_completed_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/registration_completed_forms/new.html.erb
@@ -9,8 +9,10 @@
 
   <p><%= t(".paragraph_1", email: @registration.contact_email) %></p>
 
-  <% if @registration.upper_tier? %>
-    <p><%= t(".paragraph_2", email: @registration.email_to_send_receipt) %></p>
+  <% unless WasteCarriersEngine.configuration.host_is_back_office? %>
+    <% if @registration.upper_tier? %>
+      <p><%= t(".paragraph_2", email: @registration.email_to_send_receipt) %></p>
+    <% end %>
   <% end %>
 
   <h2 class="heading-medium"><%= t(".subheading_1") %></h2>

--- a/app/views/waste_carriers_engine/registration_received_pending_conviction_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/registration_received_pending_conviction_forms/new.html.erb
@@ -6,7 +6,11 @@
   </div>
 
   <p><%= t(".paragraph_1", email: @registration.contact_email) %></p>
-  <p><%= t(".paragraph_2", email: @registration.email_to_send_receipt) %></p>
+
+  <% unless WasteCarriersEngine.configuration.host_is_back_office? %>
+    <p><%= t(".paragraph_2", email: @registration.email_to_send_receipt) %></p>
+  <% end %>
+
   <h2 class="heading-medium"><%= t(".subheading_1") %></h2>
   <p><%= t(".paragraph_3") %></p>
 

--- a/app/views/waste_carriers_engine/registration_received_pending_worldpay_payment_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/registration_received_pending_worldpay_payment_forms/new.html.erb
@@ -6,7 +6,10 @@
   </div>
 
   <p><%= t(".paragraph_1", email: @registration.contact_email) %></p>
-  <p><%= t(".paragraph_2", email: @registration.email_to_send_receipt) %></p>
+
+  <% unless WasteCarriersEngine.configuration.host_is_back_office? %>
+    <p><%= t(".paragraph_2", email: @registration.email_to_send_receipt) %></p>
+  <% end %>
 
   <h2 class="heading-medium"><%= t(".subheading_1") %></h2>
   <p><%= t(".paragraph_3") %></p>

--- a/app/views/waste_carriers_engine/renewal_complete_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/renewal_complete_forms/new.html.erb
@@ -20,7 +20,10 @@
 
       <p><%= t(".paragraph_1", date: @renewal_complete_form.projected_renewal_end_date) %></p>
       <p><%= t(".paragraph_2", email: @renewal_complete_form.contact_email) %></p>
-      <p><%= t(".paragraph_3", email: @renewal_complete_form.transient_registration.email_to_send_receipt) %></p>
+
+      <% unless WasteCarriersEngine.configuration.host_is_back_office? %>
+        <p><%= t(".paragraph_3", email: @renewal_complete_form.transient_registration.email_to_send_receipt) %></p>
+      <% end %>
 
       <h2 class="heading-medium"><%= t(".subheading_2") %></h2>
       <p><%= t(".paragraph_4.#{@renewal_complete_form.registration_type}") %></p>

--- a/app/views/waste_carriers_engine/renewal_received_pending_conviction_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/renewal_received_pending_conviction_forms/new.html.erb
@@ -23,7 +23,10 @@
       </div>
 
       <p><%= t(".paragraph_1", email: @renewal_received_pending_conviction_form.transient_registration.contact_email) %></p>
-      <p><%= t(".paragraph_2", email: @renewal_received_pending_conviction_form.transient_registration.email_to_send_receipt) %></p>
+
+      <% unless WasteCarriersEngine.configuration.host_is_back_office? %>
+        <p><%= t(".paragraph_2", email: @renewal_received_pending_conviction_form.transient_registration.email_to_send_receipt) %></p>
+      <% end %>
 
       <h2 class="heading-medium"><%= t(".subheading") %></h2>
 

--- a/app/views/waste_carriers_engine/renewal_received_pending_worldpay_payment_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/renewal_received_pending_worldpay_payment_forms/new.html.erb
@@ -29,7 +29,9 @@
 
       <p><%= t(".paragraph_2") %></p>
 
-      <p><%= t(".paragraph_3", email: @renewal_received_pending_worldpay_payment_form.transient_registration.email_to_send_receipt) %></p>
+      <% unless WasteCarriersEngine.configuration.host_is_back_office? %>
+        <p><%= t(".paragraph_3", email: @renewal_received_pending_worldpay_payment_form.transient_registration.email_to_send_receipt) %></p>
+      <% end %>
 
       <div class="panel panel-border-wide">
         <p><%= t(".paragraph_4") %></p>

--- a/config/locales/forms/registration_received_pending_worldpay_payment_forms/en.yml
+++ b/config/locales/forms/registration_received_pending_worldpay_payment_forms/en.yml
@@ -9,4 +9,4 @@ en:
         paragraph_2: "A payment confirmation will be sent to %{email}."
         subheading_1: "We have received your application"
         paragraph_3: "We’re currently processing your payment and will let you know when it has been received."
-        paragraph_4: "Your registration will not be active until we have confirmed your registration"
+        paragraph_4: "You’re not legally entitled to operate as a waste carrier until we have confirmed your registration."


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1141

We have come across an issue where we need to change behaviour in the journey based on whether a registration or renewal is being carried out in either the front-office app or the back-office app.

We should have known, but have just realised that Worldpay does not send payment confirmation emails if the merchant code used is MOTO.

So we shouldn't show content in the back-office that suggests a payment confirmation email will be sent. This change hides this content in the 'end' pages.