### PR TITLE
Company name header text depends on tier level for LTD and LLP

### DIFF
--- a/app/forms/waste_carriers_engine/company_name_form.rb
+++ b/app/forms/waste_carriers_engine/company_name_form.rb
@@ -2,7 +2,7 @@
 
 module WasteCarriersEngine
   class CompanyNameForm < ::WasteCarriersEngine::BaseForm
-    delegate :business_type, :company_name, :registered_company_name, to: :transient_registration
+    delegate :business_type, :company_name, :registered_company_name, :tier, to: :transient_registration
 
     validates :company_name, "waste_carriers_engine/company_name": true
   end

--- a/app/views/waste_carriers_engine/company_name_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/company_name_forms/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t(".heading.#{@company_name_form.business_type}").html_safe %>
+<% content_for :title, t(".heading.#{@company_name_form.business_type}.#{@company_name_form.tier}").html_safe %>
 <%= render("waste_carriers_engine/shared/back", back_path: back_company_name_forms_path(@company_name_form.token)) %>
 
 <div class="govuk-grid-row">
@@ -8,7 +8,7 @@
       <%= f.govuk_text_field :company_name,
           width: "one-half",
           label: {
-            text: t(".heading.#{@company_name_form.business_type}"),
+            text: t(".heading.#{@company_name_form.business_type}.#{@company_name_form.tier}"),
             tag: "h1", size: "l"
           },
           hint: {

--- a/config/locales/forms/company_name_forms/en.yml
+++ b/config/locales/forms/company_name_forms/en.yml
@@ -4,15 +4,33 @@ en:
       new:
         title: Business or organisation name
         heading:
-          localAuthority: What's the name of the local authority or public body?
-          limitedCompany: Do you trade under a different name? (optional)
-          limitedLiabilityPartnership: Do you trade under a different name? (optional)
-          overseas: What's the name of the business or organisation?
-          partnership: What's the name of the partnership?
-          soleTrader: What's the name of the business?
-          charity: What's the name of the charity or trust?
-          authority: What's the name of the local authority?
-          publicBody: What's the name of the public body?
+          localAuthority:
+            UPPER: &value "What's the name of the local authority or public body?"
+            LOWER: *value
+          limitedCompany:
+            UPPER: Do you trade under a different name? (optional)
+            LOWER: What's the name of the company?
+          limitedLiabilityPartnership:
+            UPPER: Do you trade under a different name? (optional)
+            LOWER: What's the name of the limited liability partnership?
+          overseas:
+            UPPER: &value What's the name of the business or organisation?
+            LOWER: *value
+          partnership:
+            UPPER: &value What's the name of the partnership?
+            LOWER: *value
+          soleTrader:
+            UPPER: &value What's the name of the business?
+            LOWER: *value
+          charity:
+            UPPER: &value What's the name of the charity or trust?
+            LOWER: *value
+          authority:
+            UPPER: &value What's the name of the local authority?
+            LOWER: *value
+          publicBody:
+            UPPER: &value What's the name of the public body?
+            LOWER: *value
         company_name_label:
           localAuthority: Enter your local authority or public body name
           limitedCompany: Enter a business or trading name. This will be displayed on the public register.


### PR DESCRIPTION
A previous PR changed the H1 text on the company name form to "Do you trade under a different name? (optional)" for all LTD and LLP entities. However this should only be the case for upper-tier registrations; lower-tier registrations must enter a company (business) name.
This change makes the H1 text dependent on both the business type and the tier.
https://eaflood.atlassian.net/browse/RUBY-1798 - updated a/c.