### PR TITLE
Enable address reuse for corporate and overseas addresses

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
@@ -244,12 +244,7 @@ module WasteCarriersEngine
                       to: :contact_email_form
 
           transitions from: :contact_email_form,
-                      to: :contact_address_manual_form,
-                      if: :overseas?
-
-          transitions from: :contact_email_form,
-                      to: :contact_address_reuse_form,
-                      if: :business_type_can_reuse_registered_address?
+                      to: :contact_address_reuse_form
 
           transitions from: :contact_email_form,
                       to: :contact_postcode_form
@@ -260,6 +255,11 @@ module WasteCarriersEngine
                       to: :check_your_answers_form,
                       if: :reuse_registered_address?,
                       after: :set_contact_address_as_registered_address
+
+          transitions from: :contact_address_reuse_form,
+                      to: :contact_address_manual_form,
+                      unless: :reuse_registered_address?,
+                      if: :overseas?
 
           transitions from: :contact_address_reuse_form,
                       to: :contact_postcode_form,
@@ -509,8 +509,7 @@ module WasteCarriersEngine
                       to: :contact_email_form
 
           transitions from: :contact_postcode_form,
-                      to: :contact_address_reuse_form,
-                      if: :business_type_can_reuse_registered_address?
+                      to: :contact_address_reuse_form
 
           transitions from: :contact_postcode_form,
                       to: :contact_email_form
@@ -519,7 +518,7 @@ module WasteCarriersEngine
                       to: :contact_postcode_form
 
           transitions from: :contact_address_manual_form,
-                      to: :contact_email_form,
+                      to: :contact_address_reuse_form,
                       if: :overseas?
 
           transitions from: :contact_address_manual_form,
@@ -658,10 +657,6 @@ module WasteCarriersEngine
         return switch_to_upper_tier if temp_check_your_tier == "upper"
 
         switch_to_lower_tier
-      end
-
-      def business_type_can_reuse_registered_address?
-        !%w[limitedCompany limitedLiabilityPartnership].include?(businessType)
       end
 
       def reuse_registered_address?

--- a/spec/models/waste_carriers_engine/new_registration_workflow/contact_address_manual_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/contact_address_manual_form_spec.rb
@@ -6,7 +6,7 @@ module WasteCarriersEngine
   RSpec.describe NewRegistration do
     describe "#workflow_state" do
       it_behaves_like "a manual address transition",
-                      previous_state_if_overseas: :contact_email_form,
+                      previous_state_if_overseas: :contact_address_reuse_form,
                       next_state: :check_your_answers_form,
                       address_type: "contact",
                       factory: :new_registration

--- a/spec/models/waste_carriers_engine/new_registration_workflow/contact_email_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/contact_email_form_spec.rb
@@ -9,12 +9,6 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":contact_email_form state transitions" do
         context "on next" do
-          context "when the business is based overseas" do
-            subject { build(:new_registration, workflow_state: "contact_email_form", location: "overseas") }
-
-            include_examples "has next transition", next_state: "contact_address_manual_form"
-          end
-
           include_examples "has next transition", next_state: "contact_address_reuse_form"
         end
 


### PR DESCRIPTION
This builds on previous work that introduced an [address reuse form](https://github.com/DEFRA/waste-carriers-engine/commit/5cefc1dad4b45c57e78e15ccd222ac839a18b3a7)

https://eaflood.atlassian.net/browse/RUBY-1717