### PR TITLE
Reset company-specific attributes when business type form is submitted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
       # Install various other dependencies
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install xvfb -y
           sudo apt-get install wkhtmltopdf -y
 

--- a/app/controllers/waste_carriers_engine/business_type_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/business_type_forms_controller.rb
@@ -7,6 +7,7 @@ module WasteCarriersEngine
     end
 
     def create
+      reset_business_type_attributes
       super(BusinessTypeForm, "business_type_form")
     end
 
@@ -14,6 +15,15 @@ module WasteCarriersEngine
 
     def transient_registration_attributes
       params.fetch(:business_type_form, {}).permit(:business_type, :token)
+    end
+
+    # Clear any previous business-type specific attributes to handle cases where the user 
+    # starts with one business type and then navigates back and changes the business type.
+    def reset_business_type_attributes
+      @transient_registration.company_no = nil
+      @transient_registration.registered_company_name = nil
+      @transient_registration.temp_use_registered_company_details = nil
+      @transient_registration.save!
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/business_type_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/business_type_forms_controller.rb
@@ -17,7 +17,7 @@ module WasteCarriersEngine
       params.fetch(:business_type_form, {}).permit(:business_type, :token)
     end
 
-    # Clear any previous business-type specific attributes to handle cases where the user 
+    # Clear any previous business-type specific attributes to handle cases where the user
     # starts with one business type and then navigates back and changes the business type.
     def reset_business_type_attributes
       @transient_registration.company_no = nil

--- a/spec/requests/waste_carriers_engine/business_type_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/business_type_forms_spec.rb
@@ -22,6 +22,26 @@ module WasteCarriersEngine
                          "business_type_form",
                          valid_params: { business_type: "limitedCompany" },
                          invalid_params: { business_type: "foo" }
+
+        # When the user starts with one business type then navigates back and changes the type
+        context "when the transient_registration already has limitedCompany attributes" do
+          before do
+            transient_registration.company_no = Faker::Number.number(digits: 8)
+            transient_registration.registered_company_name = Faker::Company.name
+            transient_registration.temp_use_registered_company_details = "yes"
+            transient_registration.save!
+          end
+
+          subject { post_form_with_params("business_type_form", transient_registration.token, { business_type: "soleTrader" }) }
+
+          it "removes the limitedCompany attributes" do
+            subject
+            transient_registration.reload
+            expect(transient_registration.company_no).to be_nil
+            expect(transient_registration.registered_company_name).to be_nil
+            expect(transient_registration.temp_use_registered_company_details).to be_nil
+          end
+        end
       end
     end
 


### PR DESCRIPTION
This change resolves an issue which arose when a user started the WCR registration journey using a company business type, entered some company details and then navigated back to the business type form and changed the business type to e.g. sole trader. The company attributes were still present on the transient registration and so were shown on the check-answers page even though they were no longer relevant.
The solution here is to clear the company-specific attributes whenever the business type form is submitted. This will have no effect the first time the form is submitted, but will remove the unnecessary attributes on any subsequent submissions.
https://eaflood.atlassian.net/browse/RUBY-1254 