### PR TITLE
Rework registration.already_renewed? check

### DIFF
--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -69,10 +69,18 @@ module WasteCarriersEngine
     end
 
     def already_renewed?
-      period_after_last_window = Rails.configuration.expires_after.years + Rails.configuration.grace_window.days
-      registration_window = expires_on - period_after_last_window + 1.day
+      # Does a past registration exist which was created by a renewal and has
+      # an expiry date less than 6 months old? If so, we can determine that
+      # a renewal has recently been created for a registration that would
+      # otherwise be expiring around now.
+      expires_on_gte = Date.current - Rails.configuration.renewal_window.months
 
-      past_registrations.where(cause: nil, :expires_on.gte => registration_window).any?
+      past_registrations.where(
+        cause: nil,
+        expires_on: {
+          "$gte" => expires_on_gte
+        }
+      ).any?
     end
 
     def past_renewal_window?

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -30,10 +30,11 @@ FactoryBot.define do
     end
 
     trait :already_renewed do
-      expires_soon
+      expires_in_3_years
 
       after :create do |registration|
-        WasteCarriersEngine::PastRegistration.build_past_registration(registration)
+        past_registration = WasteCarriersEngine::PastRegistration.build_past_registration(registration)
+        past_registration.update(expires_on: registration.expires_on - 3.years)
       end
     end
 
@@ -110,6 +111,11 @@ FactoryBot.define do
     trait :expires_later do
       metaData { build(:metaData, :has_required_data, status: :ACTIVE) }
       expires_on { 2.years.from_now }
+    end
+
+    trait :expires_in_3_years do
+      metaData { build(:metaData, :has_required_data, status: :ACTIVE) }
+      expires_on { 3.years.from_now }
     end
 
     trait :is_pending do

--- a/spec/requests/waste_carriers_engine/renews_spec.rb
+++ b/spec/requests/waste_carriers_engine/renews_spec.rb
@@ -42,11 +42,19 @@ module WasteCarriersEngine
         end
 
         context "when the registration has already been renewed" do
-          let(:registration) { create(:registration, :has_required_data, :already_renewed) }
+          let(:registration) do
+            create(:registration,
+                   :has_required_data,
+                   :already_renewed,
+                   # Normally we would not be allowed to generate a token for a
+                   # registration this far in advance, so some fudging needed
+                   renew_token: SecureTokenService.run)
+          end
 
           it "returns a 200 response code and the correct template" do
             allow(Rails.configuration).to receive(:renewal_window).and_return(3)
 
+            puts registration.past_registrations.last.expires_on
             get renew_path(token: registration.renew_token)
 
             expect(response).to have_http_status(200)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1210

This check wasn't behaving as expected and was causing confusion. Decided to rework it so that if a past_registration exists for a registration which would otherwise have expired within the last 6 months, we can determine that a renewal has already occured.