### PR TITLE
Feature/order items log

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ end
 group :test do
   gem "database_cleaner-mongoid"
   gem "factory_bot_rails", require: false
+  gem "faker"
   gem "govuk_design_system_formbuilder"
   gem "rails-controller-testing"
   gem "rspec-html-matchers"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,8 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faker (2.19.0)
+      i18n (>= 1.6, < 2)
     faraday (1.7.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -444,6 +446,7 @@ DEPENDENCIES
   devise (>= 4.4.3)
   dotenv-rails
   factory_bot_rails
+  faker
   github_changelog_generator
   govuk_design_system_formbuilder
   jquery-rails

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The engine is mounted in [waste-carriers-front-office](https://github.com/DEFRA/
 Make sure you already have:
 
 - Git
-- Ruby 2.7.1
+- Ruby 2.7.5
 - [Bundler](http://bundler.io/) – for installing Ruby gems
 - MongoDb 3.6
 

--- a/app/models/waste_carriers_engine/order_item_log.rb
+++ b/app/models/waste_carriers_engine/order_item_log.rb
@@ -13,6 +13,7 @@ module WasteCarriersEngine
     field :activated_at,    type: DateTime
     field :type,            type: String
     field :quantity,        type: Integer
+    field :exported,        type: Boolean, default: false
 
     def self.create_from_registration(registration)
       registration.finance_details.orders.each do |order|

--- a/app/models/waste_carriers_engine/order_item_log.rb
+++ b/app/models/waste_carriers_engine/order_item_log.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# This collection duplicates order item details in a simple flat structure
+# to facilitate queries for reports and exports. The source data structure
+# has multiple embedded layers which leads to complex / brittle query logic.
+module WasteCarriersEngine
+  class OrderItemLog
+    include Mongoid::Document
+
+    field :registration_id, type: BSON::ObjectId
+    field :order_id,        type: BSON::ObjectId
+    field :order_item_id,   type: BSON::ObjectId
+    field :activated_at,    type: DateTime
+    field :type,            type: String
+
+    # A single OrderItem can generate multiple OrderItemLogs.
+    def self.create_from(order_item)
+      order_item.quantity.times do
+        create!(order_item)
+      end
+    end
+
+    private
+
+    def initialize(order_item)
+      super()
+      order = order_item.order
+      registration = order.finance_details.registration
+
+      self.order_item_id   = order_item.id
+      self.type            = order_item.type
+      self.order_id        = order.id
+      self.registration_id = registration.id
+      self.activated_at    = registration.metaData.dateActivated
+    end
+
+  end
+end

--- a/app/services/waste_carriers_engine/registration_activation_service.rb
+++ b/app/services/waste_carriers_engine/registration_activation_service.rb
@@ -19,7 +19,7 @@ module WasteCarriersEngine
     def activate_registration
       @registration.metaData.date_activated = Time.current
       @registration.metaData.activate!
-      create_order_item_logs
+      OrderItemLog.create_from_registration(@registration)
     end
 
     def can_be_completed?
@@ -40,14 +40,6 @@ module WasteCarriersEngine
 
     def send_registration_confirmation
       RegistrationConfirmationService.run(registration: @registration)
-    end
-
-    def create_order_item_logs
-      @registration.finance_details.orders.each do |order|
-        order.order_items.each do |order_item|
-          OrderItemLog.create_from(order_item)
-        end
-      end
     end
 
   end

--- a/app/services/waste_carriers_engine/registration_activation_service.rb
+++ b/app/services/waste_carriers_engine/registration_activation_service.rb
@@ -19,6 +19,7 @@ module WasteCarriersEngine
     def activate_registration
       @registration.metaData.date_activated = Time.current
       @registration.metaData.activate!
+      create_order_item_logs
     end
 
     def can_be_completed?
@@ -40,5 +41,14 @@ module WasteCarriersEngine
     def send_registration_confirmation
       RegistrationConfirmationService.run(registration: @registration)
     end
+
+    def create_order_item_logs
+      @registration.finance_details.orders.each do |order|
+        order.order_items.each do |order_item|
+          OrderItemLog.create_from(order_item)
+        end
+      end
+    end
+
   end
 end

--- a/app/services/waste_carriers_engine/renewal_completion_service.rb
+++ b/app/services/waste_carriers_engine/renewal_completion_service.rb
@@ -38,6 +38,7 @@ module WasteCarriersEngine
           copy_names_to_contact_address
           create_past_registration
           update_registration
+          create_order_item_logs
           delete_transient_registration
           send_confirmation_email
         end
@@ -93,6 +94,10 @@ module WasteCarriersEngine
     def extend_expiry_date
       expiry_check_service = ExpiryCheckService.new(registration)
       registration.expires_on = expiry_check_service.expiry_date_after_renewal
+    end
+
+    def create_order_item_logs
+      OrderItemLog.create_from_registration(transient_registration)
     end
 
     def delete_transient_registration

--- a/spec/models/waste_carriers_engine/order_item_log_spec.rb
+++ b/spec/models/waste_carriers_engine/order_item_log_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe OrderItemLog, type: :model do
+    describe "initialize" do
+      let(:registration) { build(:registration, :has_required_data, :has_copy_cards_order) }
+      let(:order) { registration.finance_details.orders[0] }
+      let(:registration_order_item) { order.order_items[0] }
+
+      subject { described_class.create!(registration_order_item) }
+
+      it "persists the order item log" do
+        expect { subject }.to change { OrderItemLog.count }.from(0).to(1)
+      end
+
+      it "saves the registration id" do
+        expect(subject.registration_id).to eq registration.id
+      end
+
+      it "saves the registration activation date" do
+        expect(subject.activated_at).to eq registration.metaData.dateActivated
+      end
+
+      it "saves the order id" do
+        expect(subject.order_id).to eq order.id
+      end
+
+      it "copies the OrderItem attributes" do
+        expect(subject.order_item_id).to eq registration_order_item.id
+        expect(subject.type).to eq registration_order_item.type
+      end
+
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/order_item_log_spec.rb
+++ b/spec/models/waste_carriers_engine/order_item_log_spec.rb
@@ -4,34 +4,76 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe OrderItemLog, type: :model do
-    describe "initialize" do
+    describe "#initialize" do
+
+      context "for a new registration" do
+        let(:registration) { build(:registration, :has_required_data, :has_copy_cards_order) }
+        let(:order) { registration.finance_details.orders[0] }
+        let(:registration_order_item) { order.order_items[0] }
+
+        subject { described_class.create_from_order_item(registration_order_item) }
+
+        it "persists the order item log" do
+          expect { subject }.to change { OrderItemLog.count }.from(0).to(1)
+        end
+
+        it "saves the registration id" do
+          expect(subject.registration_id).to eq registration.id
+        end
+
+        it "saves the registration activation date" do
+          expect(subject.activated_at).to eq registration.metaData.dateActivated
+        end
+
+        it "saves the order id" do
+          expect(subject.order_id).to eq order.id
+        end
+
+        it "copies the OrderItem attributes" do
+          expect(subject.order_item_id).to eq registration_order_item.id
+          expect(subject.type).to eq registration_order_item.type
+          expect(subject.quantity).to eq registration_order_item.quantity
+        end
+      end
+    end
+
+    describe ".create_from_registration" do
       let(:registration) { build(:registration, :has_required_data, :has_copy_cards_order) }
-      let(:order) { registration.finance_details.orders[0] }
-      let(:registration_order_item) { order.order_items[0] }
-
-      subject { described_class.create!(registration_order_item) }
-
-      it "persists the order item log" do
-        expect { subject }.to change { OrderItemLog.count }.from(0).to(1)
+      subject { described_class.create_from_registration(registration) }
+      before do
+        3.times { registration.finance_details.orders << build(:order, :has_copy_cards_item) }
       end
 
-      it "saves the registration id" do
-        expect(subject.registration_id).to eq registration.id
+      context "for a new registration" do
+        it "creates the correct number of order item logs" do
+          expect { subject }.to change { OrderItemLog.count }
+            .from(0)
+            .to(order_item_count(registration))
+        end
       end
 
-      it "saves the registration activation date" do
-        expect(subject.activated_at).to eq registration.metaData.dateActivated
-      end
+      context "for a registration with previously logged order items" do
+        let(:new_order) { build(:order, :has_copy_cards_item) }
 
-      it "saves the order id" do
-        expect(subject.order_id).to eq order.id
-      end
+        before do
+          Timecop.freeze(1.month.ago) do
+            described_class.create_from_registration(registration)
+          end
+        end
 
-      it "copies the OrderItem attributes" do
-        expect(subject.order_item_id).to eq registration_order_item.id
-        expect(subject.type).to eq registration_order_item.type
-      end
+        it "adds only the new order item logs" do
+          previous_count = order_item_count(registration)
+          registration.finance_details.orders << new_order
+          expect { subject }.to change { OrderItemLog.count }
+            .from(previous_count)
+            .to(order_item_count(registration))
+        end
 
+      end
+    end
+
+    def order_item_count(registration)
+      registration.finance_details.orders.sum { |o| o.order_items.length }
     end
   end
 end

--- a/spec/models/waste_carriers_engine/order_item_log_spec.rb
+++ b/spec/models/waste_carriers_engine/order_item_log_spec.rb
@@ -29,6 +29,10 @@ module WasteCarriersEngine
           expect(subject.order_id).to eq order.id
         end
 
+        it "is not exported by default" do
+          expect(subject.exported).to be false
+        end
+
         it "copies the OrderItem attributes" do
           expect(subject.order_item_id).to eq registration_order_item.id
           expect(subject.type).to eq registration_order_item.type

--- a/spec/services/waste_carriers_engine/registration_activation_service_spec.rb
+++ b/spec/services/waste_carriers_engine/registration_activation_service_spec.rb
@@ -33,21 +33,33 @@ module WasteCarriersEngine
         it "activates the registration" do
           expect { service }.to change { registration.active? }.from(false).to(true)
         end
+
+        it "creates one or more order item logs" do
+          expect { service }.to change { OrderItemLog.count }.from(0)
+        end
       end
 
       context "when the balance is unpaid" do
         before { allow(registration).to receive(:unpaid_balance?).and_return(true) }
 
-        it "does not activates the registration" do
+        it "does not activate the registration" do
           expect { service }.to_not change { registration.active? }
+        end
+
+        it "does not create an order item log" do
+          expect { service }.not_to change { OrderItemLog.count }.from(0)
         end
       end
 
       context "when the registration has a pending convictions check" do
         before { allow(registration).to receive(:pending_manual_conviction_check?).and_return(true) }
 
-        it "does not activates the registration" do
+        it "does not activate the registration" do
           expect { service }.to_not change { registration.active? }
+        end
+
+        it "does not create an order item log" do
+          expect { service }.not_to change { OrderItemLog.count }.from(0)
         end
       end
     end

--- a/spec/services/waste_carriers_engine/registration_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/registration_completion_service_spec.rb
@@ -74,7 +74,7 @@ module WasteCarriersEngine
         it "creates the correct number of order item logs" do
           expect { registration }.to change { OrderItemLog.count }
             .from(0)
-            .to(transient_registration.finance_details.orders.sum { |o| o.order_items.sum(&:quantity) })
+            .to(transient_registration.finance_details.orders.sum { |o| o.order_items.length })
         end
 
         context "with multiple orders and multiple order items" do
@@ -99,7 +99,7 @@ module WasteCarriersEngine
           it "creates the correct number of order item logs" do
             expect { registration }.to change { OrderItemLog.count }
               .from(0)
-              .to(transient_registration.finance_details.orders.sum { |o| o.order_items.sum(&:quantity) })
+              .to(transient_registration.finance_details.orders.sum { |o| o.order_items.length })
           end
 
           it "captures the order item types correctly" do
@@ -107,7 +107,7 @@ module WasteCarriersEngine
             registration.finance_details.orders.map do |o|
               o.order_items.each do |oi|
                 order_items_by_type[oi["type"]] ||= 0
-                order_items_by_type[oi["type"]] += oi.quantity
+                order_items_by_type[oi["type"]] += 1
               end
             end
             order_items_by_type.each do |k, _v|

--- a/spec/services/waste_carriers_engine/registration_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/registration_completion_service_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "faker"
 
 module WasteCarriersEngine
   RSpec.describe RegistrationCompletionService do
@@ -57,8 +58,9 @@ module WasteCarriersEngine
         end
       end
 
-      context "when the balance have been cleared and there are no pending convictions checks" do
+      context "when the balance has been cleared and there are no pending convictions checks" do
         let(:finance_details) { build(:finance_details, :has_paid_order_and_payment) }
+        let(:registration) { described_class.run(transient_registration) }
 
         before do
           transient_registration.finance_details = finance_details
@@ -66,9 +68,56 @@ module WasteCarriersEngine
         end
 
         it "activates the registration" do
-          registration = described_class.run(transient_registration)
-
           expect(registration).to be_active
+        end
+
+        it "creates the correct number of order item logs" do
+          expect { registration }.to change { OrderItemLog.count }
+            .from(0)
+            .to(transient_registration.finance_details.orders.sum { |o| o.order_items.sum(&:quantity) })
+        end
+
+        context "with multiple orders and multiple order items" do
+          # Allow for multiple orders per registration, multiple order items per order and a variable quantity per order item
+          before do
+            orders = []
+            order_count = Faker::Number.between(from: 1, to: 3)
+            order_count.times do
+              order = build(:order)
+              order_item_count = Faker::Number.between(from: 1, to: 5)
+              order.order_items = build_list(
+                :order_item,
+                order_item_count,
+                quantity: Faker::Number.between(from: 1, to: 7),
+                type: OrderItem::TYPES.values[rand(OrderItem::TYPES.size)]
+              )
+              orders << order
+            end
+            transient_registration.finance_details.orders = orders
+          end
+
+          it "creates the correct number of order item logs" do
+            expect { registration }.to change { OrderItemLog.count }
+              .from(0)
+              .to(transient_registration.finance_details.orders.sum { |o| o.order_items.sum(&:quantity) })
+          end
+
+          it "captures the order item types correctly" do
+            order_items_by_type = {}
+            registration.finance_details.orders.map do |o|
+              o.order_items.each do |oi|
+                order_items_by_type[oi["type"]] ||= 0
+                order_items_by_type[oi["type"]] += oi.quantity
+              end
+            end
+            order_items_by_type.each do |k, _v|
+              expect(OrderItemLog.where(type: k).count).to eq order_items_by_type[k]
+            end
+          end
+
+          it "stores the registration activation date for all order items" do
+            expect(OrderItemLog.where(activated_at: registration.metaData.dateActivated).count).to eq OrderItemLog.count
+          end
         end
       end
 
@@ -104,6 +153,10 @@ module WasteCarriersEngine
             expect(Airbrake)
               .to receive(:notify)
               .with(the_error, { registration_no: transient_registration.reg_identifier })
+          end
+
+          it "does not create an order item log" do
+            expect { described_class.run(transient_registration) }.not_to change { OrderItemLog.count }.from(0)
           end
 
           it "notifies Airbrake" do
@@ -144,6 +197,10 @@ module WasteCarriersEngine
             expect(Airbrake)
               .to receive(:notify)
               .with(the_error, { registration_no: transient_registration.reg_identifier })
+          end
+
+          it "does not create an order item log" do
+            expect { described_class.run(transient_registration) }.not_to change { OrderItemLog.count }.from(0)
           end
 
           it "notifies Airbrake" do
@@ -195,6 +252,10 @@ module WasteCarriersEngine
                 .with(the_error, { registration_no: transient_registration.reg_identifier })
             end
 
+            it "does not create an order item log" do
+              expect { described_class.run(transient_registration) }.not_to change { OrderItemLog.count }.from(0)
+            end
+
             it "notifies Airbrake" do
               described_class.run(transient_registration)
             end
@@ -213,6 +274,11 @@ module WasteCarriersEngine
             expect(Notify::RegistrationPendingConvictionCheckEmailService).to_not receive(:run)
 
             described_class.run(transient_registration)
+          end
+
+          it "does not create an order item log" do
+            described_class.run(transient_registration)
+            expect(OrderItemLog.count).to be_zero
           end
         end
       end

--- a/spec/services/waste_carriers_engine/renewal_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/renewal_completion_service_spec.rb
@@ -140,6 +140,12 @@ module WasteCarriersEngine
           end
         end
 
+        it "creates the correct number of order item logs" do
+          expect { renewal_completion_service.complete_renewal }.to change { OrderItemLog.count }
+            .from(0)
+            .to(transient_registration.finance_details.orders.sum { |o| o.order_items.length })
+        end
+
         # This only applies to attributes where a value could be set, but not always - for example, smart answers
         context "if the registration has an attribute which is not in the transient_registration" do
           before do


### PR DESCRIPTION
This change adds a reporting table for order items, and populates it when registrations are activated or renewed, and when copy cards are ordered mid-registration.
The new collection will be queried by waste-carriers-back-office to generate order reports.