### PR TITLE
Set worldpay_url in Rails.configuration for specs involving worldpay_service

### DIFF
--- a/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
@@ -6,6 +6,7 @@ require "rails_helper"
 module WasteCarriersEngine
   RSpec.describe "WorldpayForms", type: :request do
     let(:host) { "https://secure-test.worldpay.com" }
+    before { allow(Rails.configuration).to receive(:worldpay_url).and_return(host) }
 
     context "when a valid user is signed in" do
       let(:user) { create(:user) }

--- a/spec/services/waste_carriers_engine/worldpay_service_spec.rb
+++ b/spec/services/waste_carriers_engine/worldpay_service_spec.rb
@@ -6,6 +6,7 @@ require "rails_helper"
 module WasteCarriersEngine
   RSpec.describe WorldpayService do
     let(:host) { "https://secure-test.worldpay.com" }
+    before { allow(Rails.configuration).to receive(:worldpay_url).and_return(host) }
 
     let(:transient_registration) do
       create(:renewing_registration,


### PR DESCRIPTION
This change resolves an issue where three Worldpay unit tests were failing when run under vagrant. The unit tests were not failing in other environments.
The fix is to align the `Rails.configuration` value for `worldpay_url` with the value set in the unit tests, removing the dependency on environment-specific configuration.
https://eaflood.atlassian.net/browse/RUBY-1764