### PR TITLE
Do not pre-populate company name form for upper-tier companies and sole traders

### DIFF
--- a/app/controllers/waste_carriers_engine/renewal_start_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/renewal_start_forms_controller.rb
@@ -14,16 +14,13 @@ module WasteCarriersEngine
 
     private
 
+    # rubocop:disable Naming/MemoizedInstanceVariableName
     def find_or_initialize_transient_registration(token)
       @transient_registration ||= RenewingRegistration.where(token: token).first ||
                                   RenewingRegistration.where(reg_identifier: token).first ||
                                   RenewingRegistration.new(reg_identifier: token)
-
-      # Any existing company name should not be used for a registration renewal where company_name is optional.
-      @transient_registration.company_name = nil unless @transient_registration.company_name_required?
-
-      @transient_registration
     end
+    # rubocop:enable Naming/MemoizedInstanceVariableName
 
     def should_authenticate_user?
       find_or_initialize_transient_registration(params[:token])

--- a/app/controllers/waste_carriers_engine/renewal_start_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/renewal_start_forms_controller.rb
@@ -14,13 +14,11 @@ module WasteCarriersEngine
 
     private
 
-    # rubocop:disable Naming/MemoizedInstanceVariableName
     def find_or_initialize_transient_registration(token)
-      @transient_registration ||= RenewingRegistration.where(token: token).first ||
-                                  RenewingRegistration.where(reg_identifier: token).first ||
-                                  RenewingRegistration.new(reg_identifier: token)
+      @transient_registration = RenewingRegistration.where(token: token).first ||
+                                RenewingRegistration.where(reg_identifier: token).first ||
+                                RenewingRegistration.new(reg_identifier: token)
     end
-    # rubocop:enable Naming/MemoizedInstanceVariableName
 
     def should_authenticate_user?
       find_or_initialize_transient_registration(params[:token])

--- a/app/forms/waste_carriers_engine/check_registered_company_name_form.rb
+++ b/app/forms/waste_carriers_engine/check_registered_company_name_form.rb
@@ -18,6 +18,9 @@ module WasteCarriersEngine
     def submit(params)
       params[:registered_company_name] = registered_company_name
 
+      # Any existing company name should not be used for a registration renewal where company_name is optional.
+      params[:company_name] = nil unless transient_registration.company_name_required?
+
       super
     end
 

--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -133,7 +133,7 @@ module WasteCarriersEngine
         case business_type
         when "limitedCompany", "limitedLiabilityPartnership", "soleTrader"
           # mandatory for lower tier, optional for upper tier
-          !upper_tier?
+          lower_tier?
         else
           # otherwise mandatory
           true

--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -131,10 +131,7 @@ module WasteCarriersEngine
 
       def company_name_required?
         case business_type
-        when "limitedCompany", "limitedLiabilityPartnership"
-          # mandatory unless registered_company_name is present
-          !registered_company_name.present?
-        when "soleTrader"
+        when "limitedCompany", "limitedLiabilityPartnership", "soleTrader"
           # mandatory for lower tier, optional for upper tier
           !upper_tier?
         else

--- a/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
@@ -195,8 +195,7 @@ module WasteCarriersEngine
                       if: :incorrect_company_data?
 
           transitions from: :check_registered_company_name_form,
-                      to: :company_name_form,
-                      after: :save_registered_company_name
+                      to: :company_name_form
 
           transitions from: :incorrect_company_form,
                       to: :registration_number_form
@@ -688,10 +687,6 @@ module WasteCarriersEngine
 
       def incorrect_company_data?
         temp_use_registered_company_details == "no"
-      end
-
-      def save_registered_company_name
-        update_attributes(registered_company_name: registered_company_name)
       end
     end
     # rubocop:enable Metrics/BlockLength

--- a/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
@@ -169,8 +169,7 @@ module WasteCarriersEngine
                       if: :incorrect_company_data?
 
           transitions from: :check_registered_company_name_form,
-                      to: :company_name_form,
-                      after: :save_registered_company_name
+                      to: :company_name_form
 
           transitions from: :incorrect_company_form,
                       to: :registration_number_form
