### PR TITLE
Legal entities changes for renewals

### DIFF
--- a/app/controllers/waste_carriers_engine/renewal_start_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/renewal_start_forms_controller.rb
@@ -14,13 +14,16 @@ module WasteCarriersEngine
 
     private
 
-    # rubocop:disable Naming/MemoizedInstanceVariableName
     def find_or_initialize_transient_registration(token)
       @transient_registration ||= RenewingRegistration.where(token: token).first ||
                                   RenewingRegistration.where(reg_identifier: token).first ||
                                   RenewingRegistration.new(reg_identifier: token)
+
+      # Any existing company name should not be used for a registration renewal where company_name is optional.
+      @transient_registration.company_name = nil unless @transient_registration.company_name_required?
+
+      @transient_registration
     end
-    # rubocop:enable Naming/MemoizedInstanceVariableName
 
     def should_authenticate_user?
       find_or_initialize_transient_registration(params[:token])

--- a/app/forms/waste_carriers_engine/check_your_answers_form.rb
+++ b/app/forms/waste_carriers_engine/check_your_answers_form.rb
@@ -9,7 +9,7 @@ module WasteCarriersEngine
     delegate :first_name, :last_name, :location, :main_people, :phone_number, to: :transient_registration
     delegate :registered_company_name, :registration_type, :relevant_people, :tier, to: :transient_registration
     delegate :registered_address, :declared_convictions, to: :transient_registration
