### PR TITLE
Validate registration number against Companies House records

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       defra_ruby_address
       defra_ruby_alert (~> 2.1)
       defra_ruby_email
-      defra_ruby_validators
+      defra_ruby_validators (>= 2.4.1)
       high_voltage (~> 3.0)
       jbuilder (~> 2.0)
       jquery-rails

--- a/app/forms/waste_carriers_engine/registration_number_form.rb
+++ b/app/forms/waste_carriers_engine/registration_number_form.rb
@@ -5,7 +5,15 @@ module WasteCarriersEngine
     delegate :company_no, :business_type, to: :transient_registration
 
     validates :company_no, "defra_ruby/validators/companies_house_number": {
-      messages: custom_error_messages(:company_no, :inactive)
+      messages: custom_error_messages(:company_no, :inactive),
+      company_type: "llp",
+      if: -> { business_type == "limitedLiabilityPartnership" }
+    }
+
+    validates :company_no, "defra_ruby/validators/companies_house_number": {
+      messages: custom_error_messages(:company_no, :inactive),
+      company_type: "ltd",
+      if: -> { business_type == "limitedCompany" }
     }
 
     def submit(params)

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/registration_number_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/registration_number_form_spec.rb
@@ -4,13 +4,13 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe RenewingRegistration, type: :model do
-    subject do
-      build(:renewing_registration,
-            :has_required_data,
-            workflow_state: "registration_number_form")
-    end
-
     describe "#workflow_state" do
+      subject do
+        build(:renewing_registration,
+              :has_required_data,
+              workflow_state: "registration_number_form")
+      end
+
       context ":registration_number_form state transitions" do
         context "on next" do
           include_examples "has next transition", next_state: "company_name_form"
@@ -41,6 +41,58 @@ module WasteCarriersEngine
 
         context "on back" do
           include_examples "has back transition", previous_state: "renewal_information_form"
+        end
+      end
+    end
+
+    describe "validating the company_no" do
+      let(:validator) { double(:validator, :validate_each) }
+      let!(:registration_number_form) { build(:registration_number_form, :has_required_data) }
+
+      before do
+        allow(registration_number_form)
+          .to receive(:business_type)
+          .and_return(business_type)
+      end
+
+      context "when the registration is for a limitedLiabilityPartnership" do
+        let(:business_type) { "limitedLiabilityPartnership" }
+
+        before do
+          expect_any_instance_of(DefraRuby::Validators::CompaniesHouseNumberValidator)
+            .to receive(:validate_each)
+            .with(registration_number_form, :company_no, registration_number_form.company_no)
+        end
+
+        it "invokes the validator" do
+          registration_number_form.valid?
+        end
+      end
+
+      context "when the registration is for a limitedCompany" do
+        let(:business_type) { "limitedCompany" }
+
+        before do
+          expect_any_instance_of(DefraRuby::Validators::CompaniesHouseNumberValidator)
+            .to receive(:validate_each)
+            .with(registration_number_form, :company_no, registration_number_form.company_no)
+        end
+
+        it "invokes the validator" do
+          registration_number_form.valid?
+        end
+      end
+
+      context "when the registration is for somethingElse" do
+        let(:business_type) { "somethingElse" }
+
+        before do
+          expect_any_instance_of(DefraRuby::Validators::CompaniesHouseNumberValidator)
+            .not_to receive(:validate_each)
+        end
+
+        it "does not invoke the validator" do
+          registration_number_form.valid?
         end
       end
     end

--- a/waste_carriers_engine.gemspec
+++ b/waste_carriers_engine.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_dependency "high_voltage", "~> 3.0"
 
   # Validations
-  s.add_dependency "defra_ruby_validators"
+  s.add_dependency "defra_ruby_validators", ">= 2.4.1"
   s.add_dependency "uk_postcode"
 
   # defra_ruby_alert is a gem we created to manage airbrake across projects


### PR DESCRIPTION
Here we implement validation by business_type. For a LLP or LTD, the company_no is checked with the companies house validator.

Includes a bump to [defra-ruby-validators](https://github.com/DEFRA/defra-ruby-validators) to a version that supports this new validation by business_type.

https://eaflood.atlassian.net/browse/RUBY-1743