### PR TITLE
Pin loofah to 2.2.1 in the lock file

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,7 +225,7 @@ GEM
       thor (>= 0.14, < 2.0)
     json (2.3.0)
     jwt (2.2.3)
-    loofah (2.13.0)
+    loofah (2.2.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)


### PR DESCRIPTION
- 2.13.0 has a security vulnerability: CVE-2018-8048