### PR TITLE
Implement companies house data reuse for registration

### DIFF
--- a/app/controllers/waste_carriers_engine/check_company_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/check_company_forms_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class CheckCompanyFormsController < ::WasteCarriersEngine::FormsController
+    def new
+      super(CheckCompanyForm, "check_company_form")
+    end
+
+    def create
+      super(CheckCompanyForm, "check_company_form")
+    end
+
+    private
+
+    def transient_registration_attributes
+      params.fetch(:check_company_form, {}).permit(:temp_use_companies_house_details)
+    end
+  end
+end

--- a/app/controllers/waste_carriers_engine/incorrect_company_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/incorrect_company_forms_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class IncorrectCompanyFormsController < ::WasteCarriersEngine::FormsController
+    def new
+      super(IncorrectCompanyForm, "incorrect_company_form")
+    end
+  end
+end

--- a/app/forms/waste_carriers_engine/check_company_form.rb
+++ b/app/forms/waste_carriers_engine/check_company_form.rb
@@ -1,9 +1,40 @@
 # frozen_string_literal: true
 
+require "defra_ruby_companies_house"
+
 module WasteCarriersEngine
   class CheckCompanyForm < ::WasteCarriersEngine::BaseForm
-    delegate :temp_use_companies_house_details, to: :transient_registration
+    delegate :company_no, :temp_use_companies_house_details, to: :transient_registration
 
     validates :temp_use_companies_house_details, "waste_carriers_engine/yes_no": true
+
+    def ch_company_name
+      company[:company_name]
+    end
+
+    def ch_registered_office_address_lines
+      [
+        company[:registered_office_address][:address_line_1],
+        company[:registered_office_address][:address_line_2],
+        company[:registered_office_address][:locality],
+        company[:registered_office_address][:postal_code]
+      ].compact
+    end
+
+    def ch_officer_names
+      companies_house_service.active_officers.map do |officer|
+        officer[:name].split(", ").reverse.join(" ")
+      end
+    end
+
+    private
+
+    def company
+      @_company ||= companies_house_service.company
+    end
+
+    def companies_house_service
+      @_companies_house_service ||= DefraRubyCompaniesHouse.new(company_no)
+    end
   end
 end

--- a/app/forms/waste_carriers_engine/check_company_form.rb
+++ b/app/forms/waste_carriers_engine/check_company_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class CheckCompanyForm < ::WasteCarriersEngine::BaseForm
+    delegate :temp_use_companies_house_details, to: :transient_registration
+
+    validates :temp_use_companies_house_details, "waste_carriers_engine/yes_no": true
+  end
+end

--- a/app/forms/waste_carriers_engine/incorrect_company_form.rb
+++ b/app/forms/waste_carriers_engine/incorrect_company_form.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class IncorrectCompanyForm < ::WasteCarriersEngine::BaseForm
+    include CannotSubmit
+  end
+end

--- a/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
@@ -39,6 +39,8 @@ module WasteCarriersEngine
 
         state :cbd_type_form
         state :registration_number_form
+        state :check_company_form
+        state :incorrect_company_form
 
         state :company_name_form
         state :company_postcode_form
@@ -186,7 +188,15 @@ module WasteCarriersEngine
                       to: :registration_number_form
 
           transitions from: :registration_number_form,
-                      to: :company_name_form
+                      to: :check_company_form
+
+          transitions from: :check_company_form,
+                      to: :incorrect_company_form,
+                      unless: :use_companies_house_details?
+
+          transitions from: :check_company_form,
+                      to: :declare_convictions_form,
+                      if: :use_companies_house_details?
 
           transitions from: :company_name_form,
                       to: :company_address_manual_form,
@@ -414,8 +424,11 @@ module WasteCarriersEngine
                       to: :cbd_type_form,
                       if: :skip_registration_number?
 
-          transitions from: :company_name_form,
+          transitions from: :check_company_form,
                       to: :registration_number_form
