### PR TITLE
Extend 'trading as' logic in presentation name to upper-tier sole traders

### DIFF
--- a/app/presenters/waste_carriers_engine/can_present_entity_display_name.rb
+++ b/app/presenters/waste_carriers_engine/can_present_entity_display_name.rb
@@ -11,9 +11,9 @@ module WasteCarriersEngine
     # finding and formatting that single person.
     def entity_display_name
       if upper_tier_sole_trader?
-        list_main_people
+        legal_name_and_or_trading_name(list_main_people)
       else
-        company_registered_and_or_trading_name
+        legal_name_and_or_trading_name(registered_company_name)
       end
     end
 
@@ -30,15 +30,15 @@ module WasteCarriersEngine
       upper_tier? && business_type == "soleTrader"
     end
 
-    def company_registered_and_or_trading_name
+    def legal_name_and_or_trading_name(legal_name)
       if company_name.present?
-        if registered_company_name.present?
-          "#{registered_company_name} trading as #{company_name}"
+        if legal_name.present?
+          "#{legal_name} trading as #{company_name}"
         else
           company_name
         end
       else
-        registered_company_name
+        legal_name
       end
     end
   end

--- a/spec/support/shared_examples/can_present_entity_display_name.rb
+++ b/spec/support/shared_examples/can_present_entity_display_name.rb
@@ -18,9 +18,22 @@ RSpec.shared_examples "Can present entity display name" do
     context "when the registration business type is 'soleTrader'" do
       let(:business_type) { "soleTrader" }
       let(:key_people) { [person_a] }
+      let(:trader_name) { "#{key_people[0].first_name} #{key_people[0].last_name}" }
 
-      it "returns the carrier's name" do
-        expect(subject.entity_display_name).to eq("#{person_a.first_name} #{person_a.last_name}")
+      context "without a business name" do
+        let(:company_name) { nil }
+
+        it "returns the trader's name" do
+          expect(subject.entity_display_name).to eq trader_name
+        end
+      end
+
+      context "with a business name" do
+        let(:company_name) { Faker::Company.name }
+
+        it "returns the sole trader name and the business name" do
+          expect(subject.entity_display_name).to eq "#{trader_name} trading as #{company_name}"
+        end
       end
     end
 


### PR DESCRIPTION
This change extends the existing "trading as" registered company name / business name logic to upper-tier sole traders.
https://eaflood.atlassian.net/browse/RUBY-1779