### PR TITLE
Pre-fill manual address forms with existing answers on error

### DIFF
--- a/app/views/waste_carriers_engine/shared/_manual_address.html.erb
+++ b/app/views/waste_carriers_engine/shared/_manual_address.html.erb
@@ -6,7 +6,8 @@
   <%= f.govuk_text_field :house_number,
       label: { text: t(".house_number_label") },
       hint: { text: t(".house_number_hint") },
-      width: "one-half"
+      width: "one-half",
+      value: form.house_number
   %>
 </div>
 
@@ -17,14 +18,16 @@
 
   <%= f.govuk_text_field :address_line_1,
     label: { text: t(".address_line_1_label") },
-    width: "one-half"
+    width: "one-half",
+    value: form.address_line_1
   %>
 </div>
 
 <div class="govuk-form-group">
   <%= f.govuk_text_field :address_line_2,
     label: { text: t(".address_line_2_label") },
-    width: "one-half"
+    width: "one-half",
+    value: form.address_line_2
   %>
 </div>
 
@@ -35,7 +38,8 @@
 
   <%= f.govuk_text_field :town_city,
     label: { text: t(".town_city_label") },
-    width: "one-half"
+    width: "one-half",
+    value: form.town_city
   %>
 </div>
 
@@ -47,7 +51,8 @@
 
     <%= f.govuk_text_field :postcode,
       label: { text: t(".postcode_label") },
-      width: "one-half"
+      width: "one-half",
+      value: form.postcode
     %>
   </div>
 
@@ -58,7 +63,8 @@
 
     <%= f.govuk_text_field :country,
       label: { text: t(".country_label") },
-      width: "one-half"
+      width: "one-half",
+      value: form.country
     %>
   </div>
 <% else %>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1670

If there is a validation error, we don't want to lose the previously submitted answers. They should remain so the user can edit them.