### PR TITLE
Page title matches H1 #1723

### DIFF
--- a/config/locales/forms/business_type_forms/en.yml
+++ b/config/locales/forms/business_type_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     business_type_forms:
       new:
-        title: Business type
+        title: What type of business or organisation are you?
         heading: What type of business or organisation are you?
         options:
           individual: Individual or sole trader

--- a/config/locales/forms/cannot_renew_company_no_change_forms/en.yml
+++ b/config/locales/forms/cannot_renew_company_no_change_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     cannot_renew_company_no_change_forms:
       new:
-        title: Your Companies House number has changed
+        title: You cannot renew %{reg_identifier}
         heading: You cannot renew %{reg_identifier}
         paragraph_1: Your Companies House registration number has changed, which means the organisation responsible for this registration has changed.
         paragraph_2: Because of this change, you cannot renew %{reg_identifier} and instead must make a new registration.

--- a/config/locales/forms/cannot_renew_type_change_forms/en.yml
+++ b/config/locales/forms/cannot_renew_type_change_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     cannot_renew_type_change_forms:
       new:
-        title: Your business type has changed
+        title: You need a new registration
         heading: You need a new registration
         paragraph: You’ve told us your business type has changed, so you will need to create a new registration rather than renew.
         next_button: Start a new registration

--- a/config/locales/forms/cbd_type_forms/en.yml
+++ b/config/locales/forms/cbd_type_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     cbd_type_forms:
       new:
-        title: Registration type
+        title: Do you carry the waste?
         heading: Do you carry the waste?
         options:
           carrier_dealer: We carry the waste (carrier and dealer)

--- a/config/locales/forms/cease_or_revoke_forms/en.yml
+++ b/config/locales/forms/cease_or_revoke_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     cease_or_revoke_forms:
       new:
-        title: "Revoke or cease"
+        title: "Revoke or cease registration %{reg_identifier}"
         heading: "Revoke or cease registration %{reg_identifier}"
         reason:
           label: "Reason"

--- a/config/locales/forms/ceased_or_revoked_confirm_forms/en.yml
+++ b/config/locales/forms/ceased_or_revoked_confirm_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     ceased_or_revoked_confirm_forms:
       new:
-        title: "Confirm cease or revoke"
+        title: "Confirm %{revoke_or_cease} for registration %{reg_identifier}"
         heading: "Confirm %{revoke_or_cease} for registration %{reg_identifier}"
         revoke_or_cease:
           revoked: "revoke"

--- a/config/locales/forms/check_your_tier_forms/en.yml
+++ b/config/locales/forms/check_your_tier_forms/en.yml
@@ -3,7 +3,7 @@ en:
     check_your_tier_forms:
       new:
         paragraph: "If you are not sure, you can check by answering a few questions about your business activities."
-        title: Check your tier
+        title: What kind of registration do you need?
         heading: What kind of registration do you need?
         options:
           unknown: "Help me decide"

--- a/config/locales/forms/confirm_bank_transfer_forms/en.yml
+++ b/config/locales/forms/confirm_bank_transfer_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     confirm_bank_transfer_forms:
       new:
-        title: Pay by bank transfer
+        title: Registration takes longer if you pay by bank transfer
         heading: Registration takes longer if you pay by bank transfer
         paragraphs:
           instructions: "In order to pay by bank transfer, you will need to follow the instructions on the next screen and email us to confirm payment. This will take approximately 5 working days."

--- a/config/locales/forms/construction_demolition_forms/en.yml
+++ b/config/locales/forms/construction_demolition_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     construction_demolition_forms:
       new:
-        title: Building, construction and demolition waste
+        title: Do you ever deal with building, construction or demolition waste?
         heading: Do you ever deal with building, construction or demolition waste?
         options:
           "yes": "Yes"

--- a/config/locales/forms/contact_address_forms/en.yml
+++ b/config/locales/forms/contact_address_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     contact_address_forms:
       new:
-        title: Contact address selection
+        title: Select the contact address
         heading: Select the contact address
         postcode_label: Postcode
         postcode_change_link: "Change postcode"

--- a/config/locales/forms/contact_address_manual_forms/en.yml
+++ b/config/locales/forms/contact_address_manual_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     contact_address_manual_forms:
       new:
-        title: Contact address
+        title: What's the contact address?
         heading: What's the contact address?
         os_places_error_heading: Our address finder is not working
         os_places_error_text: Please enter the address below.