+
+          transitions from: :incorrect_company_form,
+                      to: :check_company_form
 
           transitions from: :other_businesses_form,
                       to: :check_your_tier_form
@@ -475,6 +488,10 @@ module WasteCarriersEngine
                       to: :company_address_form
 
           # End registered address
+
+          transitions from: :declare_convictions_form,
+                      to: :check_company_form,
+                      if: :use_companies_house_details?
 
           transitions from: :declare_convictions_form,
                       to: :main_people_form
@@ -665,6 +682,10 @@ module WasteCarriersEngine
 
       def set_contact_address_as_registered_address
         WasteCarriersEngine::ContactAddressAsRegisteredAddressService.run(self)
+      end
+
+      def use_companies_house_details?
+        temp_use_companies_house_details == "yes"
       end
     end
     # rubocop:enable Metrics/BlockLength

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -23,6 +23,7 @@ module WasteCarriersEngine
     field :temp_payment_method, type: String
     field :temp_tier_check, type: String # 'yes' or 'no' - should refactor to boolean
     field :temp_reuse_registered_address, type: String
+    field :temp_use_companies_house_details, type: String
 
     scope :in_progress, -> { where(:workflow_state.nin => RenewingRegistration::SUBMITTED_STATES) }
     scope :submitted, -> { where(:workflow_state.in => RenewingRegistration::SUBMITTED_STATES) }

