### PR TITLE
Format registration date as a string for Notify display

### DIFF
--- a/app/services/waste_carriers_engine/notify/registration_activated_email_service.rb
+++ b/app/services/waste_carriers_engine/notify/registration_activated_email_service.rb
@@ -16,7 +16,7 @@ module WasteCarriersEngine
             last_name: @registration.last_name,
             phone_number: @registration.phone_number,
             registered_address: registered_address,
-            date_registered: @registration.metaData.date_registered,
+            date_registered: date_registered,
             link_to_file: Notifications.prepare_upload(pdf)
           }
         }
@@ -40,6 +40,10 @@ module WasteCarriersEngine
 
       def registered_address
         certificate_presenter.registered_address_fields.join(", ")
+      end
+
+      def date_registered
+        @registration.metaData.date_registered.in_time_zone("London").to_date.to_s
       end
 
       def certificate_presenter

--- a/spec/services/waste_carriers_engine/notify/registration_activated_email_service_spec.rb
+++ b/spec/services/waste_carriers_engine/notify/registration_activated_email_service_spec.rb
@@ -17,7 +17,7 @@ module WasteCarriersEngine
               last_name: "Doe",
               phone_number: "03708 506506",
               registered_address: "42, Foo Gardens, Baz City, FA1 1KE",
-              date_registered: registration.metaData.date_registered,
+              date_registered: registration.metaData.date_registered.strftime("%e %B %Y"),
               link_to_file: "Hello World"
             }
           }


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/RUBY/boards/374

- With an ActionMailer view template, the `to_s` formatting is taken care of.
- With a Notify template, we need to explicitly format the dates

@irisfaraway  There may be a better / existing way of doing this?