### PR TITLE
Remove magic link constraint for renew endpoint

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -642,7 +642,6 @@ WasteCarriersEngine::Engine.routes.draw do
 
   # Renew via magic link token
   get "/renew/:token",
-      constraints: ->(_request) { WasteCarriersEngine::FeatureToggle.active?(:renew_via_magic_link) },
       to: "renews#new",
       as: "renew"
 

--- a/spec/requests/waste_carriers_engine/renews_spec.rb
+++ b/spec/requests/waste_carriers_engine/renews_spec.rb
@@ -4,9 +4,6 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe "Renews", type: :request do
-    # TODO: Remove once renew via magic link is no longer behind a feature toggle
-    before(:each) { allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:renew_via_magic_link).and_return(true) }
-
     describe "GET renew_path" do
       context "when the renew token is valid" do
         let(:registration) { create(:registration, :has_required_data, :expires_soon) }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1170

RUBY-1170 merged `email_reminders` and `renew_via_magic_link` into a new single feature toggle called `renewal_reminders`. Our work has come so far that we don't actually make a distinction between renewal reminders and renewal reminders with magic links. There is only the version with magic links.

So we needed to update the engine to use the new toggle but instead have removed it.

If we continued to use the toggle against the `/renew` endpoint the following scenario would happen

- renewal reminders are enabled
- a user (along with others) gets a renewal reminder email containing a magic link
- NCCC request renewal reminders are disabled because of an increase in calls
- the user then decides to try and renew, clicks the link in the email but gets an error
- the user calls NCCC to report issue along with everyone else trying!

So we will offer a better experience if the `/renew` endpoint remains open. It is only of use if you have a valid token, and we'll only be generating those if `renewal_reminders` is enabled.