### PR TITLE
Refresh registered company name from companies house

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -62,6 +62,7 @@ module WasteCarriersEngine
       field :receipt_email,                                                 type: String
       field :regIdentifier, as: :reg_identifier,                            type: String
       field :registeredCompanyName, as: :registered_company_name,           type: String
+      field :companiesHouseUpdatedAt, as: :companies_house_updated_at,      type: DateTime
       field :registrationType, as: :registration_type,                      type: String
       field :reg_uuid,                                                      type: String # Used by waste-carriers-frontend
       field :uuid,                                                          type: String

--- a/app/presenters/waste_carriers_engine/edit_form_presenter.rb
+++ b/app/presenters/waste_carriers_engine/edit_form_presenter.rb
@@ -37,7 +37,7 @@ module WasteCarriersEngine
     end
 
     def companies_house_updated_at
-      transient_registration.companies_house_updated_at.to_formatted_s(:day_month_year)
+      transient_registration.companies_house_updated_at.try(:to_formatted_s, :day_month_year)
     end
 
     def company_no

--- a/app/presenters/waste_carriers_engine/edit_form_presenter.rb
+++ b/app/presenters/waste_carriers_engine/edit_form_presenter.rb
@@ -32,6 +32,14 @@ module WasteCarriersEngine
       transient_registration.company_name
     end
 
+    def registered_company_name
+      transient_registration.registered_company_name
+    end
+
+    def companies_house_updated_at
+      transient_registration.companies_house_updated_at.to_formatted_s(:day_month_year)
+    end
+
     def company_no
       transient_registration.company_no
     end

--- a/app/services/waste_carriers_engine/refresh_companies_house_name_service.rb
+++ b/app/services/waste_carriers_engine/refresh_companies_house_name_service.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "defra_ruby_companies_house"
+
+module WasteCarriersEngine
+  class RefreshCompaniesHouseNameService < WasteCarriersEngine::BaseService
+    def run(reg_identifier:)
+      registration = Registration.find_by(reg_identifier: reg_identifier)
+  
+      company_name = DefraRubyCompaniesHouse.new(registration.company_no).company_name
+      registration.registered_company_name = company_name
+      registration.companies_house_updated_at = Time.current
+      registration.save!
+  
+      true
+    end
+  end
+end

--- a/app/services/waste_carriers_engine/refresh_companies_house_name_service.rb
+++ b/app/services/waste_carriers_engine/refresh_companies_house_name_service.rb
@@ -6,12 +6,12 @@ module WasteCarriersEngine
   class RefreshCompaniesHouseNameService < WasteCarriersEngine::BaseService
     def run(reg_identifier:)
       registration = Registration.find_by(reg_identifier: reg_identifier)
-  
+
       company_name = DefraRubyCompaniesHouse.new(registration.company_no).company_name
       registration.registered_company_name = company_name
       registration.companies_house_updated_at = Time.current
       registration.save!
-  
+
       true
     end
   end

--- a/app/views/waste_carriers_engine/edit_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/edit_forms/new.html.erb
@@ -118,6 +118,29 @@
                 <%= t(".edit_links.no_edit") %>
               </td>
             </tr>
+            <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">
+              <%= t(".sections.business.labels.registered_company_name") %>
+            </th>
+            <td class="govuk-table__cell">
+              <%= @presenter.registered_company_name %>
+              <% if @presenter.companies_house_updated_at %>
+                <br>
+                <span class="govuk-body-s">
+                  <%= t(".sections.business.labels.registered_company_name_last_updated",
+                        last_updated: @presenter.companies_house_updated_at) %>
+                </span>
+              <% end %>
+            </td>
+            <td class="govuk-table__cell govuk-table__cell--numeric">
+              <%= link_to t(".sections.business.labels.refresh_registered_company_name_html"),
+                            Rails.application.routes.url_helpers
+                                 .registration_companies_house_details_path(@transient_registration.reg_identifier),
+                            method: :patch,
+                            class: "govuk-button" %>
+            </td>
+          </tr>
+
           <% end %>
           <% if @presenter.main_people_with_roles.any? %>
             <tr class="govuk-table__row">

--- a/app/views/waste_carriers_engine/edit_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/edit_forms/new.html.erb
@@ -119,29 +119,25 @@
               </td>
             </tr>
             <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header">
