### PR TITLE
Prefer multi-line address on registration activated email template

### DIFF
--- a/app/services/waste_carriers_engine/notify/registration_activated_email_service.rb
+++ b/app/services/waste_carriers_engine/notify/registration_activated_email_service.rb
@@ -39,7 +39,7 @@ module WasteCarriersEngine
       end
 
       def registered_address
-        certificate_presenter.registered_address_fields.join(", ")
+        certificate_presenter.registered_address_fields.join("\r\n")
       end
 
       def date_registered

--- a/spec/services/waste_carriers_engine/notify/registration_activated_email_service_spec.rb
+++ b/spec/services/waste_carriers_engine/notify/registration_activated_email_service_spec.rb
@@ -16,7 +16,7 @@ module WasteCarriersEngine
               first_name: "Jane",
               last_name: "Doe",
               phone_number: "03708 506506",
-              registered_address: "42, Foo Gardens, Baz City, FA1 1KE",
+              registered_address: "42\r\nFoo Gardens\r\nBaz City\r\nFA1 1KE",
               date_registered: registration.metaData.date_registered.strftime("%e %B %Y"),
               link_to_file: "Hello World"
             }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1291

Here we format the registered address with line breaks,
(as opposed to a single line)