### PR TITLE
Fix EPR query

### DIFF
--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -46,7 +46,7 @@ module WasteCarriersEngine
         { :expires_on.gte => normal_expiry_date },
         # Registration had a COVID extension and is within the COVID grace window
         { expires_on: {
-          "$lte" => Rails.configuration.end_of_covid_extension,
+          "$lt" => Rails.configuration.end_of_covid_extension,
           "$gte" => earliest_day_of_covid_grace_window
         } }
       )

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -178,7 +178,7 @@ module WasteCarriersEngine
 
           future_expire_date = create(:registration, :has_required_data, expires_on: 2.days.from_now)
           past_covid_extension_in_grace_window = create(:registration, :has_required_data, expires_on: 20.days.ago)
-          past_covid_extension_edge_grace_window = create(:registration, :has_required_data, expires_on: 30.days.ago)
+          past_covid_extension_edge_grace_window = create(:registration, :has_required_data, expires_on: 30.days.ago.beginning_of_day)
           past_covid_extension_not_in_grace_window = create(:registration, :has_required_data, expires_on: 40.days.ago)
           past_not_covid = create(:registration, :has_required_data, expires_on: 2.days.ago)
           lower_tier = create(:registration, :has_required_data, :lower_tier, expires_on: nil)


### PR DESCRIPTION
This was including registrations where the registration's expires_on was less than or equal to the cutoff date. We actually want to exclude any regs from the cutoff date and onwards.

Unit tests didn't catch this because the expires_on was being set to later in the day on the cutoff date, rather than 00:00, so it was considered later than.