### PR TITLE
Make sole trader business name optional

### DIFF
--- a/app/validators/waste_carriers_engine/company_name_validator.rb
+++ b/app/validators/waste_carriers_engine/company_name_validator.rb
@@ -34,6 +34,9 @@ module WasteCarriersEngine
       case record.business_type
       when "limitedCompany", "limitedLiabilityPartnership"
         return value_is_present?(record, attribute, value) unless record.registered_company_name.present?
+
+      else
+        return true
       end
       true
     end

--- a/app/validators/waste_carriers_engine/company_name_validator.rb
+++ b/app/validators/waste_carriers_engine/company_name_validator.rb
@@ -31,12 +31,8 @@ module WasteCarriersEngine
     end
 
     def valid_company_name?(record, attribute, value)
-      case record.business_type
-      when "limitedCompany", "limitedLiabilityPartnership"
+      if %w[limitedCompany limitedLiabilityPartnership].include? record.business_type
         return value_is_present?(record, attribute, value) unless record.registered_company_name.present?
-
-      else
-        return true
       end
       true
     end

--- a/app/validators/waste_carriers_engine/company_name_validator.rb
+++ b/app/validators/waste_carriers_engine/company_name_validator.rb
@@ -34,10 +34,6 @@ module WasteCarriersEngine
       case record.business_type
       when "limitedCompany", "limitedLiabilityPartnership"
         return value_is_present?(record, attribute, value) unless record.registered_company_name.present?
-      when "soleTrader"
-        unless record.tier == WasteCarriersEngine::Registration::UPPER_TIER
-          return value_is_present?(record, attribute, value)
-        end
       end
       true
     end

--- a/app/validators/waste_carriers_engine/company_name_validator.rb
+++ b/app/validators/waste_carriers_engine/company_name_validator.rb
@@ -5,7 +5,11 @@ module WasteCarriersEngine
     include CanAddValidationErrors
 
     def validate_each(record, attribute, value)
-      return false unless value_is_present?(record, attribute, value)
+      if attribute == :company_name
+        return false unless valid_company_name?(record, attribute, value)
+      else
+        return false unless value_is_present?(record, attribute, value)
+      end
 
       value_is_not_too_long?(record, attribute, value)
     end
@@ -14,8 +18,6 @@ module WasteCarriersEngine
 
     def value_is_present?(record, attribute, value)
       return true if value.present?
-
-      return true if attribute == :company_name && record.registered_company_name.present?
 
       add_validation_error(record, attribute, :blank)
       false
@@ -26,6 +28,18 @@ module WasteCarriersEngine
 
       add_validation_error(record, attribute, :too_long)
       false
+    end
+
+    def valid_company_name?(record, attribute, value)
+      case record.business_type
+      when "limitedCompany", "limitedLiabilityPartnership"
+        return value_is_present?(record, attribute, value) unless record.registered_company_name.present?
+      when "soleTrader"
+        unless record.tier == WasteCarriersEngine::Registration::UPPER_TIER
+          return value_is_present?(record, attribute, value)
+        end
+      end
+      true
     end
   end
 end

--- a/app/validators/waste_carriers_engine/company_name_validator.rb
+++ b/app/validators/waste_carriers_engine/company_name_validator.rb
@@ -31,9 +31,11 @@ module WasteCarriersEngine
     end
 
     def valid_company_name?(record, attribute, value)
-      if %w[limitedCompany limitedLiabilityPartnership].include? record.business_type
-        return value_is_present?(record, attribute, value) unless record.registered_company_name.present?
+      if (%w[limitedCompany limitedLiabilityPartnership].include? record.business_type) &&
+         !record.registered_company_name.present?
+        return value_is_present?(record, attribute, value)
       end
+
       true
     end
   end

