### PR TITLE
Fix hardcoded links to old frontend

### DIFF
--- a/app/forms/waste_carriers_engine/renewal_complete_form.rb
+++ b/app/forms/waste_carriers_engine/renewal_complete_form.rb
@@ -4,7 +4,7 @@ module WasteCarriersEngine
   class RenewalCompleteForm < ::WasteCarriersEngine::BaseForm
     include CannotSubmit
 
-    attr_accessor :certificate_link, :contact_email, :projected_renewal_end_date, :registration_type
+    attr_accessor :contact_email, :projected_renewal_end_date, :registration_type
 
     def self.can_navigate_flexibly?
       false
@@ -13,21 +13,9 @@ module WasteCarriersEngine
     def initialize(transient_registration)
       super
 
-      self.certificate_link = build_certificate_link
       self.contact_email = transient_registration.contact_email
       self.projected_renewal_end_date = transient_registration.projected_renewal_end_date
       self.registration_type = transient_registration.registration_type
-    end
-
-    private
-
-    def build_certificate_link
-      registration = @transient_registration.registration
-      return unless registration.present?
-
-      id = registration.id
-      root = Rails.configuration.wcrs_frontend_url
-      "#{root}/registrations/#{id}/view"
     end
   end
 end

--- a/app/views/waste_carriers_engine/cannot_renew_company_no_change_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/cannot_renew_company_no_change_forms/new.html.erb
@@ -5,5 +5,5 @@
   <p><%= t(".paragraph_1") %></p>
   <p><%= t(".paragraph_2", reg_identifier: @cannot_renew_company_no_change_form.reg_identifier) %></p>
   <p><%= t(".paragraph_3") %></p>
-  <a href="<%= Rails.configuration.wcrs_frontend_url %>/registrations/start" class="button"><%= t(".next_button") %></a>
+  <%= link_to t(".next_button"), start_forms_path, class: "button" %>
 </div>

--- a/app/views/waste_carriers_engine/cannot_renew_lower_tier_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/cannot_renew_lower_tier_forms/new.html.erb
@@ -4,5 +4,5 @@
   <h1 class="heading-large"><%= t(".heading", reg_identifier: @cannot_renew_lower_tier_form.reg_identifier) %></h1>
   <p><%= t(".paragraph_1") %></p>
   <p><%= t(".paragraph_2") %></p>
-  <a href="<%= Rails.configuration.wcrs_frontend_url %>/registrations/start" class="button"><%= t(".next_button") %></a>
+  <%= link_to t(".next_button"), start_forms_path, class: "button" %>
 </div>

--- a/app/views/waste_carriers_engine/cannot_renew_type_change_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/cannot_renew_type_change_forms/new.html.erb
@@ -3,5 +3,5 @@
 <div class="text">
   <h1 class="heading-large"><%= t(".heading", reg_identifier: @cannot_renew_type_change_form.reg_identifier) %></h1>
   <p><%= t(".paragraph") %></p>
-  <a href="<%= Rails.configuration.wcrs_frontend_url %>/registrations/start" class="button"><%= t(".next_button") %></a>
+  <%= link_to t(".next_button"), start_forms_path, class: "button" %>
 </div>

--- a/app/views/waste_carriers_engine/renewal_mailer/send_renewal_complete_email.html.erb
+++ b/app/views/waste_carriers_engine/renewal_mailer/send_renewal_complete_email.html.erb
@@ -125,7 +125,7 @@
 
               <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">
                 <%= t(".details.paragraph_2.part_1") %>
-                <%= link_to(t(".details.paragraph_2.link_text"), "#{Rails.configuration.wcrs_frontend_url}/users/sign_in") %>
+                <%= link_to(t(".details.paragraph_2.link_text"), "#{Rails.configuration.wcrs_renewals_url}/fo/users/sign_in") %>
                 <%= t(".details.paragraph_2.part_2") %>
               </p>
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1223

We spotted that some pages (and an email) had hardcoded links to the old frontend. Since the frontend is being removed, we need to update these to go to the front office instead.

One of these instances was no longer being used in the code at all, so I have removed it.