--- a/config/locales/forms/contact_address_reuse_forms/en.yml
+++ b/config/locales/forms/contact_address_reuse_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     contact_address_reuse_forms:
       new:
-        title: Contact address selection
+        title: Do you want to use this address as a contact address?
         heading: Do you want to use this address as a contact address?
         options:
           "yes": "Yes"

--- a/config/locales/forms/contact_email_forms/en.yml
+++ b/config/locales/forms/contact_email_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     contact_email_forms:
       new:
-        title: Contact email address
+        title: What’s the contact email address?
         heading: What’s the contact email address?
         paragraph_1: We will contact you on this email address when your registration is due to be renewed.
         paragraph_2: If we cannot reach you, you’ll have to pay more for a new registration.

--- a/config/locales/forms/contact_name_forms/en.yml
+++ b/config/locales/forms/contact_name_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     contact_name_forms:
       new:
-        title: Person to contact
+        title: Who should we contact about this registration?
         heading: Who should we contact about this registration?
         description: Tell us who to contact if we need to confirm any details.
         first_name_label: First name

--- a/config/locales/forms/contact_phone_forms/en.yml
+++ b/config/locales/forms/contact_phone_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     contact_phone_forms:
       new:
-        title: Contact telephone number
+        title: What’s the contact telephone number?
         heading: What’s the contact telephone number?
         phone_number_label: Enter a telephone number
         phone_number_hint: This can be a landline or mobile

--- a/config/locales/forms/contact_postcode_forms/en.yml
+++ b/config/locales/forms/contact_postcode_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     contact_postcode_forms:
       new:
-        title: Contact address postcode
+        title: Find the contact address
         heading: Find the contact address
         detail_paragraph: We’ll only write to you if we cannot reach you via email.
         temp_contact_postcode_label: Please enter a UK postcode

--- a/config/locales/forms/conviction_details_forms/en.yml
+++ b/config/locales/forms/conviction_details_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     conviction_details_forms:
       new:
-        title: Conviction details
+        title: Details of the person with a conviction
         list_of_people: You have added the following people
         delete_person_link: Delete
       form:

--- a/config/locales/forms/copy_cards_bank_transfer_forms/en.yml
+++ b/config/locales/forms/copy_cards_bank_transfer_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     copy_cards_bank_transfer_forms:
       new:
-        title: "Registration cards bank transfer details"
+        title: "Details for bank transfer"
         next_button: Continue
         heading: "Details for bank transfer"
         subheading_panel: "Make sure the customer includes their CBDU number as the payment reference, or we won’t be able to match the payment."

--- a/config/locales/forms/copy_cards_forms/en.yml
+++ b/config/locales/forms/copy_cards_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     copy_cards_forms:
       new:
-        title: "Order registration cards"
+        title: "Order registration cards for %{reg_identifier}"
         heading: "Order registration cards for %{reg_identifier}"
         temp_cards_label: "Number of cards at £5 each"
         next_button: "Continue"

--- a/config/locales/forms/copy_cards_order_completed_forms/en.yml
+++ b/config/locales/forms/copy_cards_order_completed_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     copy_cards_order_completed_forms:
       new:
-        title: "Confirm order of registration cards"
+        title: "Confirmation of order"
         heading: "Confirmation of order"
         awaiting_payment_message:
           "true_html": "Order is awaiting payment."

--- a/config/locales/forms/copy_cards_payment_forms/en.yml
+++ b/config/locales/forms/copy_cards_payment_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     copy_cards_payment_forms:
       new:
-        title: "Registration cards payment summary"
+        title: "Payment summary"
         heading: "Payment summary"
         total_cost:
           one: "1 registration card total cost"

--- a/config/locales/forms/declare_convictions_forms/en.yml
+++ b/config/locales/forms/declare_convictions_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     declare_convictions_forms:
       new:
-        title: Convictions
+        title: Do any of the following have an unspent conviction for a relevant offence?
         heading: Do any of the following have an unspent conviction for a relevant offence?
         partnership_relevant_list:
           - "The individual partners in the partnership"

--- a/config/locales/forms/edit_forms/en.yml
+++ b/config/locales/forms/edit_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     edit_forms:
       new:
-        title: Edit a registration
+        title: Edit %{reg_identifier} registration
         heading: Edit %{reg_identifier} registration
         edit_meta:
           created_at: "This edit was started at %{created_at}."

