### PR TITLE
Adjust spelling of dependentThoroughfare to match OS Places API

### DIFF
--- a/app/models/waste_carriers_engine/address.rb
+++ b/app/models/waste_carriers_engine/address.rb
@@ -80,7 +80,8 @@ module WasteCarriersEngine
       # but OS places does not include them in the "lines" array.
       # If either or both are present, insert them before the thoroughFareName value.
       if data["thoroughfareName"].present? && (insert_position = lines.index(data["thoroughfareName"]))
-        add_line_at?(lines, insert_position, data["dependentThoroughfare"])
+        # Note: The OS Places API spells dependentThoroughfare as dependentThroughfare.
+        add_line_at?(lines, insert_position, data["dependentThroughfare"])
         add_line_at?(lines, insert_position, data["buildingName"])
       end
 

--- a/spec/models/waste_carriers_engine/address_spec.rb
+++ b/spec/models/waste_carriers_engine/address_spec.rb
@@ -83,7 +83,8 @@ module WasteCarriersEngine
 
       context "with no dependent thoroughfare or building name" do
         before do
-          os_places_data["dependentThoroughfare"] = ""
+          # Note: The OS Places API response payload spells dependentThoroughfare as dependentThroughfare.
+          os_places_data["dependentThroughfare"] = ""
           os_places_data["buildingName"] = ""
         end
 
@@ -106,7 +107,7 @@ module WasteCarriersEngine
       context "with a dependent thoroughfare and no building name" do
         let(:dependent_thoroughfare) { Faker::Address.street_name }
         before do
-          os_places_data["dependentThoroughfare"] = dependent_thoroughfare
+          os_places_data["dependentThroughfare"] = dependent_thoroughfare
           os_places_data["buildingName"] = ""
         end
 
@@ -144,7 +145,7 @@ module WasteCarriersEngine
       context "with a building name and no dependent thoroughfare" do
         let(:building_name) { Faker::Address.secondary_address }
         before do
-          os_places_data["dependentThoroughfare"] = ""
+          os_places_data["dependentThroughfare"] = ""
           os_places_data["buildingName"] = building_name
         end
 
@@ -183,7 +184,7 @@ module WasteCarriersEngine
         let(:dependent_thoroughfare) { Faker::Address.street_name }
         let(:building_name) { Faker::Address.secondary_address }
         before do
-          os_places_data["dependentThoroughfare"] = dependent_thoroughfare
+          os_places_data["dependentThroughfare"] = dependent_thoroughfare
           os_places_data["buildingName"] = building_name
         end
 


### PR DESCRIPTION
This change aligns the spelling of the `dependentThoroughfare` field with that returned by the OS Places API, i.e. `dependentThroughfare` (missing the first "o").
Note that this is used only to extract the dependent thoroughfare value from the OS Places API response, if present. There is an unused database field in WCR called `dependentThoroughfare` and that is not affected by this change.

https://eaflood.atlassian.net/browse/RUBY-1812