### PR TITLE
Swap to Mongoid-specific DB-cleaning gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ group :production do
 end
 
 group :test do
-  gem "database_cleaner"
+  gem "database_cleaner-mongoid"
   gem "factory_bot_rails", require: false
   gem "rails-controller-testing"
   gem "simplecov", "~> 0.17.1", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,10 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    database_cleaner (1.8.5)
+    database_cleaner-core (2.0.1)
+    database_cleaner-mongoid (2.0.1)
+      database_cleaner-core (~> 2.0.0)
+      mongoid
     defra_ruby_address (0.1.0)
       rest-client (~> 2.0)
     defra_ruby_alert (2.1.1)
@@ -384,7 +387,7 @@ PLATFORMS
 
 DEPENDENCIES
   cancancan (~> 1.10)
-  database_cleaner
+  database_cleaner-mongoid
   defra_ruby_style
   devise (>= 4.4.3)
   dotenv-rails

--- a/spec/requests/waste_carriers_engine/renews_spec.rb
+++ b/spec/requests/waste_carriers_engine/renews_spec.rb
@@ -54,7 +54,6 @@ module WasteCarriersEngine
           it "returns a 200 response code and the correct template" do
             allow(Rails.configuration).to receive(:renewal_window).and_return(3)
 
-            puts registration.past_registrations.last.expires_on
             get renew_path(token: registration.renew_token)
 
             expect(response).to have_http_status(200)

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 # Require this to support automatically cleaning the database when testing
-require "database_cleaner"
+require "database_cleaner-mongoid"
 
 RSpec.configure do |config|
   # Clean the registrations and users databases before running tests
   config.before(:suite) do
-    DatabaseCleaner[:mongoid].strategy = :truncation
-    DatabaseCleaner[:mongoid, { connection: :users }].strategy = :truncation
+    DatabaseCleaner[:mongoid].strategy = :deletion
+    DatabaseCleaner[:mongoid, { db: :users }].strategy = :deletion
 
     DatabaseCleaner.clean
   end


### PR DESCRIPTION
We used to use the generic database_cleaner gem but this is now moving in the direction of having ORM-specific gems. ~2.0 updates were failing so it's time to swap.

Also removed some debug output from the tests that was accidentally left in.