### PR TITLE
'Error' showing in company's address and address of director

### DIFF
--- a/app/views/waste_carriers_engine/company_address_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/company_address_forms/new.html.erb
@@ -5,6 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @company_address_form do |form| %>
       <%= form.govuk_error_summary link_base_errors_to: 'uprn' %>
+      <% content_for :error_title, "Error" if form.govuk_error_summary %>
 
 
       <h1 class="govuk-heading-l">

--- a/app/views/waste_carriers_engine/contact_address_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/contact_address_forms/new.html.erb
@@ -4,6 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @contact_address_form do |form| %>
       <%= form.govuk_error_summary link_base_errors_to: 'uprn' %>
+      <% content_for :error_title, "Error" if form.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">
         <%= t(".heading") %>


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/RUBY/boards/374?selectedIssue=RUBY-1726

A fix for the feature of 'Error' appearing in the titles of pages that have generate it. 
Company's address and the directors address now include this feature. 