-    delegate :lower_tier?, :upper_tier?, :company_no_required?, to: :transient_registration
+    delegate :lower_tier?, :upper_tier?, :company_no_required?, :company_name_required?, to: :transient_registration
 
     validates :business_type, "defra_ruby/validators/business_type": {
       allow_overseas: true,

--- a/app/forms/waste_carriers_engine/company_name_form.rb
+++ b/app/forms/waste_carriers_engine/company_name_form.rb
@@ -6,15 +6,5 @@ module WasteCarriersEngine
              :registered_company_name, :tier, to: :transient_registration
 
     validates :company_name, "waste_carriers_engine/company_name": true
-
-    def initialize(transient_registration)
-      # Any existing company name should not be used for a registration renewal where company_name is optional.
-      if transient_registration.is_a?(WasteCarriersEngine::RenewingRegistration) &&
-         !transient_registration.company_name_required?
-        transient_registration.company_name = nil
-      end
-
-      super(transient_registration)
-    end
   end
 end

--- a/app/forms/waste_carriers_engine/company_name_form.rb
+++ b/app/forms/waste_carriers_engine/company_name_form.rb
@@ -5,5 +5,14 @@ module WasteCarriersEngine
     delegate :business_type, :company_name, :registered_company_name, :tier, to: :transient_registration
 
     validates :company_name, "waste_carriers_engine/company_name": true
+
+    def initialize(transient_registration)
+      # Any existing company name should not be used for a registration renewal.
+      if transient_registration.is_a?(WasteCarriersEngine::RenewingRegistration)
+        transient_registration.company_name = nil
+      end
+
+      super(transient_registration)
+    end
   end
 end

--- a/app/forms/waste_carriers_engine/company_name_form.rb
+++ b/app/forms/waste_carriers_engine/company_name_form.rb
@@ -2,13 +2,15 @@
 
 module WasteCarriersEngine
   class CompanyNameForm < ::WasteCarriersEngine::BaseForm
-    delegate :business_type, :company_name, :registered_company_name, :tier, to: :transient_registration
+    delegate :business_type, :company_name, :company_name_required?,
+             :registered_company_name, :tier, to: :transient_registration
 
     validates :company_name, "waste_carriers_engine/company_name": true
 
     def initialize(transient_registration)
-      # Any existing company name should not be used for a registration renewal.
-      if transient_registration.is_a?(WasteCarriersEngine::RenewingRegistration)
+      # Any existing company name should not be used for a registration renewal where company_name is optional.
+      if transient_registration.is_a?(WasteCarriersEngine::RenewingRegistration) &&
+         !transient_registration.company_name_required?
         transient_registration.company_name = nil
       end
 

--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -129,6 +129,20 @@ module WasteCarriersEngine
         %w[limitedCompany limitedLiabilityPartnership].include?(business_type)
       end
 
+      def company_name_required?
+        case business_type
+        when "limitedCompany", "limitedLiabilityPartnership"
+          # mandatory unless registered_company_name is present
+          !registered_company_name.present?
+        when "soleTrader"
+          # mandatory for lower tier, optional for upper tier
+          !upper_tier?
+        else
+          # otherwise mandatory
+          true
+        end
+      end
+
       def rejected_conviction_checks?
         return false unless conviction_sign_offs&.any?
 

--- a/app/validators/waste_carriers_engine/company_name_validator.rb
+++ b/app/validators/waste_carriers_engine/company_name_validator.rb
@@ -31,16 +31,7 @@ module WasteCarriersEngine
     end
 
     def valid_company_name?(record, attribute, value)
-      case record.business_type
-      when "limitedCompany", "limitedLiabilityPartnership"
-        # mandatory unless registered_company_name is present
-        record.registered_company_name.present? || value_is_present?(record, attribute, value)
-      when "soleTrader"
-        # mandatory for lower tier, optional for upper tier
-        (record.tier == WasteCarriersEngine::Registration::UPPER_TIER) || value_is_present?(record, attribute, value)
-      else
-        true
-      end
+      !record.company_name_required? || value_is_present?(record, attribute, value)
     end
   end
 end

--- a/app/views/waste_carriers_engine/check_registered_company_name_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/check_registered_company_name_forms/new.html.erb
@@ -30,8 +30,11 @@
           legend: -> do %>
 
             <h2 class="govuk-heading-m">
-              <%= @check_registered_company_name_form.registered_company_name %>
+              <%= t(".company_number", company_no: @check_registered_company_name_form.company_no) %>
             </h2> 
+            <h2 class="govuk-heading-m">
+              <%= @check_registered_company_name_form.registered_company_name %>
+            </h2>
             <p class="govuk-body">
               <% @check_registered_company_name_form.registered_office_address_lines.each do |line| %>
                 <%= line %> <br>
@@ -43,7 +46,11 @@
     <% end %>
 
     <p class="govuk-body">
-      <%= link_to t(".enter_a_different_number"), new_registration_number_form_path %>
+      <% if @transient_registration.is_a?(WasteCarriersEngine::NewRegistration) %>
+        <%= link_to t(".enter_a_different_number"), new_registration_number_form_path %>
+      <% else %>
+        <%= t(".must_create_new_registration") %>
+      <% end %>
     </p>
   </div>
 </div>

--- a/app/views/waste_carriers_engine/incorrect_company_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/incorrect_company_forms/new.html.erb
@@ -14,8 +14,16 @@
 
       <p class="govuk-body"><%= t(".description") %></p>
 
-      <p class="govuk-body"><a href="https://www.gov.uk/file-changes-to-a-company-with-companies-house" target="_blank"><%= t(".service_link") %></a>.</p>
-      <%= f.govuk_submit t(".enter_a_different_number") %>
+      <p class="govuk-body"><a href="https://www.gov.uk/file-changes-to-a-company-with-companies-house" target="_blank"><%= t(".service_link") %></a></p>
+
+      <p class="govuk-body">
+        <% if @transient_registration.is_a?(WasteCarriersEngine::NewRegistration) %>
+            <%= f.govuk_submit t(".enter_a_different_number") %>
+          <% else %>
+            <%= t(".must_create_new_registration") %>
+          <% end %>
+      </p>
+
     <% end %>
   </div>
 </div>

--- a/config/locales/forms/check_registered_company_name_forms/en.yml
+++ b/config/locales/forms/check_registered_company_name_forms/en.yml
@@ -7,8 +7,11 @@ en:
         options:
           "yes": "Yes"
           "no": "No"
+        company_number: "Companies House Number - %{company_no}"
         next_button: Continue
         enter_a_different_number: "Enter a different number"
+        must_create_new_registration: If you have a new companies house number you need to create a new registration
+
   activemodel:
     errors:
       models:

--- a/config/locales/forms/incorrect_company_forms/en.yml
+++ b/config/locales/forms/incorrect_company_forms/en.yml
@@ -8,6 +8,7 @@ en:
         next_button: Continue
         description: If your Companies House information is incorrect you must update it with Companies House before you can register as a waste carrier.
         enter_a_different_number: Enter a different number
+        must_create_new_registration: If you have a new companies house number you need to create a new registration
         company_house_link: Change and update your Companies House information
   activemodel:
     errors:

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/check_registered_company_name_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/check_registered_company_name_form_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    subject { build(:renewing_registration, workflow_state: "check_registered_company_name_form") }
+
+    describe "#workflow_state" do
+      context ":check_registered_company_name_form state transitions" do
+        context "on next" do
+          context "when the user confirms their company house details are correct" do
+            subject { build(:new_registration, workflow_state: "check_registered_company_name_form", temp_use_registered_company_details: "yes") }
+
+            include_examples "has next transition", next_state: "company_name_form"
+          end
+
+          context "when the user confirms their company house details are wrong" do
+            subject { build(:new_registration, workflow_state: "check_registered_company_name_form", temp_use_registered_company_details: "no") }
+
+            include_examples "has next transition", next_state: "incorrect_company_form"
+          end
+        end
+
+        context "on back" do
+          include_examples "has back transition", previous_state: "registration_number_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/company_name_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/company_name_form_spec.rb
@@ -36,13 +36,13 @@ module WasteCarriersEngine
           context "when the business type is limitedCompany" do
             let(:business_type) { "limitedCompany" }
 
-            include_examples "has back transition", previous_state: "registration_number_form"
+            include_examples "has back transition", previous_state: "check_registered_company_name_form"
           end
 
           context "when the business type is limitedLiabilityPartnership" do
             let(:business_type) { "limitedLiabilityPartnership" }
 
-            include_examples "has back transition", previous_state: "registration_number_form"
+            include_examples "has back transition", previous_state: "check_registered_company_name_form"
           end
 
           context "when the business type is partnership" do

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/incorrect_company_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/incorrect_company_form_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe RenewingRegistration, type: :model do
+    subject do
+      build(:renewing_registration, :has_required_data, workflow_state: "incorrect_company_form")
+    end
+
+    describe "#workflow_state" do
+      context ":incorrect_company_form state transitions" do
+        context "on back" do
+          include_examples "has back transition", previous_state: "check_registered_company_name_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/registration_number_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/registration_number_form_spec.rb
@@ -13,7 +13,7 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":registration_number_form state transitions" do
         context "on next" do
-          include_examples "has next transition", next_state: "company_name_form"
+          include_examples "has next transition", next_state: "check_registered_company_name_form"
 
           context "when the company_no has changed" do
             before { subject.company_no = "01234567" }
@@ -26,7 +26,7 @@ module WasteCarriersEngine
                 subject.registration.update_attributes(business_type: "partnership")
               end
 
-              include_examples "has next transition", next_state: "company_name_form"
+              include_examples "has next transition", next_state: "check_registered_company_name_form"
             end
           end
 
@@ -35,7 +35,7 @@ module WasteCarriersEngine
               subject.registration.update_attributes(company_no: "#{subject.company_no} ")
             end
 
-            include_examples "has next transition", next_state: "company_name_form"
+            include_examples "has next transition", next_state: "check_registered_company_name_form"
           end
         end
 

--- a/spec/requests/waste_carriers_engine/company_name_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/company_name_forms_spec.rb
@@ -55,22 +55,22 @@ module WasteCarriersEngine
             context "when the business type is limitedCompany" do
               before(:each) { transient_registration.update_attributes(business_type: "limitedCompany") }
 
-              it "returns a 302 response and redirects to the registration_number form" do
+              it "returns a 302 response and redirects to the check_registered_company_name form" do
                 get back_company_name_forms_path(transient_registration[:token])
 
                 expect(response).to have_http_status(302)
-                expect(response).to redirect_to(new_registration_number_form_path(transient_registration[:token]))
+                expect(response).to redirect_to(new_check_registered_company_name_form_path(transient_registration[:token]))
               end
             end
 
             context "when the business type is limitedLiabilityPartnership" do
               before(:each) { transient_registration.update_attributes(business_type: "limitedLiabilityPartnership") }
 
-              it "returns a 302 response and redirects to the registration_number form" do
+              it "returns a 302 response and redirects to the check_registered_company_name form" do
                 get back_company_name_forms_path(transient_registration[:token])
 
                 expect(response).to have_http_status(302)
-                expect(response).to redirect_to(new_registration_number_form_path(transient_registration[:token]))
+                expect(response).to redirect_to(new_check_registered_company_name_form_path(transient_registration[:token]))
               end
             end
 

--- a/spec/requests/waste_carriers_engine/registration_number_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/registration_number_forms_spec.rb
@@ -28,11 +28,11 @@ module WasteCarriersEngine
           context "when valid params are submitted and the company_no is the same as the original registration" do
             let(:valid_params) { { company_no: transient_registration[:company_no] } }
 
-            it "returns a 302 response and redirects to the company_name form" do
+            it "returns a 302 response and redirects to the check_registered_company_name form" do
               post registration_number_forms_path(transient_registration[:token]), params: { registration_number_form: valid_params }
 
               expect(response).to have_http_status(302)
-              expect(response).to redirect_to(new_company_name_form_path(transient_registration[:token]))
+              expect(response).to redirect_to(new_check_registered_company_name_form_path(transient_registration[:token]))
             end
 
             context "when the original registration had a shorter variant of the company_no" do
@@ -41,11 +41,11 @@ module WasteCarriersEngine
                 registration.update_attributes(company_no: "9360070")
               end
 
-              it "returns a 302 response and redirects to the company_name form" do
+              it "returns a 302 response and redirects to the check_registered_company_name form" do
                 post registration_number_forms_path(transient_registration[:token]), params: { registration_number_form: valid_params }
 
                 expect(response).to have_http_status(302)
-                expect(response).to redirect_to(new_company_name_form_path(transient_registration[:token]))
+                expect(response).to redirect_to(new_check_registered_company_name_form_path(transient_registration[:token]))
               end
             end
           end

--- a/spec/support/shared_examples/can_have_registration_attributes.rb
+++ b/spec/support/shared_examples/can_have_registration_attributes.rb
@@ -486,4 +486,64 @@ RSpec.shared_examples "Can have registration attributes" do |factory:|
       it_behaves_like "LTD or LLP"
     end
   end
+
+  describe "#company_name_required?" do
+    let(:registered_company_name) { nil }
+    let(:resource) do
+      build(factory, business_type: business_type, tier: tier, registered_company_name: registered_company_name)
+    end
+
+    subject { resource.company_name_required? }
+
+    shared_examples "when the registration is lower tier" do
+      let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
+      it "returns true" do
+        expect(subject).to be true
+      end
+    end
+
+    shared_examples "LTD or LLP" do
+
+      context "when the registration is upper tier" do
+        let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
+        context "without a registered_company_name" do
+          it "returns true" do
+            expect(subject).to be true
+          end
+        end
+
+        context "with a registered_company_name" do
+          let(:registered_company_name) { Faker::Company.name }
+          it "returns false" do
+            expect(subject).to be false
+          end
+        end
+      end
+
+      it_behaves_like "when the registration is lower tier"
+    end
+
+    context "for a limited company" do
+      let(:business_type) { "limitedCompany" }
+      it_behaves_like "LTD or LLP"
+    end
+
+    context "for a limited liability partnership" do
+      let(:business_type) { "limitedLiabilityPartnership" }
+      it_behaves_like "LTD or LLP"
+    end
+
+    context "for a sole trader" do
+      let(:business_type) { "soleTrader" }
+
+      context "when the registration is upper tier" do
+        let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
+        it "returns false" do
+          expect(subject).to be false
+        end
+      end
+
+      it_behaves_like "when the registration is lower tier"
+    end
+  end
 end


### PR DESCRIPTION
This change extends the legal entities changes for new registrations to the renewal journey.
https://eaflood.atlassian.net/browse/RUBY-1818
https://eaflood.atlassian.net/browse/RUBY-1819
https://eaflood.atlassian.net/browse/RUBY-1820
https://eaflood.atlassian.net/browse/RUBY-1821
https://eaflood.atlassian.net/browse/RUBY-1822
