### PR TITLE
Hide contact name, phone and email in renewals

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_copy_data_from_registration.rb
+++ b/app/models/concerns/waste_carriers_engine/can_copy_data_from_registration.rb
@@ -12,7 +12,7 @@ module WasteCarriersEngine
       copy_attributes_from_registration
       copy_addresses_from_registration if options[:copy_addresses]
       copy_people_from_registration if options[:copy_people]
-      remove_invalid_attributes if options[:remove_invalid_attributes]
+      remove_revoked_reason if options[:remove_revoked_reason]
     end
 
     def copy_attributes_from_registration
@@ -30,18 +30,6 @@ module WasteCarriersEngine
       registration.key_people.each do |key_person|
         key_people << KeyPerson.new(key_person.attributes.except("_id", "conviction_search_result"))
       end
-    end
-
-    def remove_invalid_attributes
-      remove_invalid_phone_numbers
-      remove_revoked_reason
-    end
-
-    def remove_invalid_phone_numbers
-      validator = DefraRuby::Validators::PhoneNumberValidator.new(attributes: :phone_number)
-      return if validator.validate_each(self, :phone_number, phone_number)
-
-      self.phone_number = nil
     end
 
     def remove_revoked_reason

--- a/app/models/waste_carriers_engine/renewing_registration.rb
+++ b/app/models/waste_carriers_engine/renewing_registration.rb
@@ -33,7 +33,7 @@ module WasteCarriersEngine
                                lastName
                                phoneNumber
                                contactEmail],
-      remove_invalid_attributes: true
+      remove_revoked_reason: true
     }.freeze
 
     SUBMITTED_STATES = %w[renewal_complete_form

--- a/app/models/waste_carriers_engine/renewing_registration.rb
+++ b/app/models/waste_carriers_engine/renewing_registration.rb
@@ -28,7 +28,11 @@ module WasteCarriersEngine
                                declaration
                                past_registrations
                                copy_cards
-                               receipt_email],
+                               receipt_email
+                               firstName
+                               lastName
+                               phoneNumber
+                               contactEmail],
       remove_invalid_attributes: true
     }.freeze
 

--- a/spec/factories/renewing_registration.rb
+++ b/spec/factories/renewing_registration.rb
@@ -7,6 +7,10 @@ FactoryBot.define do
 
     trait :has_required_data do
       location { "england" }
+      first_name { "Mary" }
+      last_name { "Wollstonecraft" }
+      phone_number { "01234 567890" }
+      contact_email { "mary@example.com" }
       declared_convictions { "no" }
       temp_cards { 1 }
 
@@ -85,6 +89,10 @@ FactoryBot.define do
     trait :has_required_overseas_data do
       location { "overseas" }
       business_type { "overseas" }
+      first_name { "Sojourner" }
+      last_name { "Truth" }
+      phone_number { "01234 567890" }
+      contact_email { "sojourner@example.com" }
       declared_convictions { "no" }
       temp_cards { 1 }
 

--- a/spec/fixtures/files/request_to_worldpay.xml
+++ b/spec/fixtures/files/request_to_worldpay.xml
@@ -16,8 +16,8 @@
       </shopper>
       <billingAddress>
         <address>
-          <firstName>Jane</firstName>
-          <lastName>Doe</lastName>
+          <firstName>Mary</firstName>
+          <lastName>Wollstonecraft</lastName>
           <address1>42 Foo Gardens</address1>
           <address2/>
           <postalCode>FA1 1KE</postalCode>

--- a/spec/models/waste_carriers_engine/renewing_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_spec.rb
@@ -87,31 +87,6 @@ module WasteCarriersEngine
         end
       end
 
-      context "when the source registration has a valid phone_number" do
-        let(:registration) do
-          create(:registration,
-                 :has_required_data)
-        end
-
-        it "imports it" do
-          renewing_registration = RenewingRegistration.new(reg_identifier: registration.reg_identifier)
-          expect(renewing_registration.phone_number).to eq(registration.phone_number)
-        end
-      end
-
-      context "when the source registration has an invalid phone_number" do
-        let(:registration) do
-          create(:registration,
-                 :has_required_data,
-                 phone_number: "test")
-        end
-
-        it "does not import it" do
-          renewing_registration = RenewingRegistration.new(reg_identifier: registration.reg_identifier)
-          expect(renewing_registration.phone_number).to eq(nil)
-        end
-      end
-
       context "when the source registration has a revoked_reason" do
         let(:revoked_renewing_registration) { build(:renewing_registration, :has_revoked_registration) }
 

--- a/spec/models/waste_carriers_engine/renewing_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_spec.rb
@@ -119,6 +119,25 @@ module WasteCarriersEngine
           expect(revoked_renewing_registration.metaData.revoked_reason).to eq(nil)
         end
       end
+
+      context "when copying data from the source registration" do
+        let(:registration) do
+          create(:registration,
+                 :has_required_data,
+                 first_name: "Mary",
+                 last_name: "Wollstonecraft",
+                 phone_number: "01234 567890",
+                 contact_email: "mary@example.com")
+        end
+
+        it "does not copy over private contact information" do
+          renewing_registration = RenewingRegistration.new(reg_identifier: registration.reg_identifier)
+          expect(renewing_registration.first_name).to eq(nil)
+          expect(renewing_registration.last_name).to eq(nil)
+          expect(renewing_registration.phone_number).to eq(nil)
+          expect(renewing_registration.contact_email).to eq(nil)
+        end
+      end
     end
 
     describe "status" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1171

NCCC want to allow as many users as possible to renew via magic link. 2 major blockers are

- 3rd party agents acting on behalf of users
- the 3 year gap between renewing where contacts at an organisation have changed

This means the automated renewal reminders containing magic links won't get to who they need to. When these people call NCCC to renew (because they didn't receive the reminder) NCCC would like to manually send them a registrations renewal link. We've already covered exposing the link in [PR #963](https://github.com/DEFRA/waste-carriers-back-office/pull/963). But to ensure we don't inadvertently expose any personal details NCCC would also like the contact details which are not currently public, to not pre-populate for renewals.

Ideally we would have 2 journeys; one for recognised users with as much information as possible pre-populated, and one for anonymous renewals. But with our current resources reducing the amount we pre-populate will help more people renew online more quickly in the short-term.

So this change stops the following being copied into the renewal when initialised from a registration

- contact name
- contact phone
- contact email