### PR TITLE
intermittent unit test failure on check_registered_company_name_form

### DIFF
--- a/spec/requests/waste_carriers_engine/check_registered_company_name_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/check_registered_company_name_forms_spec.rb
@@ -34,7 +34,7 @@ module WasteCarriersEngine
 
           it "displays the registered company name" do
             get check_registered_company_name_forms_path(transient_registration[:token])
-            expect(response.body).to include(company_name)
+            expect(CGI.unescapeHTML(response.body)).to include(company_name)
           end
 
           it "displays the registered company address" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1826

Here we have changed the check_registered_company_name test to include html escape as the test was failing if the companies name included an apostrophe.
This change has been tested using a hard coded company name including an apostrophe among other symbols. 
Once happy the test was passing we then changed the test back to including Faker