@@ -574,10 +573,6 @@ module WasteCarriersEngine
 
     def incorrect_company_data?
       temp_use_registered_company_details == "no"
-    end
-
-    def save_registered_company_name
-      update_attributes(registered_company_name: registered_company_name)
     end
 
     def send_renewal_pending_worldpay_payment_email

--- a/app/views/waste_carriers_engine/incorrect_company_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/incorrect_company_forms/new.html.erb
@@ -14,7 +14,7 @@
 
       <p class="govuk-body"><%= t(".description") %></p>
 
-      <p class="govuk-body"><a href="https://www.gov.uk/file-changes-to-a-company-with-companies-house" target="_blank"><%= t(".service_link") %></a></p>
+      <p class="govuk-body"><a href="https://www.gov.uk/file-changes-to-a-company-with-companies-house" target="_blank"><%= t(".service_link") %></a> <%= t(".new_window") %> </p>
 
       <p class="govuk-body">
         <% if @transient_registration.is_a?(WasteCarriersEngine::NewRegistration) %>
@@ -23,7 +23,7 @@
             <%= t(".must_create_new_registration") %>
           <% end %>
       </p>
-
+    
     <% end %>
   </div>
 </div>

--- a/config/locales/forms/incorrect_company_forms/en.yml
+++ b/config/locales/forms/incorrect_company_forms/en.yml
@@ -4,12 +4,12 @@ en:
       new:
         title: My Companies House information is incorrect
         heading: My Companies House information is incorrect
-        service_link: Change and update your Companies House information
+        service_link: Update your Companies House information
         next_button: Continue
         description: If your Companies House information is incorrect you must update it with Companies House before you can register as a waste carrier.
         enter_a_different_number: Enter a different number
+        new_window: (Opens in new window)
         must_create_new_registration: If you have a new companies house number you need to create a new registration
-        company_house_link: Change and update your Companies House information
   activemodel:
     errors:
       models:

--- a/spec/factories/forms/check_registered_company_name_form.rb
+++ b/spec/factories/forms/check_registered_company_name_form.rb
@@ -2,8 +2,22 @@
 
 FactoryBot.define do
   factory :check_registered_company_name_form, class: WasteCarriersEngine::CheckRegisteredCompanyNameForm do
+
+    # set a default type
+    transient do
+      registration_type { :new_registration }
+    end
+
+    trait :new_registration do
+      registration_type { :new_registration }
+    end
+
+    trait :renewing_registration do
+      registration_type { :renewing_registration }
+    end
+
     trait :has_required_data do
-      initialize_with { new(create(:new_registration, :has_required_data, workflow_state: "check_registered_company_name_form")) }
+      initialize_with { new(create(registration_type, :has_required_data, workflow_state: "check_registered_company_name_form")) }
     end
   end
 end

--- a/spec/forms/waste_carriers_engine/company_name_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/company_name_forms_spec.rb
@@ -20,6 +20,8 @@ module WasteCarriersEngine
         let(:company_name_form) { build(:company_name_form, :has_required_data) }
         let(:invalid_params) { { company_name: "" } }
 
+        before { company_name_form.transient_registration.tier = WasteCarriersEngine::Registration::LOWER_TIER }
+
         it "should not submit" do
           expect(company_name_form.submit(invalid_params)).to eq(false)
         end

--- a/spec/requests/waste_carriers_engine/company_name_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/company_name_forms_spec.rb
@@ -15,7 +15,7 @@ module WasteCarriersEngine
 
       context "When the transient_registration is a new registration" do
         let(:transient_registration) do
-          create(:new_registration, :has_required_data, workflow_state: "company_name_form")
+          create(:new_registration, :has_required_data, tier: "LOWER", workflow_state: "company_name_form")
         end
 
         include_examples "POST form",

--- a/spec/support/shared_examples/can_have_registration_attributes.rb
+++ b/spec/support/shared_examples/can_have_registration_attributes.rb
@@ -495,55 +495,35 @@ RSpec.shared_examples "Can have registration attributes" do |factory:|
 
     subject { resource.company_name_required? }
 