--- a/config/locales/forms/edit_payment_summary_forms/en.yml
+++ b/config/locales/forms/edit_payment_summary_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     edit_payment_summary_forms:
       new:
-        title: "Edit payment summary"
+        title: "Payment summary"
         heading: "Payment summary"
         payment_method:
           subheading: "Payment method"

--- a/config/locales/forms/location_forms/en.yml
+++ b/config/locales/forms/location_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     location_forms:
       new:
-        title: Business location
+        title: Where is your principal place of business?
         heading: Where is your principal place of business?
         location_detail_subheading: What is the principal place of business?
         location_detail_paragraph: "For companies and LLPs this is where your business is registered. For others, this is where the day-to-day business is run."

--- a/config/locales/forms/location_forms/en.yml
+++ b/config/locales/forms/location_forms/en.yml
@@ -24,3 +24,4 @@ en:
               invalid_format: "The registration ID is not in a valid format"
               no_registration: "There is no registration matching this ID"
               renewal_in_progress: "This renewal is already in progress"
+

--- a/config/locales/forms/other_businesses_forms/en.yml
+++ b/config/locales/forms/other_businesses_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     other_businesses_forms:
       new:
-        title: Waste from other people
+        title: Do you ever deal with waste from other businesses or households?
         heading: Do you ever deal with waste from other businesses or households?
         options:
           "yes": "Yes"

--- a/config/locales/forms/renew_registration_forms/en.yml
+++ b/config/locales/forms/renew_registration_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     renew_registration_forms:
       new:
-        title: Renew your registration
+        title: What's your waste carrier registration number?
         heading: What's your waste carrier registration number?
         temp_lookup_number_label: Waste carrier registration number
         temp_lookup_number_hint: "Example: CBDU59475"

--- a/config/locales/forms/renewal_received_pending_conviction_forms/en.yml
+++ b/config/locales/forms/renewal_received_pending_conviction_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     renewal_received_pending_conviction_forms:
       new:
-        title: Renewal application received
+        title: Application received
         heading: Application received
         highlight_text: "Your registration number is still"
         paragraph_1: "We have sent a confirmation email to %{email}."

--- a/config/locales/forms/renewal_received_pending_payment_forms/en.yml
+++ b/config/locales/forms/renewal_received_pending_payment_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     renewal_received_pending_payment_forms:
       new:
-        title: Renewal application received
+        title: Application received
         heading: Application received
         highlight_text: "Your registration number is still"
         panel_text: "We cannot register you until your payment clears."

--- a/config/locales/forms/renewal_received_pending_worldpay_payment_forms/en.yml
+++ b/config/locales/forms/renewal_received_pending_worldpay_payment_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     renewal_received_pending_worldpay_payment_forms:
       new:
-        title: Renewal application received
+        title: Application received
         heading: Application received
         highlight_text: "Your registration number is still"
         subheading: "Processing your payment"

--- a/config/locales/forms/renewal_start_forms/en.yml
+++ b/config/locales/forms/renewal_start_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     renewal_start_forms:
       new:
-        title: You are about to renew your registration
+        title: You are about to renew registration %{reg_identifier}
         heading: You are about to renew registration %{reg_identifier}
         paragraph_1_html: "Renewing will extend this <span class=\"strong\">upper tier registration</span> to %{date}. Renewal costs £%{renewal_charge}."
         paragraph_2_html: "If your <span class=\"strong\">carrier type</span> changes, for example from carrier-dealer to broker-dealer, you can continue to renew but must pay an additional £%{type_change_charge} charge."

--- a/config/locales/forms/service_provided_forms/en.yml
+++ b/config/locales/forms/service_provided_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     service_provided_forms:
       new:
-        title: Who creates the waste?
+        title: Who creates the waste that you deal with?
         heading: Who creates the waste that you deal with?
         error_heading: Something is wrong
         options:

--- a/config/locales/forms/start_forms/en.yml
+++ b/config/locales/forms/start_forms/en.yml
@@ -2,7 +2,7 @@ en:
   waste_carriers_engine:
     start_forms:
       new:
-        title: Registration start
+        title: Is this a new registration?
         heading: Is this a new registration?
         options:
           new: "Yes"


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/RUBY/boards/374?selectedIssue=RUBY-1723

Here we have changed the titles tags to match the page H1 tags to make the text more accessible for those using a screen reader. 

The only exception is on config/locals/forms/waste_types_forms/en.yml where the header doesn't provide enough context for the user so the page title has been kept in place instead. 