### PR TITLE
Don't copy account email around editing

### DIFF
--- a/app/models/waste_carriers_engine/edit_registration.rb
+++ b/app/models/waste_carriers_engine/edit_registration.rb
@@ -9,9 +9,12 @@ module WasteCarriersEngine
 
     validates :reg_identifier, "waste_carriers_engine/reg_identifier": true
 
+    # IMPORTANT! When specifying attributes be sure to use the name as seen in
+    # the database and not the alias in the model. For example use accountEmail
+    # not account_email.
     COPY_DATA_OPTIONS = {
       ignorable_attributes: %w[_id
-                               account_email
+                               accountEmail
                                addresses
                                expires_on
                                renew_token

--- a/app/services/waste_carriers_engine/edit_completion_service.rb
+++ b/app/services/waste_carriers_engine/edit_completion_service.rb
@@ -39,9 +39,12 @@ module WasteCarriersEngine
     end
 
     def copy_attributes
+      # IMPORTANT! When specifying attributes be sure to use the name as seen in
+      # the database and not the alias in the model. For example use
+      # accountEmail not account_email.
       copyable_attributes = transient_registration.attributes.except("_id",
                                                                      "token",
-                                                                     "account_email",
+                                                                     "accountEmail",
                                                                      "created_at",
                                                                      "expires_on",
                                                                      "financeDetails",

--- a/spec/models/waste_carriers_engine/edit_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/edit_registration_spec.rb
@@ -38,7 +38,7 @@ module WasteCarriersEngine
         let(:edit_registration) { described_class.new(reg_identifier: registration.reg_identifier) }
 
         copyable_properties = Registration.attribute_names - %w[_id
-                                                                account_email
+                                                                accountEmail
                                                                 addresses
                                                                 expires_on
                                                                 key_people

--- a/spec/requests/waste_carriers_engine/edit_complete_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/edit_complete_forms_spec.rb
@@ -92,6 +92,14 @@ module WasteCarriersEngine
               end
             end
 
+            # A registration can be renewed or transferred after an edit is
+            # started. So when the edit completes it must not override key
+            # fields lik expiry_date and account_email
+            #
+            # See the following PR's for details of what issues this test is
+            # confirming is fixed.
+            # https://github.com/DEFRA/waste-carriers-engine/pull/879
+            # https://github.com/DEFRA/waste-carriers-engine/pull/902
             context "when key details have been changed by other actions since the edit was started" do
               let(:email) { "behindthescenes@example.com" }
               let(:expires_on) { Date.today + 42.days }

--- a/spec/requests/waste_carriers_engine/edit_complete_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/edit_complete_forms_spec.rb
@@ -105,7 +105,14 @@ module WasteCarriersEngine
               let(:expires_on) { Date.today + 42.days }
 
               it "it does not overwrite those details" do
-                edit_record = transient_registration
+                # We have to be careful of lazy let() evaluation. We need to
+                # ensure the transient_registration (edit record) is created
+                # before we make our changes to the registration. So these
+                # expects not only ensure that, they also mean the transient
+                # is initialised before we then apply changes to the
+                # registration.
+                expect(transient_registration.account_email).to_not eq(email)
+                expect(transient_registration.expires_on).to_not eq(expires_on)
 
                 registration.account_email = email
                 registration.expires_on = expires_on

--- a/spec/requests/waste_carriers_engine/edit_complete_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/edit_complete_forms_spec.rb
@@ -91,6 +91,25 @@ module WasteCarriersEngine
                 expect(registration.finance_details.orders.count).to eq(old_orders_count + 1)
               end
             end
+
+            context "when key details have been changed by other actions since the edit was started" do
+              let(:email) { "behindthescenes@example.com" }
+              let(:expires_on) { Date.today + 42.days }
+
+              it "it does not overwrite those details" do
+                edit_record = transient_registration
+
+                registration.account_email = email
+                registration.expires_on = expires_on
+                registration.save!
+
+                get new_edit_complete_form_path(transient_registration.token)
+                registration.reload
+
+                expect(registration.account_email).to eq(email)
+                expect(registration.expires_on).to eq(expires_on)
+              end
+            end
           end
 
           context "when the workflow_state is not correct" do

--- a/spec/services/waste_carriers_engine/edit_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/edit_completion_service_spec.rb
@@ -16,7 +16,7 @@ module WasteCarriersEngine
       {
         "_id" => nil,
         "token" => nil,
-        "account_email" => nil,
+        "accountEmail" => nil,
         "created_at" => nil,
         "expires_on" => nil,
         "financeDetails" => nil,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1178

Previously during an edit, the value of account_email was copied from the registration to the transient_registration and then copied back again when the edit was completed.

If the registration was transferred between the edit being started and completed, this resulted in a bug where the account_email date was "reset" to its previous value.

There was existing code to try and prevent this. But there was a mistake in the naming convention used caused by a legacy issue of the old app not being consistent with camelCase and snake_case field names.

This PR fixes the existing code.