### PR TITLE
Make sole trader business name mandatory for lower-tier registrations

### DIFF
--- a/app/validators/waste_carriers_engine/company_name_validator.rb
+++ b/app/validators/waste_carriers_engine/company_name_validator.rb
@@ -31,12 +31,16 @@ module WasteCarriersEngine
     end
 
     def valid_company_name?(record, attribute, value)
-      if (%w[limitedCompany limitedLiabilityPartnership].include? record.business_type) &&
-         !record.registered_company_name.present?
-        return value_is_present?(record, attribute, value)
+      case record.business_type
+      when "limitedCompany", "limitedLiabilityPartnership"
+        # mandatory unless registered_company_name is present
+        return record.registered_company_name.present? || value_is_present?(record, attribute, value)
+      when "soleTrader"
+        # mandatory for lower tier, optional for upper tier
+        return (record.tier == WasteCarriersEngine::Registration::UPPER_TIER) || value_is_present?(record, attribute, value)
+      else
+        return true
       end
-
-      true
     end
   end
 end

--- a/app/validators/waste_carriers_engine/company_name_validator.rb
+++ b/app/validators/waste_carriers_engine/company_name_validator.rb
@@ -34,12 +34,12 @@ module WasteCarriersEngine
       case record.business_type
       when "limitedCompany", "limitedLiabilityPartnership"
         # mandatory unless registered_company_name is present
-        return record.registered_company_name.present? || value_is_present?(record, attribute, value)
+        record.registered_company_name.present? || value_is_present?(record, attribute, value)
       when "soleTrader"
         # mandatory for lower tier, optional for upper tier
-        return (record.tier == WasteCarriersEngine::Registration::UPPER_TIER) || value_is_present?(record, attribute, value)
+        (record.tier == WasteCarriersEngine::Registration::UPPER_TIER) || value_is_present?(record, attribute, value)
       else
-        return true
+        true
       end
     end
   end

--- a/config/locales/forms/company_name_forms/en.yml
+++ b/config/locales/forms/company_name_forms/en.yml
@@ -8,10 +8,10 @@ en:
             UPPER: &value "What's the name of the local authority or public body?"
             LOWER: *value
           limitedCompany:
-            UPPER: &trade_name Do you trade under a different name? (optional)
+            UPPER: &optional_trade_name Do you trade under a different name? (optional)
             LOWER: What's the name of the company?
           limitedLiabilityPartnership:
-            UPPER: *trade_name
+            UPPER: *optional_trade_name
             LOWER: What's the name of the limited liability partnership?
           overseas:
             UPPER: &value What's the name of the business or organisation?
@@ -20,8 +20,8 @@ en:
             UPPER: &value What's the name of the partnership?
             LOWER: *value
           soleTrader:
-            UPPER: *trade_name
-            LOWER: *trade_name
+            UPPER: *optional_trade_name
+            LOWER: Enter your business trading name
           charity:
             UPPER: &value What's the name of the charity or trust?
             LOWER: *value

--- a/spec/validators/waste_carriers_engine/company_name_validator.rb
+++ b/spec/validators/waste_carriers_engine/company_name_validator.rb
@@ -9,6 +9,7 @@ module Test
     attr_reader :company_name
     attr_reader :registered_company_name
     attr_reader :business_type
+    attr_reader :tier
 
     validates_with WasteCarriersEngine::CompanyNameValidator, attributes: [:company_name]
   end
@@ -75,7 +76,15 @@ module WasteCarriersEngine
     describe "#valid?" do
       context "sole trader" do
         before { allow(subject).to receive(:business_type).and_return("soleTrader") }
-        it_behaves_like "business name is optional"
+        context "upper tier" do
+          before { allow(subject).to receive(:tier).and_return("UPPER") }
+          it_behaves_like "business name is optional"
+        end
+        context "lower tier" do
+          before { allow(subject).to receive(:tier).and_return("LOWER") }
+          # WCR does not capture sole trader name for lower tier registrations, so business name is required
+          it_behaves_like "business name is required"
+        end
       end
       context "limited company" do
         before { allow(subject).to receive(:business_type).and_return("limitedCompany") }

--- a/spec/validators/waste_carriers_engine/company_name_validator.rb
+++ b/spec/validators/waste_carriers_engine/company_name_validator.rb
@@ -30,7 +30,6 @@ module WasteCarriersEngine
         expect(subject).not_to be_valid
       end
     end
-
     RSpec.shared_examples "business name is required" do
       context "with a business name" do
         before { allow(subject).to receive(:company_name).and_return(Faker::Company.name) }

--- a/spec/validators/waste_carriers_engine/company_name_validator.rb
+++ b/spec/validators/waste_carriers_engine/company_name_validator.rb
@@ -30,6 +30,7 @@ module WasteCarriersEngine
         expect(subject).not_to be_valid
       end
     end
+
     RSpec.shared_examples "business name is required" do
       context "with a business name" do
         before { allow(subject).to receive(:company_name).and_return(Faker::Company.name) }


### PR DESCRIPTION
Sole trader name is not captured for lower-tier sole trader registrations, so business name is mandatory in such cases. This change modifies the company name validator and the business name page to force an error if a business name is not provided for a lower-tier sole trader registration.
https://eaflood.atlassian.net/browse/RUBY-1806