### PR TITLE
Worldpay integration requires POST instead of GET

### DIFF
--- a/app/services/concerns/waste_carriers_engine/can_send_worldpay_request.rb
+++ b/app/services/concerns/waste_carriers_engine/can_send_worldpay_request.rb
@@ -14,7 +14,7 @@ module WasteCarriersEngine
         response = nil
         begin
           response = RestClient::Request.execute(
-            method: :get,
+            method: :post,
             url: url,
             payload: xml,
             headers: {


### PR DESCRIPTION
World pay test environment had stopped working for our service,
after troubleshooting the problem has been indentified as an
incorrect http request.

https://eaflood.atlassian.net/browse/RUBY-1838