-              <%= t(".sections.business.labels.registered_company_name") %>
-            </th>
-            <td class="govuk-table__cell">
-              <%= @presenter.registered_company_name %>
-              <% if @presenter.companies_house_updated_at %>
-                <br>
-                <span class="govuk-body-s">
-                  <%= t(".sections.business.labels.registered_company_name_last_updated",
-                        last_updated: @presenter.companies_house_updated_at) %>
-                </span>
-              <% end %>
-            </td>
-            <td class="govuk-table__cell govuk-table__cell--numeric">
-              <%= link_to t(".sections.business.labels.refresh_registered_company_name_html"),
-                            Rails.application.routes.url_helpers
-                                 .registration_companies_house_details_path(@transient_registration.reg_identifier),
-                            method: :patch,
-                            class: "govuk-button" %>
-            </td>
-          </tr>
-
+              <th scope="row" class="govuk-table__header">
+                <%= t(".sections.business.labels.registered_company_name") %>
+              </th>
+              <td class="govuk-table__cell">
+                <%= @presenter.registered_company_name %>
+                <% if @presenter.companies_house_updated_at %>
+                  <br>
+                  <span class="govuk-body-s">
+                    <%= t(".sections.business.labels.registered_company_name_last_updated",
+                          last_updated: @presenter.companies_house_updated_at) %>
+                  </span>
+                <% end %>
+              </td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+               <%= t(".edit_links.no_edit") %>
+              </td>
+            </tr>
           <% end %>
+
           <% if @presenter.main_people_with_roles.any? %>
             <tr class="govuk-table__row">
               <th scope="row" class="govuk-table__header">

--- a/config/locales/forms/edit_forms/en.yml
+++ b/config/locales/forms/edit_forms/en.yml
@@ -19,8 +19,11 @@ en:
             heading: Waste carrier business details
             labels:
               business_type: Type
-              company_name: Trading name
+              company_name: Business name
               company_no: Company number
+              registered_company_name: Registered company name
+              registered_company_name_last_updated: (refreshed on %{last_updated})
+              refresh_registered_company_name_html: Update&nbsp;from<br>com. house
               main_people: Main people
               registered_address: Address
           contact:

--- a/spec/services/waste_carriers_engine/refresh_companies_house_name_service_spec.rb
+++ b/spec/services/waste_carriers_engine/refresh_companies_house_name_service_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 require "defra_ruby_companies_house"
 
 RSpec.describe WasteCarriersEngine::RefreshCompaniesHouseNameService do
-  
+
   let(:new_registered_name) { Faker::Company.name }
   let(:registration) { create(:registration, :has_required_data, registered_company_name: old_registered_name) }
   let(:reg_identifier) { registration.reg_identifier }

--- a/spec/services/waste_carriers_engine/refresh_companies_house_name_service_spec.rb
+++ b/spec/services/waste_carriers_engine/refresh_companies_house_name_service_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "defra_ruby_companies_house"
+
+RSpec.describe WasteCarriersEngine::RefreshCompaniesHouseNameService do
+  
+  let(:new_registered_name) { Faker::Company.name }
+  let(:registration) { create(:registration, :has_required_data, registered_company_name: old_registered_name) }
+  let(:reg_identifier) { registration.reg_identifier }
+  let(:companies_house_name) { new_registered_name }
+
+  before do
+    allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:load_company)
+    allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:company_name).and_return(companies_house_name)
+  end
+
+  subject { described_class.run(reg_identifier: reg_identifier) }
+
+  context "with no previous companies house name" do
+    let(:old_registered_name) { nil }
+
+    it "stores the companies house name" do
+      expect { subject }.to change { registration_data(registration).registered_company_name }
+        .from(nil)
+        .to(new_registered_name)
+    end
+  end
+
+  context "with an existing registered company name" do
+    let(:old_registered_name) { Faker::Company.name }
+
+    context "when the new company name is the same as the old one" do
+      let(:new_registered_name) { old_registered_name }
+
+      it "does not change the companies house name" do
+        expect { subject }.not_to change { registration_data(registration).registered_company_name }
+      end
+    end
+
+    context "when the new company name is different to the old one" do
+      it "updates the registered company name" do
+        expect { subject }
+          .to change { registration_data(registration).registered_company_name }
+          .from(old_registered_name)
+          .to(new_registered_name)
+      end
+    end
+  end
+end
+
+def registration_data(registration)
+  WasteCarriersEngine::Registration.find_by(reg_identifier: registration.reg_identifier)
+end


### PR DESCRIPTION
This change adds a service to refresh the registered company name using the Companies House API.
It also displays the registered company name within the "Edit registration" form.