### PR TITLE
Add `registered_company_name` to the registration search terms

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -91,6 +91,7 @@ module WasteCarriersEngine
         any_of({ reg_identifier: /\A#{escaped_term}\z/i },
                { company_name: /#{escaped_term}/i },
                { last_name: /#{escaped_term}/i },
+               { registered_company_name: /#{escaped_term}/i },
                "addresses.postcode": /#{escaped_term}/i)
       }
 

--- a/spec/support/shared_examples/search_scope.rb
+++ b/spec/support/shared_examples/search_scope.rb
@@ -30,6 +30,22 @@ RSpec.shared_examples "Search scopes" do |record_class:, factory:|
       end
     end
 
+    context "when the search term is a registered_company_name" do
+      let(:term) { "Absolute Skips" }
+
+      let(:matching_record) do
+        create(factory, :has_required_data, registered_company_name: "Absolute Skips Ltd")
+      end
+
+      it "returns records with a matching registered_company_name" do
+        expect(scope).to include(matching_record)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(non_matching_record)
+      end
+    end
+
     context "when the search term is a name" do
       let(:term) { "Lee" }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1794

This is to support a back office search for registered_company_name