### PR TITLE
Configure defra_ruby_email gem

### DIFF
--- a/config/initializers/defra_ruby_email.rb
+++ b/config/initializers/defra_ruby_email.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+DefraRubyEmail.configure do |configuration|
+  configuration.notify_api_key = ENV["NOTIFY_API_KEY"]
+end


### PR DESCRIPTION
We need to set the Notify API key here or the /email/last-notify-message endpoint won't work.