-    shared_examples "when the registration is lower tier" do
-      let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
-      it "returns true" do
-        expect(subject).to be true
-      end
-    end
-
-    shared_examples "LTD or LLP" do
-
-      context "when the registration is upper tier" do
-        let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
-        context "without a registered_company_name" do
-          it "returns true" do
-            expect(subject).to be true
-          end
-        end
-
-        context "with a registered_company_name" do
-          let(:registered_company_name) { Faker::Company.name }
-          it "returns false" do
-            expect(subject).to be false
-          end
-        end
-      end
-
-      it_behaves_like "when the registration is lower tier"
-    end
-
-    context "for a limited company" do
-      let(:business_type) { "limitedCompany" }
-      it_behaves_like "LTD or LLP"
-    end
-
-    context "for a limited liability partnership" do
-      let(:business_type) { "limitedLiabilityPartnership" }
-      it_behaves_like "LTD or LLP"
-    end
-
-    context "for a sole trader" do
-      let(:business_type) { "soleTrader" }
-
-      context "when the registration is upper tier" do
+    shared_examples "it is required for lower tier only" do
+      context "upper tier" do
         let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
         it "returns false" do
           expect(subject).to be false
         end
       end
 
-      it_behaves_like "when the registration is lower tier"
+      context "lower tier" do
+        let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
+        it "returns true" do
+          expect(subject).to be true
+        end
+      end
+    end
+
+    context "for a limited company" do
+      let(:business_type) { "limitedCompany" }
+      it_behaves_like "it is required for lower tier only"
+    end
+
+    context "for a limited liability partnership" do
+      let(:business_type) { "limitedLiabilityPartnership" }
+      it_behaves_like "it is required for lower tier only"
+    end
+
+    context "for a sole trader" do
+      let(:business_type) { "soleTrader" }
+      it_behaves_like "it is required for lower tier only"
     end
   end
 end

--- a/spec/support/shared_examples/post_renewal_form.rb
+++ b/spec/support/shared_examples/post_renewal_form.rb
@@ -59,6 +59,8 @@ RSpec.shared_examples "POST renewal form" do |form, options|
         end
 
         context "when the params are invalid" do
+          before { transient_registration.update_attributes(tier: WasteCarriersEngine::Registration::LOWER_TIER) }
+
           it "does not update the transient registration, including workflow_state, and shows the form again" do
             transient_reg_before_submitting = transient_registration
 

--- a/spec/support/shared_examples/validate_company_name.rb
+++ b/spec/support/shared_examples/validate_company_name.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples "valid only if registered_company_name is present" do
-  context "when the registered company name is not blank" do
-    before { form.transient_registration.registered_company_name = Faker::Company.name }
+RSpec.shared_examples "valid only if company_name is not required" do
+  context "when the company name is not required" do
+    before { allow(form.transient_registration).to receive(:company_name_required?).and_return(false) }
 
     it "is valid" do
       expect(form).to be_valid
     end
   end
 
-  context "when the registered company name is blank" do
-    before { form.transient_registration.registered_company_name = "" }
+  context "when the company name is required" do
+    before { allow(form.transient_registration).to receive(:company_name_required?).and_return(true) }
 
     it "is not valid" do
       expect(form).to_not be_valid
@@ -32,13 +32,13 @@ RSpec.shared_examples "validate company_name" do |form_factory|
     context "when a company_name is blank" do
       before { form.transient_registration.company_name = "" }
 
-      it_behaves_like "valid only if registered_company_name is present"
+      it_behaves_like "valid only if company_name is not required"
     end
 
     context "when a company_name is nil" do
       before { form.transient_registration.company_name = nil }
 
-      it_behaves_like "valid only if registered_company_name is present"
+      it_behaves_like "valid only if company_name is not required"
     end
 
     context "when a company name is too long" do


### PR DESCRIPTION
This change modifies the check for whether a company needs a `company_name` so that it is not dependent on whether or not the company already has a `registered_company_name`. It also moves the logic for checking whether to remove an existing `company_name` from the transient registration (to prevent form pre-population) from the controllers to the check_registered_company_name form.
https://eaflood.atlassian.net/browse/RUBY-1820