### PR TITLE
Don't try to save temp attribute at renewal completion

### DIFF
--- a/app/services/waste_carriers_engine/renewal_completion_service.rb
+++ b/app/services/waste_carriers_engine/renewal_completion_service.rb
@@ -129,6 +129,7 @@ module WasteCarriersEngine
         "temp_os_places_error",
         "temp_payment_method",
         "temp_tier_check",
+        "temp_use_registered_company_details",
         "from_magic_link",
         "_type",
         "workflow_state",


### PR DESCRIPTION
The renewals completion service should exclude the temporary companies house attribute when migrating the transient_registration to a registration.
https://eaflood.atlassian.net/browse/RUBY-1818