--- a/app/views/waste_carriers_engine/check_company_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/check_company_forms/new.html.erb
@@ -1,0 +1,36 @@
+<%= render("waste_carriers_engine/shared/back", back_path: back_check_company_forms_path(@check_company_form.token)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <%= t(".heading") %>
+    </h1>
+    <legend class="govuk-visually-hidden">
+      <%= t(".heading") %>
+    </legend>
+
+    <%= form_for(@check_company_form) do |f| %>
+      <%= render partial: "waste_carriers_engine/shared/error_summary", locals: { f: f } %>
+
+        <%= f.govuk_collection_radio_buttons :temp_use_companies_house_details,
+            [
+              OpenStruct.new(id: :yes, name: t(".options.yes")),
+              OpenStruct.new(id: :no, name: t(".options.no"))
+            ],
+            :id,
+            :name,
+            inline: true,
+            legend: -> do %>
+
+          <h2>Here we will print the company details</h2>
+
+        <% end %>
+
+      <%= f.govuk_submit t(".next_button") %>
+    <% end %>
+
+    <p class="govuk-body">
+      <%= link_to t(".enter_a_different_number"), new_registration_number_form_path %>
+    </p>
+  </div>
+</div>

--- a/app/views/waste_carriers_engine/check_company_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/check_company_forms/new.html.erb
@@ -22,8 +22,25 @@
             inline: true,
             legend: -> do %>
 
-          <h2>Here we will print the company details</h2>
 
+          <h2 class="govuk-heading-m">
+            <%= @check_company_form.ch_company_name %>
+          </h3>
+
+          <p class="govuk-body">
+            <%= @check_company_form.ch_registered_office_address_lines.join("<br/>").html_safe %>
+          </p>
+
+          <h3 class="govuk-heading-s">
+            Directors
+          </h3>
+
+          <% @check_company_form.ch_officer_names.each do |ch_officer_name| %>
+            <p class="govuk-body">
+              <span class="govuk-!-font-weight-bold">Name</span>
+              <%= ch_officer_name %>
+            </p>
+          <% end %>
         <% end %>
 
       <%= f.govuk_submit t(".next_button") %>

--- a/app/views/waste_carriers_engine/incorrect_company_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/incorrect_company_forms/new.html.erb
@@ -1,0 +1,22 @@
+<%= render("waste_carriers_engine/shared/back", back_path: back_incorrect_company_forms_path(@incorrect_company_form.token)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <%= t(".heading") %>
+    </h1>
+    <legend class="govuk-visually-hidden">
+      <%= t(".heading") %>
+    </legend>
+
+    <p class="govuk-body">
+      <%= t(".body") %>
+    </p>
+
+    <%= link_to t(".continue_button"), main_app.root_path, class: "govuk-button" %>
+
+    <p class="govuk-body">
+      <%= link_to t(".enter_a_different_number"), new_registration_number_form_path %>
+    </p>
+  </div>
+</div>

--- a/config/locales/forms/check_company_forms/en.yml
+++ b/config/locales/forms/check_company_forms/en.yml
@@ -1,0 +1,18 @@
+en:
+  waste_carriers_engine:
+    check_company_forms:
+      new:
+        heading: "Is this information correct as we will use it to complete your registration?"
+        options:
+          "no": "No"
+          "yes": "Yes"
+        next_button: "Continue"
+        enter_a_different_number: "Enter a different number"
+  activemodel:
+    errors:
+      models:
+        waste_carriers_engine/check_company_form:
+          attributes:
+            temp_use_companies_house_address:
+              inclusion: "You must select yes or no"
+

--- a/config/locales/forms/incorrect_company_forms/en.yml
+++ b/config/locales/forms/incorrect_company_forms/en.yml
@@ -1,0 +1,8 @@
+en:
+  waste_carriers_engine:
+    incorrect_company_forms:
+      new:
+        heading: "My companies house information is incorrect"
+        body: "If your Companies House information is incorrect you must update it before you can register as a waste carrier."
+        continue_button: "Continue"
+        enter_a_different_number: "Enter a different number"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -346,6 +346,26 @@ WasteCarriersEngine::Engine.routes.draw do
                     on: :collection
               end
 
+    resources :check_company_forms,
+              only: %i[new create],
+              path: "check-company",
+              path_names: { new: "" } do
+                get "back",
+                    to: "check_company_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+
+    resources :incorrect_company_forms,
+              only: :new,
+              path: "incorrect-company",
+              path_names: { new: "" } do
+                get "back",
+                    to: "incorrect_company_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+
     resources :company_name_forms,
               only: %i[new create],
               path: "company-name",

--- a/lib/defra_ruby_companies_house.rb
+++ b/lib/defra_ruby_companies_house.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rest-client"
+
+class DefraRubyCompaniesHouse
+  def initialize(company_no)
+    @company_no = company_no
+    @company_url = "#{DefraRuby::Validators.configuration.companies_house_host}#{@company_no}"
+    @api_key = DefraRuby::Validators.configuration.companies_house_api_key
+  end
+
+  def company
+    JSON.parse(
+      RestClient::Request.execute(
+        method: :get,
+        url: @company_url,
+        user: @api_key,
+        password: ""
+      )
+    ).deep_symbolize_keys
+  rescue RestClient::ResourceNotFound
+    :not_found
+  end
+
+  def active_officers
+    officers.select do |officer|
+      officer[:resigned_on].blank? && %w[director llp-designated-member].include?(officer[:officer_role])
+    end
+  end
+
+  def officers
+    @_officers ||=
+      JSON.parse(
+        RestClient::Request.execute(
+          method: :get,
+          url: "#{@company_url}/officers",
+          user: @api_key,
+          password: ""
+        )
+      ).deep_symbolize_keys[:items]
+  rescue RestClient::ResourceNotFound
+    :not_found
+  end
+end

--- a/spec/factories/forms/check_company_form.rb
+++ b/spec/factories/forms/check_company_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :check_company_form, class: WasteCarriersEngine::CheckCompanyForm do
+    trait :has_required_data do
+      initialize_with { new(create(:renewing_registration, :has_required_data, workflow_state: "check_company_form")) }
+    end
+  end
+end

--- a/spec/factories/forms/incorrect_company_form.rb
+++ b/spec/factories/forms/incorrect_company_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :incorrect_company_form, class: WasteCarriersEngine::IncorrectCompanyForm do
+    trait :has_required_data do
+      initialize_with { new(create(:renewing_registration, :has_required_data, workflow_state: "incorrect_company_form")) }
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/company_name_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/company_name_form_spec.rb
@@ -36,12 +36,6 @@ module WasteCarriersEngine
 
             include_examples "has back transition", previous_state: "your_tier_form"
           end
-
-          context "When the registration requires a company number" do
-            subject { build(:new_registration, workflow_state: "company_name_form", business_type: "limitedCompany") }
-
-            include_examples "has back transition", previous_state: "registration_number_form"
-          end
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/registration_number_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/registration_number_form_spec.rb
@@ -9,7 +9,7 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":registration_number_form state transitions" do
         context "on next" do
-          include_examples "has next transition", next_state: "company_name_form"
+          include_examples "has next transition", next_state: "check_company_form"
         end
 
         context "on back" do

--- a/spec/requests/waste_carriers_engine/check_company_form_spec.rb
+++ b/spec/requests/waste_carriers_engine/check_company_form_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "CheckCompanyForms", type: :request do
+    include_examples "GET flexible form", "check_company_form"
+
+    let(:user) { create(:user) }
+
+    before(:each) do
+      sign_in(user)
+    end
+
+    describe "POST check_company_form_path" do
+      context "When the transient_registration is a new registration" do
+        let(:transient_registration) do
+          create(:new_registration, workflow_state: "check_company_form")
+        end
+
+        include_examples "POST form",
+                         "check_company_form",
+                         valid_params: { temp_use_companies_house_details: "yes" },
+                         invalid_params: { temp_use_companies_house_details: "" }
+
+        context "when the companies house details will be used" do
+          it "redirects to declare_convictions form" do
+            post_form_with_params(
+              :check_company_form,
+              transient_registration.token,
+              { temp_use_companies_house_details: "yes" }
+            )
+
+            expect(response).to have_http_status(302)
+
+            expect(response).to redirect_to(
+              new_declare_convictions_form_path(transient_registration.token)
+            )
+          end
+        end
+
+        context "when the companies house details are not correct" do
+          it "redirects to incorrect_company form" do
+            post_form_with_params(
+              :check_company_form,
+              transient_registration.token,
+              { temp_use_companies_house_details: "no" }
+            )
+
+            expect(response).to have_http_status(302)
+
+            expect(response).to redirect_to(
+              new_incorrect_company_form_path(transient_registration.token)
+            )
+          end
+        end
+
+        it "has a link to enter a different number" do
+          get new_check_company_form_path(transient_registration.token)
+
+          expect(response.body).to match(
+            %r{href="/#{transient_registration.token}/registration-number">Enter a different number}
+          )
+        end
+      end
+    end
+
+    describe "GET back_check_company_form_path" do
+      context "when a valid user is signed in" do
+        context "when a valid transient registration exists" do
+          let(:transient_registration) do
+            create(:new_registration,
+                   :has_required_data,
+                   account_email: user.email,
+                   workflow_state: "check_company_form")
+          end
+
+          context "when the back action is triggered" do
+            it "returns a 302 response and redirects to the company_number form" do
+              get back_contact_address_reuse_forms_path(transient_registration.token)
+
+              expect(response).to have_http_status(302)
+              expect(response).to redirect_to(new_check_company_form_path(transient_registration.token))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/waste_carriers_engine/incorrect_company_form_spec.rb
+++ b/spec/requests/waste_carriers_engine/incorrect_company_form_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "IncorrectCompanyForms", type: :request do
+    include_examples "GET flexible form", "incorrect_company_form"
+
+    let(:transient_registration) do
+      create(:new_registration, workflow_state: "incorrect_company_form")
+    end
+
+    it "has the expected links to continue" do
+      get new_incorrect_company_form_path(transient_registration.token)
+
+      expect(response.body).to match(%r{href="/">Continue})
+
+      expect(response.body).to match(
+        %r{href="/#{transient_registration.token}/registration-number">Enter a different number}
+      )
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1732

Here we introduce a new workflow that uses Companies House data to populate company/details.

- Applies to a Limited company / LLP and an UPPER tier registration,
- For a lower tier registration, we do not currently ask a user for their company number, so this new workflow does not apply.
 