### PR TITLE
Registered Company Name saved to the transient registration

### DIFF
--- a/app/forms/waste_carriers_engine/check_registered_company_name_form.rb
+++ b/app/forms/waste_carriers_engine/check_registered_company_name_form.rb
@@ -3,15 +3,22 @@
 module WasteCarriersEngine
   class CheckRegisteredCompanyNameForm < ::WasteCarriersEngine::BaseForm
     delegate :company_no, to: :transient_registration
+    delegate :registered_company_name, to: :transient_registration
     delegate :temp_use_registered_company_details, to: :transient_registration
     validates :temp_use_registered_company_details, "waste_carriers_engine/yes_no": true
 
-    def company_name
+    def registered_company_name
       companies_house_service.company_name
     end
 
     def registered_office_address_lines
       companies_house_service.registered_office_address_lines
+    end
+
+    def submit(params)
+      params[:registered_company_name] = registered_company_name
+
+      super
     end
 
     private

--- a/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
@@ -195,7 +195,8 @@ module WasteCarriersEngine
                       if: :incorrect_company_data?
 
           transitions from: :check_registered_company_name_form,
-                      to: :company_name_form
+                      to: :company_name_form,
+                      after: :save_registered_company_name
 
           transitions from: :incorrect_company_form,
                       to: :registration_number_form
@@ -687,6 +688,10 @@ module WasteCarriersEngine
 
       def incorrect_company_data?
         temp_use_registered_company_details == "no"
+      end
+
+      def save_registered_company_name
+        update_attributes(registered_company_name: registered_company_name)
       end
     end
     # rubocop:enable Metrics/BlockLength

--- a/app/views/waste_carriers_engine/check_registered_company_name_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/check_registered_company_name_forms/new.html.erb
@@ -30,7 +30,7 @@
           legend: -> do %>
 
             <h2 class="govuk-heading-m">
-              <%= @check_registered_company_name_form.company_name %>
+              <%= @check_registered_company_name_form.registered_company_name %>
             </h2> 
             <p class="govuk-body">
               <% @check_registered_company_name_form.registered_office_address_lines.each do |line| %>

--- a/spec/forms/waste_carriers_engine/check_registered_company_name_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/check_registered_company_name_forms_spec.rb
@@ -18,10 +18,27 @@ module WasteCarriersEngine
       let(:check_registered_company_name_form) { build(:check_registered_company_name_form, :has_required_data) }
 
       context "when the form is valid" do
-        let(:valid_params) { { token: check_registered_company_name_form.token, temp_use_registered_company_details: "no" } }
+        subject { check_registered_company_name_form.submit(valid_params) }
 
-        it "should submit" do
-          expect(check_registered_company_name_form.submit(valid_params)).to be_truthy
+        context "when the user selects yes to the company house details being correct" do
+          let(:valid_params) { { token: check_registered_company_name_form.token, temp_use_registered_company_details: "yes" } }
+          let(:transient_registration) { check_registered_company_name_form.transient_registration }
+
+          it "should submit" do
+            expect(subject).to be_truthy
+          end
+
+          it "should update the transient registration" do
+            expect { subject }.to change { transient_registration.reload.attributes["registeredCompanyName"] }.to(company_name)
+          end
+        end
+
+        context "when the user selects no to the company house details being correct" do
+          let(:valid_params) { { token: check_registered_company_name_form.token, temp_use_registered_company_details: "no" } }
+
+          it "should submit" do
+            expect(subject).to be_truthy
+          end
         end
       end
 

--- a/spec/forms/waste_carriers_engine/check_registered_company_name_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/check_registered_company_name_forms_spec.rb
@@ -35,5 +35,7 @@ module WasteCarriersEngine
         end
       end
     end
+
+    include_examples "validate yes no", :check_registered_company_name_form, :temp_use_registered_company_details
   end
 end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/check_registered_company_name_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/check_registered_company_name_form_spec.rb
@@ -9,7 +9,17 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":check_registered_company_name_form state transitions" do
         context "on next" do
-          include_examples "has next transition", next_state: "company_name_form"
+          context "when the user confirms their company house details are correct" do
+            subject { build(:new_registration, workflow_state: "check_registered_company_name_form", temp_use_registered_company_details: "yes") }
+
+            include_examples "has next transition", next_state: "company_name_form"
+          end
+
+          context "when the user confirms their company house details are wrong" do
+            subject { build(:new_registration, workflow_state: "check_registered_company_name_form", temp_use_registered_company_details: "no") }
+
+            include_examples "has next transition", next_state: "incorrect_company_form"
+          end
         end
 
         context "on back" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1745

Here we have the work for confirming the registered company name. Once the user has confirmed the name and address that is pulled from the company house API (using their inputted company number) we are then saving their registered company name into the transient registration. This populates in the database as registeredCompanyName. This leaves the field companyName in the database which is optional for the user to enter a trading/business name

To Do:
* Testing 