### PR TITLE
Update links to Wales, Scotland and NI registration

### DIFF
--- a/app/views/waste_carriers_engine/register_in_northern_ireland_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/register_in_northern_ireland_forms/new.html.erb
@@ -8,7 +8,7 @@
 
     <div class="form-group">
       <p><%= t(".paragraph_1") %></p>
-      <p><%= t(".paragraph_2") %> <a href="https://www.gov.uk/waste-carrier-or-broker-registration-northern-ireland"><%= t(".service_link") %></a>.</p>
+      <p><%= t(".paragraph_2") %> <a href="https://www.daera-ni.gov.uk/articles/registration-carriers-and-brokers"><%= t(".service_link") %></a>.</p>
       <p><%= t(".paragraph_3") %></p>
     </div>
 

--- a/app/views/waste_carriers_engine/register_in_scotland_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/register_in_scotland_forms/new.html.erb
@@ -8,7 +8,7 @@
 
     <div class="form-group">
       <p><%= t(".paragraph_1") %></p>
-      <p><%= t(".paragraph_2") %> <a href="https://www.gov.uk/waste-carrier-or-broker-registration-scotland"><%= t(".service_link") %></a>.</p>
+      <p><%= t(".paragraph_2") %> <a href="https://www.sepa.org.uk/regulations/waste/waste-carriers-and-brokers/"><%= t(".service_link") %></a>.</p>
       <p><%= t(".paragraph_3") %></p>
     </div>
 

--- a/app/views/waste_carriers_engine/register_in_wales_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/register_in_wales_forms/new.html.erb
@@ -8,7 +8,7 @@
 
     <div class="form-group">
       <p><%= t(".paragraph_1") %></p>
-      <p><%= t(".paragraph_2") %> <a href="https://www.gov.uk/register-as-a-waste-carrier-broker-or-dealer-wales"><%= t(".service_link") %></a>.</p>
+      <p><%= t(".paragraph_2") %> <a href="https://naturalresourceswales.gov.uk/permits-and-permissions/waste-permitting/register-as-a-waste-carrier-broker-or-dealer/"><%= t(".service_link") %></a>.</p>
       <p><%= t(".paragraph_3") %></p>
     </div>
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1224

The GOV.UK links no longer work and instead redirect to the "Register in England" start page. So this switches to link directly to the governing bodies' websites.