### PR TITLE
Add hint text on the address page

### DIFF
--- a/app/views/waste_carriers_engine/company_postcode_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/company_postcode_forms/new.html.erb
@@ -8,6 +8,7 @@
       <h1 class="govuk-heading-l">
         <%= t(".heading.#{@company_postcode_form.business_type}") %>
       </h1>
+       <p class="govuk-body"><%= t(".page_hint") %></p>
       <legend class="govuk-visually-hidden">
         <%= t(".heading.#{@company_postcode_form.business_type}") %>
       </legend>

--- a/config/locales/forms/company_postcode_forms/en.yml
+++ b/config/locales/forms/company_postcode_forms/en.yml
@@ -12,6 +12,7 @@ en:
           charity: Find the address of the charity or trust
           authority: Find the address of the local authority
           publicBody: Find the address of the public body
+        page_hint: This is your trading address or principal place of business. This will be displayed on the public register.
         temp_company_postcode_label: Enter a UK postcode
         temp_company_postcode_hint: For example, BS1 5AH
         error_heading: A problem to fix


### PR DESCRIPTION
This change adds explanatory text under the title of the address page.
https://eaflood.atlassian.net/browse/RUBY-1799