### PR TITLE
Ensure each template has <h1> tag

### DIFF
--- a/app/views/waste_carriers_engine/business_type_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/business_type_forms/new.html.erb
@@ -33,7 +33,7 @@
     ],
     :id,
     :name,
-    legend: { text: t(".heading"), size: "l" }
+    legend: { text: t(".heading"), size: "l", tag: "h1" }
   %>
 
   <p class="govuk-body"><%= t(".help") %></p>

--- a/app/views/waste_carriers_engine/cbd_type_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/cbd_type_forms/new.html.erb
@@ -6,7 +6,7 @@
       <%= render partial: "waste_carriers_engine/shared/error_summary", locals: { f: f } %>
 
       <%= f.govuk_radio_buttons_fieldset :registration_type,
-          legend: { text: t(".heading"), size: "l" } do %>
+          legend: { text: t(".heading"), size: "l", tag: "h1" } do %>
         <%= f.govuk_radio_button :registration_type,
             "carrier_dealer", label: { text: t(".options.carrier_dealer") }, link_errors: true %>
         <%= f.govuk_radio_button :registration_type,

--- a/app/views/waste_carriers_engine/check_your_tier_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/check_your_tier_forms/new.html.erb
@@ -23,7 +23,7 @@
         ],
         :id,
         :name,
-        legend: { text: t(".heading"), size: "l" },
+        legend: { text: t(".heading"), size: "l", tag: "h1" },
         hint: { text: t(".paragraph") }
       %>
       <%= f.govuk_submit t(".next_button") %>

--- a/app/views/waste_carriers_engine/construction_demolition_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/construction_demolition_forms/new.html.erb
@@ -19,7 +19,7 @@
         :id,
         :name,
         inline: true,
-        legend: { text: t(".heading"), size: "l" }
+        legend: { text: t(".heading"), size: "l", tag: "h1" }
       %>
       <details class="govuk-details" data-module="govuk-details">
         <summary class="govuk-details__summary">

--- a/app/views/waste_carriers_engine/declaration_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/declaration_forms/new.html.erb
@@ -5,7 +5,7 @@
 
   <%= f.govuk_check_boxes_fieldset :declaration,
       multiple: false,
-      legend: { text:  t(".heading"), size: "l" } do %>
+      legend: { text:  t(".heading"), size: "l", tag: "h1" } do %>
 
     <ul class="govuk-list govuk-list--bullet">
       <li><%= t(".list_item_1") %></li>

--- a/app/views/waste_carriers_engine/declare_convictions_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/declare_convictions_forms/new.html.erb
@@ -21,7 +21,7 @@
           :id,
           :name,
           inline: true,
-          legend: { text: t(".heading"), size: "l" },
+          legend: { text: t(".heading"), size: "l", tag: "h1" },
           hint: -> do
         %>
 

--- a/app/views/waste_carriers_engine/location_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/location_forms/new.html.erb
@@ -30,7 +30,7 @@
         ],
         :id,
         :name,
-        legend: { text: t(".location_detail_subheading"), size: "l" },
+        legend: { text: t(".location_detail_subheading"), size: "l", tag: "h1" },
         hint: -> do %>
           <details class="govuk-details" data-module="govuk-details">
             <summary class="govuk-details__summary">

--- a/app/views/waste_carriers_engine/other_businesses_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/other_businesses_forms/new.html.erb
@@ -18,7 +18,7 @@
         :id,
         :name,
         inline: true,
-        legend: { text: t(".heading"), size: "l" }
+        legend: { text: t(".heading"), size: "l", tag: "h1" }
       %>
       <%= f.govuk_submit t(".next_button") %>
     <% end %>

--- a/app/views/waste_carriers_engine/service_provided_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/service_provided_forms/new.html.erb
@@ -18,7 +18,7 @@
         ],
         :id,
         :name,
-        legend: { text: t(".heading"), size: "l" }
+        legend: { text: t(".heading"), size: "l", tag: "h1" }
       %>
       <%= f.govuk_submit t(".next_button") %>
     <% end %>

--- a/app/views/waste_carriers_engine/start_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/start_forms/new.html.erb
@@ -17,7 +17,7 @@
     ],
     :id,
     :name,
-    legend: { text: t(".heading"), size: "l" }
+    legend: { text: t(".heading"), size: "l", tag: "h1" }
   %>
 
   <%= f.govuk_submit t(".next_button") %>

--- a/app/views/waste_carriers_engine/waste_types_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/waste_types_forms/new.html.erb
@@ -18,7 +18,7 @@
         ],
         :id,
         :name,
-        legend: { text: t(".heading"), size: "l" },
+        legend: { text: t(".heading"), size: "l", tag: "h1" },
         hint: -> do %>
           <ul class="">
             <% t(".waste_types").each do |list_item| %>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1557

Here we add the `tag` attribute to the form builder to ensure
that the `legend` text  is rendered within `h1`