### PR TITLE
Do not copy receipt_email when init. renewal

### DIFF
--- a/app/models/waste_carriers_engine/renewing_registration.rb
+++ b/app/models/waste_carriers_engine/renewing_registration.rb
@@ -27,7 +27,7 @@ module WasteCarriersEngine
                                conviction_sign_offs
                                declaration
                                past_registrations
-                               copy_cards,
+                               copy_cards
                                receipt_email],
       remove_invalid_attributes: true
     }.freeze

--- a/app/models/waste_carriers_engine/renewing_registration.rb
+++ b/app/models/waste_carriers_engine/renewing_registration.rb
@@ -27,7 +27,8 @@ module WasteCarriersEngine
                                conviction_sign_offs
                                declaration
                                past_registrations
-                               copy_cards],
+                               copy_cards,
+                               receipt_email],
       remove_invalid_attributes: true
     }.freeze
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1172

This is the scenario

- User creates a new registration using the new journey in the FO
- User pays by card so a payment confirmation email is taken and :receipt_email is populated
- 3 years later user renews but as AD

Irrespective of how user pays, the renewed registration displays the payment confirmation section in Registration details

As we know that the payment confirmation email is only sent for digital users renewing or creating new registrations its a one-time thing against the registration.

So this means when a new renewal is initialised, we should not be copying the receipt email from the registration as it may not be applicable this time.