### PR TITLE
Copy card improvements - stop non card payment ad-hoc card orders

### DIFF
--- a/app/views/waste_carriers_engine/copy_cards_payment_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/copy_cards_payment_forms/new.html.erb
@@ -54,7 +54,10 @@
             </div>
 
             <div class="govuk-radios__item">
-              <%= f.radio_button :temp_payment_method, "bank_transfer", class: "govuk-radios__input" %>
+              <%= f.radio_button :temp_payment_method,
+                  "bank_transfer",
+                  class: "govuk-radios__input",
+                  disabled: WasteCarriersEngine.configuration.host_is_back_office? %>
               <%= f.label :temp_payment_method, value: "bank_transfer", class: "govuk-label govuk-radios__label" do %>
                 <%= t(".options.bank_transfer") %>
                 <span class="govuk-hint"><%= t(".hint_pay_by_bank_transfer") %></span>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1791

Here we disable the 'bank_transfer' payment option for a copy card order
process in the back office.

We don't have a good mechanism for testing the state of page objects
within the engine, but this acceptance test will need fixing:

https://github.com/DEFRA/waste-carriers-acceptance-tests/blob/main/features/bo/dashboard/order_cards.feature#L29