### PR TITLE
Overseas renewals navigate to cbd-type form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ group :development do
   gem "spring"
   gem "spring-commands-rspec"
 
-  gem 'stateoscope', '~> 0.1.3', group: :development
+  gem "stateoscope", "~> 0.1.3", group: :development
 end
 
 group :production do

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,8 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem "spring"
   gem "spring-commands-rspec"
+
+  gem 'stateoscope', '~> 0.1.3', group: :development
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -367,6 +367,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (0.0.3)
       parser (>= 2.7.0.1)
+    ruby-graphviz (1.2.5)
+      rexml
     ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.5)
     sassc (2.4.0)
@@ -399,6 +401,9 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    stateoscope (0.1.3)
+      activesupport
+      ruby-graphviz
     thor (1.2.1)
     tilt (2.0.10)
     timecop (0.9.5)
@@ -462,6 +467,7 @@ DEPENDENCIES
   simplecov (~> 0.17.1)
   spring
   spring-commands-rspec
+  stateoscope (~> 0.1.3)
   timecop
   turbolinks
   vcr

--- a/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
@@ -80,6 +80,10 @@ module WasteCarriersEngine
                       if: :should_register_in_wales?
 
           transitions from: :location_form,
+                      to: :cbd_type_form,
+                      if: :based_overseas?
+
+          transitions from: :location_form,
                       to: :business_type_form
 
           transitions from: :register_in_northern_ireland_form,

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -74,9 +74,9 @@ module Dummy
     config.expires_after = ENV["WCRS_REGISTRATION_EXPIRES_AFTER"].to_i
     config.covid_grace_window = ENV["WCRS_REGISTRATION_COVID_GRACE_WINDOW"].to_i
     config.grace_window = ENV["WCRS_REGISTRATION_GRACE_WINDOW"].to_i
-    config.end_of_covid_extension = Date.new(ENV["WCRS_END_OF_COVID_EXTENSION_YEAR"].to_i,
-                                             ENV["WCRS_END_OF_COVID_EXTENSION_MONTH"].to_i,
-                                             ENV["WCRS_END_OF_COVID_EXTENSION_DAY"].to_i)
+    config.end_of_covid_extension = Date.new((ENV["WCRS_END_OF_COVID_EXTENSION_YEAR"]|| 2020).to_i,
+                                             (ENV["WCRS_END_OF_COVID_EXTENSION_MONTH"] || 10).to_i,
+                                             (ENV["WCRS_END_OF_COVID_EXTENSION_DAY"] || 1).to_i)
 
     # Worldpay
     config.worldpay_url = ENV["WCRS_WORLDPAY_URL"] || "https://secure-test.worldpay.com/jsp/merchant/xml/paymentService.jsp"

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/location_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/location_form_spec.rb
@@ -21,7 +21,7 @@ module WasteCarriersEngine
             "northern_ireland" => :register_in_northern_ireland_form,
             "scotland" => :register_in_scotland_form,
             "wales" => :register_in_wales_form,
-            "overseas" => :business_type_form
+            "overseas" => :cbd_type_form
           }.each do |location, expected_next_state|
             context "when the location is #{location}" do
               let(:location) { location }


### PR DESCRIPTION
This change adjusts the navigation for overseas businesses so that they navigate from the location form to the cbd-type form, and not to the business-type form as businesses in England do.
https://eaflood.atlassian.net/browse/RUBY-1851