### PR TITLE
Fix test helper about COVID grace window

### DIFF
--- a/spec/support/helpers/grace_windows.rb
+++ b/spec/support/helpers/grace_windows.rb
@@ -7,7 +7,7 @@ module Helpers
     # date, this helper should ensure that tests pass before and after.
     def self.current_grace_window
       if 6.months.ago > Rails.configuration.end_of_covid_extension
-        Rails.configuration.current_grace_window
+        Rails.configuration.grace_window
       else
         Rails.configuration.covid_grace_window
       end


### PR DESCRIPTION
6 months have now passed since this extension was last applied, and so this broken line of code started to be called and broke a bunch of tests.