### PR TITLE
Enable `active_registration` for an OrderItemLog

### DIFF
--- a/app/models/waste_carriers_engine/order_item_log.rb
+++ b/app/models/waste_carriers_engine/order_item_log.rb
@@ -16,9 +16,11 @@ module WasteCarriersEngine
     field :quantity,        type: Integer
     field :exported,        type: Boolean, default: false
 
-    # enable the CanCheckRegistrationStatus concern
     belongs_to :registration
-    delegate :metaData, to: :registration
+
+    def active_registration?
+      registration.active?
+    end
 
     def self.create_from_registration(registration, activation_time = nil)
       registration.finance_details.orders.each do |order|

--- a/app/models/waste_carriers_engine/order_item_log.rb
+++ b/app/models/waste_carriers_engine/order_item_log.rb
@@ -6,6 +6,7 @@
 module WasteCarriersEngine
   class OrderItemLog
     include Mongoid::Document
+    include CanCheckRegistrationStatus
 
     field :registration_id, type: BSON::ObjectId
     field :order_id,        type: BSON::ObjectId
@@ -14,6 +15,10 @@ module WasteCarriersEngine
     field :type,            type: String
     field :quantity,        type: Integer
     field :exported,        type: Boolean, default: false
+
+    # enable the CanCheckRegistrationStatus concern
+    belongs_to :registration
+    delegate :metaData, to: :registration
 
     def self.create_from_registration(registration, activation_time = nil)
       registration.finance_details.orders.each do |order|

--- a/app/models/waste_carriers_engine/order_item_log.rb
+++ b/app/models/waste_carriers_engine/order_item_log.rb
@@ -6,7 +6,6 @@
 module WasteCarriersEngine
   class OrderItemLog
     include Mongoid::Document
-    include CanCheckRegistrationStatus
 
     field :registration_id, type: BSON::ObjectId
     field :order_id,        type: BSON::ObjectId

--- a/spec/factories/order_item_log.rb
+++ b/spec/factories/order_item_log.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :order_item_log, class: WasteCarriersEngine::OrderItemLog do
+  end
+end

--- a/spec/models/waste_carriers_engine/order_item_log_spec.rb
+++ b/spec/models/waste_carriers_engine/order_item_log_spec.rb
@@ -83,10 +83,10 @@ module WasteCarriersEngine
       end
     end
 
-    context "#active?" do
+    context "#active_registration?" do
       let(:order_item_log) { build(:order_item_log, registration: registration) }
 
-      subject { order_item_log.active? }
+      subject { order_item_log.active_registration? }
 
       context "with an active registration" do
         let(:registration) { build(:registration, :is_active) }

--- a/spec/models/waste_carriers_engine/order_item_log_spec.rb
+++ b/spec/models/waste_carriers_engine/order_item_log_spec.rb
@@ -7,7 +7,7 @@ module WasteCarriersEngine
     describe "#initialize" do
 
       context "for a new registration" do
-        let(:registration) { build(:registration, :has_required_data, :has_copy_cards_order) }
+        let(:registration) { create(:registration, :has_required_data, :has_copy_cards_order) }
         let(:order) { registration.finance_details.orders[0] }
         let(:registration_order_item) { order.order_items[0] }
 
@@ -42,7 +42,7 @@ module WasteCarriersEngine
     end
 
     describe ".create_from_registration" do
-      let(:registration) { build(:registration, :has_required_data, :has_copy_cards_order) }
+      let(:registration) { create(:registration, :has_required_data, :has_copy_cards_order) }
       subject { described_class.create_from_registration(registration) }
       before do
         3.times { registration.finance_details.orders << build(:order, :has_copy_cards_item) }
@@ -80,6 +80,24 @@ module WasteCarriersEngine
           described_class.create_from_registration(registration, DateTime.now)
           expect(described_class.first.activated_at.to_time).to be_within(1.second).of(Time.now)
         end
+      end
+    end
+
+    context "#active?" do
+      let(:order_item_log) { build(:order_item_log, registration: registration) }
+
+      subject { order_item_log.active? }
+
+      context "with an active registration" do
+        let(:registration) { build(:registration, :is_active) }
+
+        it { expect(subject).to be_truthy }
+      end
+
+      context "with an expired registration" do
+        let(:registration) { build(:registration, :is_expired) }
+
+        it { expect(subject).to be_falsey }
       end
     end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1787

- Before exporting a copy card item, we need to check that the
registration is active

- Here we mixin the `CanCheckRegistrationStatus` concern
and declare that an `OrderItemLog belongs_to Registration`

- And we update the existing specs to ensure that the `Registration`
is persisted before it is assigned to the `OrderItemLog`