### PR TITLE
Deprecation warnings

### DIFF
--- a/app/forms/waste_carriers_engine/base_form.rb
+++ b/app/forms/waste_carriers_engine/base_form.rb
@@ -71,7 +71,7 @@ module WasteCarriersEngine
       return if transient_registration.valid?
 
       transient_registration.errors.each do |_attribute, message|
-        errors[:base] << message
+        errors.add(:base, message)
       end
     end
 

--- a/spec/models/waste_carriers_engine/transient_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/transient_registration_spec.rb
@@ -8,6 +8,8 @@ module WasteCarriersEngine
 
     describe "#set_metadata_route" do
       it "updates the transient registration's metadata route" do
+        allow_message_expectations_on_nil
+
         metadata_route = double(:metadata_route)
 
         expect(Rails.configuration).to receive(:metadata_route).and_return(metadata_route)

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -6,7 +6,7 @@ require "database_cleaner-mongoid"
 RSpec.configure do |config|
   # Clean the registrations and users databases before running tests
   config.before(:suite) do
-    DatabaseCleaner[:mongoid].strategy = :deletion
+    DatabaseCleaner[:mongoid].strategy = [:deletion]
     DatabaseCleaner[:mongoid, { db: :users }].strategy = :deletion
 
     DatabaseCleaner.clean


### PR DESCRIPTION
Here we suppress some of the (many) deprecation warnings that crop up when running specs:

- Suppress 'Warn when expectation is set on nil'
- Prefer `ActiveModel::Errors#add` over `<<`