### PR TITLE
Handle a blank organisation name in conviction checks

### DIFF
--- a/app/models/waste_carriers_engine/convictions_check/entity.rb
+++ b/app/models/waste_carriers_engine/convictions_check/entity.rb
@@ -61,11 +61,9 @@ module WasteCarriersEngine
       }
 
       def self.matching_organisations(name:, company_no: nil)
-        raise ArgumentError if name.blank?
-
         results = []
         results += matching_company_number(company_no) if company_no.present?
-        results += matching_organisation_name(name)
+        results += matching_organisation_name(name) if name.present?
 
         results.uniq
       end

--- a/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
+++ b/spec/models/waste_carriers_engine/convictions_check/entity_spec.rb
@@ -317,10 +317,11 @@ module WasteCarriersEngine
         end
 
         context "when the name is blank" do
-          let(:term) { nil }
+          let(:results) { described_class.matching_organisations(name: nil, company_no: term) }
 
-          it "raises an error" do
-            expect { results }.to raise_error(ArgumentError)
+          it "returns the company_no match" do
+            company_no_match = described_class.create(company_number: term)
+            expect(results).to eq([company_no_match])
           end
         end
       end


### PR DESCRIPTION
- Here we allow the organisation match to take place, even
if the name is missing.

- This is to handle the scenario when the company_name field is blank and the check returns 'ERROR'

- Further work should be done to use other name(s) for conviction checks, but that is out of the scope of this ticket.

https://eaflood.atlassian.net/browse/RUBY-1825