### PR TITLE
Add Notify key to engine config

### DIFF
--- a/lib/waste_carriers_engine.rb
+++ b/lib/waste_carriers_engine.rb
@@ -31,6 +31,8 @@ module WasteCarriersEngine
     attr_reader :companies_house_host, :companies_house_api_key
     # Address lookup config
     attr_reader :address_host
+    # Notify config
+    attr_accessor :notify_api_key
 
     def initialize
       configure_airbrake_rails_properties

--- a/spec/dummy/config/initializers/waste_carriers_engine.rb
+++ b/spec/dummy/config/initializers/waste_carriers_engine.rb
@@ -16,5 +16,8 @@ WasteCarriersEngine.configure do |config|
 
   # Address lookup config
   config.address_host = ENV["ADDRESSBASE_URL"] || "http://localhost:3002"
+
+  # Notify config
+  config.notify_api_key = ENV["NOTIFY_API_KEY"]
 end
 WasteCarriersEngine.start_airbrake


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1277

This allows us to set the API key when we configure the engine in the front and back office.