--- a/spec/validators/waste_carriers_engine/company_name_validator.rb
+++ b/spec/validators/waste_carriers_engine/company_name_validator.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Test
+  CompanyNameValidatable = Struct.new(:company_name) do
+    include ActiveModel::Validations
+
+    attr_reader :company_name
+    attr_reader :registered_company_name
+    attr_reader :business_type
+    attr_reader :tier
+
+    validates_with WasteCarriersEngine::CompanyNameValidator, attributes: [:company_name]
+  end
+end
+
+module WasteCarriersEngine
+  RSpec.describe CompanyNameValidator do
+    subject { Test::CompanyNameValidatable.new }
+
+    RSpec.shared_examples "is valid" do
+      it "passes the valiity check" do
+        expect(subject).to be_valid
+      end
+    end
+
+    RSpec.shared_examples "is not valid" do
+      it "does not pass the validity check" do
+        expect(subject).not_to be_valid
+      end
+    end
+  
+    RSpec.shared_examples "business name is required" do
+      context "with a business name" do
+        before { allow(subject).to receive(:company_name).and_return(Faker::Company.name) }
+        it_behaves_like "is valid"
+      end
+      context "without a business name" do
+        before { allow(subject).to receive(:company_name).and_return(nil) }
+        it_behaves_like "is not valid"
+      end
+      context "with a blank business name" do
+        before { allow(subject).to receive(:company_name).and_return("") }
+        it_behaves_like "is not valid"
+      end
+    end
+
+    RSpec.shared_examples "business name is optional" do
+      context "with a business name" do
+        before { allow(subject).to receive(:company_name).and_return(Faker::Company.name) }
+        it_behaves_like "is valid"
+      end
+      context "without a business name" do
+        before { allow(subject).to receive(:company_name).and_return(nil) }
+        it_behaves_like "is valid"
+      end
+      context "with a blank business name" do
+        before { allow(subject).to receive(:company_name).and_return("") }
+        it_behaves_like "is valid"
+      end
+    end
+
+    RSpec.shared_examples "limited company or limited liability partnership" do
+      context "with a registered company name" do
+        before { allow(subject).to receive(:registered_company_name).and_return(Faker::Company.name) }
+        it_behaves_like "business name is optional"
+      end
+      context "without a registered company name" do
+        before { allow(subject).to receive(:registered_company_name).and_return(nil) }
+        it_behaves_like "business name is required"
+      end
+    end
+
+    describe "#valid?" do
+
+      context "lower tier" do
+        before { allow(subject).to receive(:tier).and_return("LOWER") }
+        context "sole trader" do
+          before { allow(subject).to receive(:business_type).and_return("soleTrader") }
+          it_behaves_like "business name is required"
+        end
+        context "limited company" do
+          before { allow(subject).to receive(:business_type).and_return("limitedCompany") }
+          it_behaves_like "limited company or limited liability partnership"
+        end
+        context "limited liability partnership" do
+          before { allow(subject).to receive(:business_type).and_return("limitedLiabilityPartnership") }
+          it_behaves_like "limited company or limited liability partnership"
+        end
+      end
+
+      context "upper tier" do
+        before { allow(subject).to receive(:tier).and_return("UPPER") }
+        context "sole trader" do
+          before { allow(subject).to receive(:business_type).and_return("soleTrader") }
+          it_behaves_like "business name is optional"
+        end
+        context "limited company" do
+          before { allow(subject).to receive(:business_type).and_return("limitedCompany") }
+          it_behaves_like "limited company or limited liability partnership"
+        end
+        context "limited liability partnership" do
+          before { allow(subject).to receive(:business_type).and_return("limitedLiabilityPartnership") }
+          it_behaves_like "limited company or limited liability partnership"
+        end
+      end
+    end
+  end
+end

--- a/spec/validators/waste_carriers_engine/company_name_validator.rb
+++ b/spec/validators/waste_carriers_engine/company_name_validator.rb
@@ -16,6 +16,7 @@ module Test
 end
 
 module WasteCarriersEngine
+  # rubocop:disable Metrics/BlockLength
   RSpec.describe CompanyNameValidator do
     subject { Test::CompanyNameValidatable.new }
 
@@ -30,7 +31,7 @@ module WasteCarriersEngine
         expect(subject).not_to be_valid
       end
     end
-  
+
     RSpec.shared_examples "business name is required" do
       context "with a business name" do
         before { allow(subject).to receive(:company_name).and_return(Faker::Company.name) }
@@ -107,4 +108,5 @@ module WasteCarriersEngine
       end
     end
   end
+  # rubocop:enable Metrics/BlockLength
 end

--- a/spec/validators/waste_carriers_engine/company_name_validator.rb
+++ b/spec/validators/waste_carriers_engine/company_name_validator.rb
@@ -9,7 +9,6 @@ module Test
     attr_reader :company_name
     attr_reader :registered_company_name
     attr_reader :business_type
-    attr_reader :tier
 
     validates_with WasteCarriersEngine::CompanyNameValidator, attributes: [:company_name]
   end
@@ -21,7 +20,7 @@ module WasteCarriersEngine
     subject { Test::CompanyNameValidatable.new }
 
     RSpec.shared_examples "is valid" do
-      it "passes the valiity check" do
+      it "passes the validity check" do
         expect(subject).to be_valid
       end
     end
@@ -74,37 +73,17 @@ module WasteCarriersEngine
     end
 
     describe "#valid?" do
-
-      context "lower tier" do
-        before { allow(subject).to receive(:tier).and_return("LOWER") }
-        context "sole trader" do
-          before { allow(subject).to receive(:business_type).and_return("soleTrader") }
-          it_behaves_like "business name is required"
-        end
-        context "limited company" do
-          before { allow(subject).to receive(:business_type).and_return("limitedCompany") }
-          it_behaves_like "limited company or limited liability partnership"
-        end
-        context "limited liability partnership" do
-          before { allow(subject).to receive(:business_type).and_return("limitedLiabilityPartnership") }
-          it_behaves_like "limited company or limited liability partnership"
-        end
+      context "sole trader" do
+        before { allow(subject).to receive(:business_type).and_return("soleTrader") }
+        it_behaves_like "business name is optional"
       end
-
-      context "upper tier" do
-        before { allow(subject).to receive(:tier).and_return("UPPER") }
-        context "sole trader" do
-          before { allow(subject).to receive(:business_type).and_return("soleTrader") }
-          it_behaves_like "business name is optional"
-        end
-        context "limited company" do
-          before { allow(subject).to receive(:business_type).and_return("limitedCompany") }
-          it_behaves_like "limited company or limited liability partnership"
-        end
-        context "limited liability partnership" do
-          before { allow(subject).to receive(:business_type).and_return("limitedLiabilityPartnership") }
-          it_behaves_like "limited company or limited liability partnership"
-        end
+      context "limited company" do
+        before { allow(subject).to receive(:business_type).and_return("limitedCompany") }
+        it_behaves_like "limited company or limited liability partnership"
+      end
+      context "limited liability partnership" do
+        before { allow(subject).to receive(:business_type).and_return("limitedLiabilityPartnership") }
+        it_behaves_like "limited company or limited liability partnership"
       end
     end
   end


### PR DESCRIPTION
This change makes business name optional for sole traders. It also adds a set of unit tests for the company name validator.
https://eaflood.atlassian.net/browse/RUBY-1806