### PR TITLE
Install Notify gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,7 @@ PATH
       mongoid
       mongoid-locker (= 2.0.0)
       nokogiri
+      notifications-ruby-client
       rails (>= 6.0.3)
       rest-client (~> 2.0)
       turbolinks

--- a/waste_carriers_engine.gemspec
+++ b/waste_carriers_engine.gemspec
@@ -55,6 +55,9 @@ Gem::Specification.new do |s|
   # details of the last email sent by the app can be accessed
   s.add_dependency "defra_ruby_email"
 
+  # Use Notify to send emails and letters
+  s.add_dependency "notifications-ruby-client"
+
   # Used to build and parse XML requests
   s.add_dependency "nokogiri"
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1277

This is required to send emails and letters through GOV.UK Notify.