### PR TITLE
Move the main people form before the company address forms

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
@@ -205,6 +205,10 @@ module WasteCarriersEngine
                       if: :overseas?
 
           transitions from: :company_name_form,
+                      to: :main_people_form,
+                      if: :upper_tier?
+
+          transitions from: :company_name_form,
                       to: :company_postcode_form
 
           # Registered address
@@ -225,19 +229,19 @@ module WasteCarriersEngine
                       if: :lower_tier?
 
           transitions from: :company_address_form,
-                      to: :main_people_form
+                      to: :declare_convictions_form
 
           transitions from: :company_address_manual_form,
                       to: :contact_name_form,
                       if: :lower_tier?
 
           transitions from: :company_address_manual_form,
-                      to: :main_people_form
+                      to: :declare_convictions_form
 
           # End registered address
 
           transitions from: :main_people_form,
-                      to: :declare_convictions_form
+                      to: :company_postcode_form
 
           transitions from: :declare_convictions_form,
                       to: :conviction_details_form,
@@ -473,6 +477,10 @@ module WasteCarriersEngine
           # Registered address
 
           transitions from: :company_postcode_form,
+                      to: :main_people_form,
+                      if: :upper_tier?
+
+          transitions from: :company_postcode_form,
                       to: :company_name_form
 
           transitions from: :company_address_form,
@@ -486,16 +494,16 @@ module WasteCarriersEngine
                       to: :company_postcode_form
 
           transitions from: :main_people_form,
-                      to: :company_address_manual_form,
-                      if: :registered_address_was_manually_entered?
-
-          transitions from: :main_people_form,
-                      to: :company_address_form
+                      to: :company_name_form
 
           # End registered address
 
           transitions from: :declare_convictions_form,
-                      to: :main_people_form
+                      to: :company_address_manual_form,
+                      if: :registered_address_was_manually_entered?
+
+          transitions from: :declare_convictions_form,
+                      to: :company_address_form
 
           transitions from: :conviction_details_form,
                       to: :declare_convictions_form

--- a/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
@@ -75,277 +75,211 @@ module WasteCarriersEngine
         # Transitions
         event :next do
           # Start
-          transitions from: :start_form,
-                      to: :location_form,
+          transitions from: :start_form, to: :location_form,
                       unless: :should_renew?
 
-          transitions from: :start_form,
-                      to: :renew_registration_form,
+          transitions from: :start_form, to: :renew_registration_form,
                       if: :should_renew?
 
           # Location
 
-          transitions from: :location_form,
-                      to: :register_in_northern_ireland_form,
+          transitions from: :location_form, to: :register_in_northern_ireland_form,
                       if: :should_register_in_northern_ireland?
 
-          transitions from: :location_form,
-                      to: :register_in_scotland_form,
+          transitions from: :location_form, to: :register_in_scotland_form,
                       if: :should_register_in_scotland?
 
-          transitions from: :location_form,
-                      to: :register_in_wales_form,
+          transitions from: :location_form, to: :register_in_wales_form,
                       if: :should_register_in_wales?
 
-          transitions from: :location_form,
-                      to: :check_your_tier_form,
+          transitions from: :location_form, to: :check_your_tier_form,
                       if: :overseas?
 
-          transitions from: :location_form,
-                      to: :business_type_form
+          transitions from: :location_form, to: :business_type_form
 
-          transitions from: :register_in_northern_ireland_form,
-                      to: :business_type_form
+          transitions from: :register_in_northern_ireland_form, to: :business_type_form
 
-          transitions from: :register_in_scotland_form,
-                      to: :business_type_form
+          transitions from: :register_in_scotland_form, to: :business_type_form
 
-          transitions from: :register_in_wales_form,
-                      to: :business_type_form
+          transitions from: :register_in_wales_form, to: :business_type_form
 
           # End location
 
-          transitions from: :business_type_form,
-                      to: :your_tier_form,
+          transitions from: :business_type_form, to: :your_tier_form,
                       if: :switch_to_lower_tier_based_on_business_type?,
                       after: :switch_to_lower_tier
 
-          transitions from: :business_type_form,
-                      to: :check_your_tier_form
+          transitions from: :business_type_form, to: :check_your_tier_form
 
-          transitions from: :check_your_tier_form,
-                      to: :other_businesses_form,
+          transitions from: :check_your_tier_form, to: :other_businesses_form,
                       if: :check_your_tier_unknown?
 
-          transitions from: :check_your_tier_form,
-                      to: :company_name_form,
+          transitions from: :check_your_tier_form, to: :company_name_form,
                       if: :check_your_tier_lower?,
                       after: :set_tier_from_check_your_tier_form
 
-          transitions from: :check_your_tier_form,
-                      to: :cbd_type_form,
+          transitions from: :check_your_tier_form, to: :cbd_type_form,
                       if: :check_your_tier_upper?,
                       after: :set_tier_from_check_your_tier_form
 
-          transitions from: :your_tier_form,
-                      to: :company_name_form,
+          transitions from: :your_tier_form, to: :company_name_form,
                       if: :lower_tier?
+
           # Smart answers
 
-          transitions from: :other_businesses_form,
-                      to: :construction_demolition_form,
+          transitions from: :other_businesses_form, to: :construction_demolition_form,
                       if: :only_carries_own_waste?
 
-          transitions from: :other_businesses_form,
-                      to: :service_provided_form
+          transitions from: :other_businesses_form, to: :service_provided_form
 
-          transitions from: :service_provided_form,
-                      to: :waste_types_form,
+          transitions from: :service_provided_form, to: :waste_types_form,
                       if: :waste_is_main_service?
 
-          transitions from: :service_provided_form,
-                      to: :construction_demolition_form
+          transitions from: :service_provided_form, to: :construction_demolition_form
 
-          transitions from: :waste_types_form,
-                      to: :your_tier_form,
+          transitions from: :waste_types_form, to: :your_tier_form,
                       if: :switch_to_lower_tier_based_on_smart_answers?,
                       after: :switch_to_lower_tier
 
-          transitions from: :waste_types_form,
-                      to: :your_tier_form,
+          transitions from: :waste_types_form, to: :your_tier_form,
                       after: :switch_to_upper_tier
 
-          transitions from: :your_tier_form,
-                      to: :cbd_type_form,
+          transitions from: :your_tier_form, to: :cbd_type_form,
                       if: :upper_tier?
 
-          transitions from: :construction_demolition_form,
-                      to: :your_tier_form,
+          transitions from: :construction_demolition_form, to: :your_tier_form,
                       if: :switch_to_lower_tier_based_on_smart_answers?,
                       after: :switch_to_lower_tier
 
-          transitions from: :construction_demolition_form,
-                      to: :your_tier_form,
+          transitions from: :construction_demolition_form, to: :your_tier_form,
                       after: :switch_to_upper_tier
 
           # End smart answers
 
-          transitions from: :cbd_type_form,
-                      to: :company_name_form,
+          transitions from: :cbd_type_form, to: :company_name_form,
                       if: :skip_registration_number?
 
-          transitions from: :cbd_type_form,
-                      to: :registration_number_form
+          transitions from: :cbd_type_form, to: :registration_number_form
 
-          transitions from: :registration_number_form,
-                      to: :check_registered_company_name_form
+          transitions from: :registration_number_form, to: :check_registered_company_name_form
 
-          transitions from: :check_registered_company_name_form,
-                      to: :incorrect_company_form,
+          transitions from: :check_registered_company_name_form, to: :incorrect_company_form,
                       if: :incorrect_company_data?
 
-          transitions from: :check_registered_company_name_form,
-                      to: :company_name_form
+          transitions from: :check_registered_company_name_form, to: :company_name_form
 
-          transitions from: :incorrect_company_form,
-                      to: :registration_number_form
+          transitions from: :incorrect_company_form, to: :registration_number_form
 
-          transitions from: :company_name_form,
-                      to: :company_address_manual_form,
+          transitions from: :company_name_form, to: :company_address_manual_form,
                       if: :overseas?
 
-          transitions from: :company_name_form,
-                      to: :main_people_form,
+          transitions from: :company_name_form, to: :main_people_form,
                       if: :upper_tier?
 
-          transitions from: :company_name_form,
-                      to: :company_postcode_form
+          transitions from: :company_name_form, to: :company_postcode_form
 
           # Registered address
 
-          transitions from: :company_postcode_form,
-                      to: :company_address_manual_form,
+          transitions from: :company_postcode_form, to: :company_address_manual_form,
                       if: :skip_to_manual_address?
 
-          transitions from: :company_postcode_form,
-                      to: :company_address_form
+          transitions from: :company_postcode_form, to: :company_address_form
 
-          transitions from: :company_address_form,
-                      to: :company_address_manual_form,
+          transitions from: :company_address_form, to: :company_address_manual_form,
                       if: :skip_to_manual_address?
 
-          transitions from: :company_address_form,
-                      to: :contact_name_form,
+          transitions from: :company_address_form, to: :contact_name_form,
                       if: :lower_tier?
 
-          transitions from: :company_address_form,
-                      to: :declare_convictions_form
+          transitions from: :company_address_form, to: :declare_convictions_form
 
-          transitions from: :company_address_manual_form,
-                      to: :contact_name_form,
+          transitions from: :company_address_manual_form, to: :contact_name_form,
                       if: :lower_tier?
 
-          transitions from: :company_address_manual_form,
-                      to: :declare_convictions_form
+          transitions from: :company_address_manual_form, to: :declare_convictions_form
 
           # End registered address
 
-          transitions from: :main_people_form,
-                      to: :company_postcode_form
+          transitions from: :main_people_form, to: :company_postcode_form
 
-          transitions from: :declare_convictions_form,
-                      to: :conviction_details_form,
+          transitions from: :declare_convictions_form, to: :conviction_details_form,
                       if: :declared_convictions?
 
-          transitions from: :declare_convictions_form,
-                      to: :contact_name_form
+          transitions from: :declare_convictions_form, to: :contact_name_form
 
-          transitions from: :conviction_details_form,
-                      to: :contact_name_form
+          transitions from: :conviction_details_form, to: :contact_name_form
 
-          transitions from: :contact_name_form,
-                      to: :contact_phone_form
+          transitions from: :contact_name_form, to: :contact_phone_form
 
-          transitions from: :contact_phone_form,
-                      to: :contact_email_form
+          transitions from: :contact_phone_form, to: :contact_email_form
 
-          transitions from: :contact_email_form,
-                      to: :contact_address_reuse_form
+          transitions from: :contact_email_form, to: :contact_address_reuse_form
 
-          transitions from: :contact_email_form,
-                      to: :contact_postcode_form
+          transitions from: :contact_email_form, to: :contact_postcode_form
 
           # Contact address
 
-          transitions from: :contact_address_reuse_form,
-                      to: :check_your_answers_form,
+          transitions from: :contact_address_reuse_form, to: :check_your_answers_form,
                       if: :reuse_registered_address?,
                       after: :set_contact_address_as_registered_address
 
-          transitions from: :contact_address_reuse_form,
-                      to: :contact_address_manual_form,
+          transitions from: :contact_address_reuse_form, to: :contact_address_manual_form,
                       unless: :reuse_registered_address?,
                       if: :overseas?
 
-          transitions from: :contact_address_reuse_form,
-                      to: :contact_postcode_form,
+          transitions from: :contact_address_reuse_form, to: :contact_postcode_form,
                       unless: :reuse_registered_address?
 
-          transitions from: :contact_postcode_form,
-                      to: :contact_address_manual_form,
+          transitions from: :contact_postcode_form, to: :contact_address_manual_form,
                       if: :skip_to_manual_address?
 
-          transitions from: :contact_postcode_form,
-                      to: :contact_address_form
+          transitions from: :contact_postcode_form, to: :contact_address_form
 
-          transitions from: :contact_address_form,
-                      to: :contact_address_manual_form,
+          transitions from: :contact_address_form, to: :contact_address_manual_form,
                       if: :skip_to_manual_address?
 
-          transitions from: :contact_address_form,
-                      to: :check_your_answers_form
+          transitions from: :contact_address_form, to: :check_your_answers_form
 
-          transitions from: :contact_address_manual_form,
-                      to: :check_your_answers_form
+          transitions from: :contact_address_manual_form, to: :check_your_answers_form
 
           # End contact address
 
-          transitions from: :check_your_answers_form,
-                      to: :declaration_form
+          transitions from: :check_your_answers_form, to: :declaration_form
 
-          transitions from: :declaration_form,
-                      to: :registration_completed_form,
+          transitions from: :declaration_form, to: :registration_completed_form,
                       if: :lower_tier?,
                       # TODO: This don't get triggered if in the `success`
                       # callback block, hence we went for `after`
                       after: :set_metadata_route
 
-          transitions from: :declaration_form,
-                      to: :cards_form
+          transitions from: :declaration_form, to: :cards_form
 
-          transitions from: :cards_form,
-                      to: :payment_summary_form
+          transitions from: :cards_form, to: :payment_summary_form
 
-          transitions from: :payment_summary_form,
-                      to: :worldpay_form,
+          transitions from: :payment_summary_form, to: :worldpay_form,
                       if: :paying_by_card?
 
-          transitions from: :payment_summary_form,
-                      to: :confirm_bank_transfer_form
+          transitions from: :payment_summary_form, to: :confirm_bank_transfer_form
 
           # Registration completion forms
-          transitions from: :confirm_bank_transfer_form,
-                      to: :registration_received_pending_payment_form,
+          transitions from: :confirm_bank_transfer_form, to: :registration_received_pending_payment_form,
                       # TODO: This don't get triggered if in the `success`
                       # callback block, hence we went for `after`
                       after: :set_metadata_route
 
           transitions from: :worldpay_form,
-                      to: :registration_received_pending_worldpay_payment_form,
-                      if: :pending_worldpay_payment?,
+                      to: :registration_received_pending_worldpay_payment_form, if: :pending_worldpay_payment?,
                       # TODO: This don't get triggered if in the `success`
                       # callback block, hence we went for `after`
                       after: :set_metadata_route
 
           transitions from: :worldpay_form,
-                      to: :registration_received_pending_conviction_form,
-                      if: :conviction_check_required?,
+                      to: :registration_received_pending_conviction_form, if: :conviction_check_required?,
                       # TODO: This don't get triggered if in the `success`
                       # callback block, hence we went for `after`
                       after: :set_metadata_route
 
-          transitions from: :worldpay_form,
-                      to: :registration_completed_form,
+          transitions from: :worldpay_form, to: :registration_completed_form,
                       # TODO: This don't get triggered if in the `success`
                       # callback block, hence we went for `after`
                       after: :set_metadata_route
@@ -353,244 +287,178 @@ module WasteCarriersEngine
 
         # Transitions
         event :back do
-          transitions from: :location_form,
-                      to: :start_form
+          transitions from: :location_form, to: :start_form
 
-          transitions from: :renew_registration_form,
-                      to: :start_form
+          transitions from: :renew_registration_form, to: :start_form
 
           # Location
 
-          transitions from: :location_form,
-                      to: :renewal_start_form
+          transitions from: :location_form, to: :renewal_start_form
 
-          transitions from: :register_in_northern_ireland_form,
-                      to: :location_form
+          transitions from: :register_in_northern_ireland_form, to: :location_form
 
-          transitions from: :register_in_scotland_form,
-                      to: :location_form
+          transitions from: :register_in_scotland_form, to: :location_form
 
-          transitions from: :register_in_wales_form,
-                      to: :location_form
+          transitions from: :register_in_wales_form, to: :location_form
 
           # End location
 
-          transitions from: :business_type_form,
-                      to: :register_in_northern_ireland_form,
+          transitions from: :business_type_form, to: :register_in_northern_ireland_form,
                       if: :should_register_in_northern_ireland?
 
-          transitions from: :business_type_form,
-                      to: :register_in_scotland_form,
+          transitions from: :business_type_form, to: :register_in_scotland_form,
                       if: :should_register_in_scotland?
 
-          transitions from: :business_type_form,
-                      to: :register_in_wales_form,
+          transitions from: :business_type_form, to: :register_in_wales_form,
                       if: :should_register_in_wales?
 
-          transitions from: :business_type_form,
-                      to: :location_form
+          transitions from: :business_type_form, to: :location_form
 
-          transitions from: :check_your_tier_form,
-                      to: :location_form,
+          transitions from: :check_your_tier_form, to: :location_form,
                       if: :overseas?
 
-          transitions from: :check_your_tier_form,
-                      to: :business_type_form
+          transitions from: :check_your_tier_form, to: :business_type_form
 
           # Smart answers
-          transitions from: :company_name_form,
-                      to: :check_your_tier_form,
+          transitions from: :company_name_form, to: :check_your_tier_form,
                       if: :check_your_tier_lower?
 
-          transitions from: :company_name_form,
-                      to: :your_tier_form,
+          transitions from: :company_name_form, to: :your_tier_form,
                       if: :lower_tier?
 
-          transitions from: :your_tier_form,
-                      to: :business_type_form,
+          transitions from: :your_tier_form, to: :business_type_form,
                       if: :switch_to_lower_tier_based_on_business_type?
 
-          transitions from: :your_tier_form,
-                      to: :check_your_tier_form,
+          transitions from: :your_tier_form, to: :check_your_tier_form,
                       unless: :check_your_tier_unknown?
 
-          transitions from: :your_tier_form,
-                      to: :construction_demolition_form,
+          transitions from: :your_tier_form, to: :construction_demolition_form,
                       if: %i[lower_tier? only_carries_own_waste?]
 
-          transitions from: :your_tier_form,
-                      to: :waste_types_form,
+          transitions from: :your_tier_form, to: :waste_types_form,
                       if: %i[lower_tier? waste_is_main_service?]
 
-          transitions from: :your_tier_form,
-                      to: :construction_demolition_form,
+          transitions from: :your_tier_form, to: :construction_demolition_form,
                       if: %i[lower_tier?]
 
-          transitions from: :company_name_form,
-                      to: :cbd_type_form,
+          transitions from: :company_name_form, to: :cbd_type_form,
                       if: :skip_registration_number?
 
-          transitions from: :company_name_form,
-                      to: :check_registered_company_name_form
+          transitions from: :company_name_form, to: :check_registered_company_name_form
 
-          transitions from: :check_registered_company_name_form,
-                      to: :registration_number_form
+          transitions from: :check_registered_company_name_form, to: :registration_number_form
 
-          transitions from: :incorrect_company_form,
-                      to: :check_registered_company_name_form
+          transitions from: :incorrect_company_form, to: :check_registered_company_name_form
 
-          transitions from: :other_businesses_form,
-                      to: :check_your_tier_form
+          transitions from: :other_businesses_form, to: :check_your_tier_form
 
-          transitions from: :service_provided_form,
-                      to: :other_businesses_form
+          transitions from: :service_provided_form, to: :other_businesses_form
 
-          transitions from: :waste_types_form,
-                      to: :service_provided_form
+          transitions from: :waste_types_form, to: :service_provided_form
 
-          transitions from: :construction_demolition_form,
-                      to: :other_businesses_form,
+          transitions from: :construction_demolition_form, to: :other_businesses_form,
                       if: :only_carries_own_waste?
 
-          transitions from: :construction_demolition_form,
-                      to: :service_provided_form
+          transitions from: :construction_demolition_form, to: :service_provided_form
 
-          transitions from: :cbd_type_form,
-                      to: :check_your_tier_form,
+          transitions from: :cbd_type_form, to: :check_your_tier_form,
                       if: :check_your_tier_upper?
 
-          transitions from: :cbd_type_form,
-                      to: :your_tier_form
+          transitions from: :cbd_type_form, to: :your_tier_form
 
-          transitions from: :your_tier_form,
-                      to: :waste_types_form,
+          transitions from: :your_tier_form, to: :waste_types_form,
                       if: :not_only_amf?
 
-          transitions from: :your_tier_form,
-                      to: :construction_demolition_form
+          transitions from: :your_tier_form, to: :construction_demolition_form
 
           # End smart answers
 
-          transitions from: :registration_number_form,
-                      to: :cbd_type_form
+          transitions from: :registration_number_form, to: :cbd_type_form
 
           # Registered address
 
-          transitions from: :company_postcode_form,
-                      to: :main_people_form,
+          transitions from: :company_postcode_form, to: :main_people_form,
                       if: :upper_tier?
 
-          transitions from: :company_postcode_form,
-                      to: :company_name_form
+          transitions from: :company_postcode_form, to: :company_name_form
 
-          transitions from: :company_address_form,
-                      to: :company_postcode_form
+          transitions from: :company_address_form, to: :company_postcode_form
 
-          transitions from: :company_address_manual_form,
-                      to: :company_name_form,
+          transitions from: :company_address_manual_form, to: :company_name_form,
                       if: :overseas?
 
-          transitions from: :company_address_manual_form,
-                      to: :company_postcode_form
+          transitions from: :company_address_manual_form, to: :company_postcode_form
 
-          transitions from: :main_people_form,
-                      to: :company_name_form
+          transitions from: :main_people_form, to: :company_name_form
 
           # End registered address
 
-          transitions from: :declare_convictions_form,
-                      to: :company_address_manual_form,
+          transitions from: :declare_convictions_form, to: :company_address_manual_form,
                       if: :registered_address_was_manually_entered?
 
-          transitions from: :declare_convictions_form,
-                      to: :company_address_form
+          transitions from: :declare_convictions_form, to: :company_address_form
 
-          transitions from: :conviction_details_form,
-                      to: :declare_convictions_form
+          transitions from: :conviction_details_form, to: :declare_convictions_form
 
-          transitions from: :contact_name_form,
-                      to: :company_address_manual_form,
+          transitions from: :contact_name_form, to: :company_address_manual_form,
                       if: %i[lower_tier? registered_address_was_manually_entered?]
 
-          transitions from: :contact_name_form,
-                      to: :company_address_form,
+          transitions from: :contact_name_form, to: :company_address_form,
                       if: :lower_tier?
 
-          transitions from: :contact_name_form,
-                      to: :conviction_details_form,
+          transitions from: :contact_name_form, to: :conviction_details_form,
                       if: :declared_convictions?
 
-          transitions from: :contact_name_form,
-                      to: :declare_convictions_form
+          transitions from: :contact_name_form, to: :declare_convictions_form
 
-          transitions from: :contact_phone_form,
-                      to: :contact_name_form
+          transitions from: :contact_phone_form, to: :contact_name_form
 
-          transitions from: :contact_email_form,
-                      to: :contact_phone_form
+          transitions from: :contact_email_form, to: :contact_phone_form
 
           # Contact address
 
-          transitions from: :contact_address_reuse_form,
-                      to: :contact_email_form
+          transitions from: :contact_address_reuse_form, to: :contact_email_form
 
-          transitions from: :contact_postcode_form,
-                      to: :contact_address_reuse_form
+          transitions from: :contact_postcode_form, to: :contact_address_reuse_form
 
-          transitions from: :contact_postcode_form,
-                      to: :contact_email_form
+          transitions from: :contact_postcode_form, to: :contact_email_form
 
-          transitions from: :contact_address_form,
-                      to: :contact_postcode_form
+          transitions from: :contact_address_form, to: :contact_postcode_form
 
-          transitions from: :contact_address_manual_form,
-                      to: :contact_address_reuse_form,
+          transitions from: :contact_address_manual_form, to: :contact_address_reuse_form,
                       if: :overseas?
 
-          transitions from: :contact_address_manual_form,
-                      to: :contact_postcode_form
+          transitions from: :contact_address_manual_form, to: :contact_postcode_form
 
-          transitions from: :check_your_answers_form,
-                      to: :contact_address_manual_form,
+          transitions from: :check_your_answers_form, to: :contact_address_manual_form,
                       if: :contact_address_was_manually_entered?
 
-          transitions from: :check_your_answers_form,
-                      to: :contact_address_reuse_form,
+          transitions from: :check_your_answers_form, to: :contact_address_reuse_form,
                       if: :reuse_registered_address?
 
-          transitions from: :check_your_answers_form,
-                      to: :contact_address_form
+          transitions from: :check_your_answers_form, to: :contact_address_form
 
           # End contact address
 
-          transitions from: :declaration_form,
-                      to: :check_your_answers_form
+          transitions from: :declaration_form, to: :check_your_answers_form
 
-          transitions from: :cards_form,
-                      to: :declaration_form
+          transitions from: :cards_form, to: :declaration_form
 
-          transitions from: :payment_summary_form,
-                      to: :cards_form
+          transitions from: :payment_summary_form, to: :cards_form
 
-          transitions from: :worldpay_form,
-                      to: :payment_summary_form
+          transitions from: :worldpay_form, to: :payment_summary_form
 
-          transitions from: :confirm_bank_transfer_form,
-                      to: :payment_summary_form
+          transitions from: :confirm_bank_transfer_form, to: :payment_summary_form
         end
 
         event :skip_to_manual_address do
-          transitions from: :company_postcode_form,
-                      to: :company_address_manual_form
+          transitions from: :company_postcode_form, to: :company_address_manual_form
 
-          transitions from: :company_address_form,
-                      to: :company_address_manual_form
+          transitions from: :company_address_form, to: :company_address_manual_form
 
-          transitions from: :contact_postcode_form,
-                      to: :contact_address_manual_form
+          transitions from: :contact_postcode_form, to: :contact_address_manual_form
 
-          transitions from: :contact_address_form,
-                      to: :contact_address_manual_form
+          transitions from: :contact_address_form, to: :contact_address_manual_form
         end
       end
 

--- a/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
@@ -129,6 +129,10 @@ module WasteCarriersEngine
                       if: :based_overseas?
 
           transitions from: :company_name_form,
+                      to: :main_people_form,
+                      if: :upper_tier?
+
+          transitions from: :company_name_form,
                       to: :company_postcode_form
 
           # Registered address
@@ -145,15 +149,23 @@ module WasteCarriersEngine
                       if: :skip_to_manual_address?
 
           transitions from: :company_address_form,
-                      to: :main_people_form
+                      to: :contact_name_form,
+                      if: :lower_tier?
+
+          transitions from: :company_address_form,
+                      to: :declare_convictions_form
 
           transitions from: :company_address_manual_form,
-                      to: :main_people_form
+                      to: :contact_name_form,
+                      if: :lower_tier?
+
+          transitions from: :company_address_manual_form,
+                      to: :declare_convictions_form
 
           # End registered address
 
           transitions from: :main_people_form,
-                      to: :declare_convictions_form
+                      to: :company_postcode_form
 
           transitions from: :declare_convictions_form,
                       to: :conviction_details_form,
@@ -310,6 +322,10 @@ module WasteCarriersEngine
           # Registered address
 
           transitions from: :company_postcode_form,
+                      to: :main_people_form,
+                      if: :upper_tier?
+
+          transitions from: :company_postcode_form,
                       to: :company_name_form
 
           transitions from: :company_address_form,
@@ -323,16 +339,16 @@ module WasteCarriersEngine
                       to: :company_postcode_form
 
           transitions from: :main_people_form,
-                      to: :company_address_manual_form,
-                      if: :registered_address_was_manually_entered?
-
-          transitions from: :main_people_form,
-                      to: :company_address_form
+                      to: :company_name_form
 
           # End registered address
 
           transitions from: :declare_convictions_form,
-                      to: :main_people_form
+                      to: :company_address_manual_form,
+                      if: :registered_address_was_manually_entered?
+
+          transitions from: :declare_convictions_form,
+                      to: :company_address_form
 
           transitions from: :conviction_details_form,
                       to: :declare_convictions_form

--- a/spec/models/waste_carriers_engine/new_registration_workflow/company_address_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/company_address_form_spec.rb
@@ -4,15 +4,34 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe NewRegistration do
-    it_behaves_like "an address lookup transition",
-                    next_state_if_not_skipping_to_manual: :main_people_form,
-                    address_type: "company",
-                    factory: :new_registration
+    context "when the registration is upper tier" do
+      let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
+
+      it_behaves_like "an address lookup transition",
+                      next_state_if_not_skipping_to_manual: :declare_convictions_form,
+                      address_type: "company",
+                      factory: :new_registration
+    end
+
+    context "when the registration is lower_tier" do
+      let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
+
+      it_behaves_like "an address lookup transition",
+                      next_state_if_not_skipping_to_manual: :contact_name_form,
+                      address_type: "company",
+                      factory: :new_registration
+    end
 
     describe "#workflow_state" do
       context ":company_address_form state transitions" do
         context "on next" do
-          context "when the registration is a lower tier" do
+          context "when the registration is upper tier" do
+            subject { build(:new_registration, :upper, workflow_state: "company_address_form") }
+
+            include_examples "has next transition", next_state: "declare_convictions_form"
+          end
+
+          context "when the registration is lower tier" do
             subject { build(:new_registration, :lower, workflow_state: "company_address_form") }
 
             include_examples "has next transition", next_state: "contact_name_form"

--- a/spec/models/waste_carriers_engine/new_registration_workflow/company_address_manual_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/company_address_manual_form_spec.rb
@@ -5,11 +5,25 @@ require "rails_helper"
 module WasteCarriersEngine
   RSpec.describe NewRegistration do
     describe "#workflow_state" do
-      it_behaves_like "a manual address transition",
-                      previous_state_if_overseas: :company_name_form,
-                      next_state: :main_people_form,
-                      address_type: "company",
-                      factory: :new_registration
+      context "when the registration is upper tier" do
+        let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
+
+        it_behaves_like "a manual address transition",
+                        previous_state_if_overseas: :company_name_form,
+                        next_state: :declare_convictions_form,
+                        address_type: "company",
+                        factory: :new_registration
+      end
+
+      context "when the registration is lower tier" do
+        let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
+
+        it_behaves_like "a manual address transition",
+                        previous_state_if_overseas: :company_name_form,
+                        next_state: :contact_name_form,
+                        address_type: "company",
+                        factory: :new_registration
+      end
 
       describe "#workflow_state" do
         context ":company_address_manual_form state transitions" do

--- a/spec/models/waste_carriers_engine/new_registration_workflow/company_name_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/company_name_form_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe NewRegistration do
-    subject { build(:new_registration, workflow_state: "company_name_form") }
+    subject { build(:new_registration, workflow_state: "company_name_form", tier: tier) }
 
     describe "#workflow_state" do
       context ":company_name_form state transitions" do
@@ -15,7 +15,15 @@ module WasteCarriersEngine
             include_examples "has next transition", next_state: "company_address_manual_form"
           end
 
-          include_examples "has next transition", next_state: "company_postcode_form"
+          context "when the registration is upper tier" do
+            let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
+            include_examples "has next transition", next_state: "main_people_form"
+          end
+
+          context "when the registration is lower tier" do
+            let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
+            include_examples "has next transition", next_state: "company_postcode_form"
+          end
         end
 
         context "on back" do

--- a/spec/models/waste_carriers_engine/new_registration_workflow/company_postcode_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/company_postcode_form_spec.rb
@@ -5,10 +5,24 @@ require "rails_helper"
 module WasteCarriersEngine
   RSpec.describe NewRegistration do
     describe "#workflow_state" do
-      it_behaves_like "a postcode transition",
-                      previous_state: :company_name_form,
-                      address_type: "company",
-                      factory: :new_registration
+
+      context "when the registration is upper tier" do
+        let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
+
+        it_behaves_like "a postcode transition",
+                        previous_state: :main_people_form,
+                        address_type: "company",
+                        factory: :new_registration
+      end
+
+      context "when the registration is lower tier" do
+        let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
+
+        it_behaves_like "a postcode transition",
+                        previous_state: :company_name_form,
+                        address_type: "company",
+                        factory: :new_registration
+      end
     end
   end
 end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/declare_convictions_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/declare_convictions_form_spec.rb
@@ -19,7 +19,14 @@ module WasteCarriersEngine
         end
 
         context "on back" do
-          include_examples "has back transition", previous_state: "main_people_form"
+          context "when the registered address was manually entered" do
+            let(:registered_address) { build(:address, :registered, :manual_foreign) }
+            subject { build(:new_registration, workflow_state: "declare_convictions_form", registered_address: registered_address) }
+
+            include_examples "has back transition", previous_state: "company_address_manual_form"
+          end
+
+          include_examples "has back transition", previous_state: "company_address_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/main_people_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/main_people_form_spec.rb
@@ -9,18 +9,11 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":main_people_form state transitions" do
         context "on next" do
-          include_examples "has next transition", next_state: "declare_convictions_form"
+          include_examples "has next transition", next_state: "company_postcode_form"
         end
 
         context "on back" do
-          context "when the registered address was manually entered" do
-            let(:registered_address) { build(:address, :registered, :manual_foreign) }
-            subject { build(:new_registration, workflow_state: "main_people_form", registered_address: registered_address) }
-
-            include_examples "has back transition", previous_state: "company_address_manual_form"
-          end
-
-          include_examples "has back transition", previous_state: "company_address_form"
+          include_examples "has back transition", previous_state: "company_name_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/company_address_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/company_address_form_spec.rb
@@ -4,9 +4,40 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe RenewingRegistration do
-    it_behaves_like "an address lookup transition",
-                    next_state_if_not_skipping_to_manual: :main_people_form,
-                    address_type: "company",
-                    factory: :renewing_registration
+    context "when the registration is upper tier" do
+      let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
+
+      it_behaves_like "an address lookup transition",
+                      next_state_if_not_skipping_to_manual: :declare_convictions_form,
+                      address_type: "company",
+                      factory: :renewing_registration
+    end
+
+    context "when the registration is lower tier" do
+      let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
+
+      it_behaves_like "an address lookup transition",
+                      next_state_if_not_skipping_to_manual: :contact_name_form,
+                      address_type: "company",
+                      factory: :renewing_registration
+    end
+
+    describe "#workflow_state" do
+      context ":company_address_form state transitions" do
+        context "on next" do
+          context "when the registration is upper tier" do
+            subject { build(:renewing_registration, tier: "UPPER", workflow_state: "company_address_form") }
+
+            include_examples "has next transition", next_state: "declare_convictions_form"
+          end
+
+          context "when the registration is lower tier" do
+            subject { build(:renewing_registration, tier: "LOWER", workflow_state: "company_address_form") }
+
+            include_examples "has next transition", next_state: "contact_name_form"
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/company_address_manual_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/company_address_manual_form_spec.rb
@@ -5,11 +5,25 @@ require "rails_helper"
 module WasteCarriersEngine
   RSpec.describe RenewingRegistration do
     describe "#workflow_state" do
-      it_behaves_like "a manual address transition",
-                      previous_state_if_overseas: :company_name_form,
-                      next_state: :main_people_form,
-                      address_type: "company",
-                      factory: :renewing_registration
+      context "when the registration is upper tier" do
+        let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
+
+        it_behaves_like "a manual address transition",
+                        previous_state_if_overseas: :company_name_form,
+                        next_state: :declare_convictions_form,
+                        address_type: "company",
+                        factory: :renewing_registration
+      end
+
+      context "when the registration is lower tier" do
+        let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
+
+        it_behaves_like "a manual address transition",
+                        previous_state_if_overseas: :company_name_form,
+                        next_state: :contact_name_form,
+                        address_type: "company",
+                        factory: :renewing_registration
+      end
     end
   end
 end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/company_name_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/company_name_form_spec.rb
@@ -9,15 +9,25 @@ module WasteCarriersEngine
             :has_required_data,
             business_type: business_type,
             location: location,
+            tier: tier,
             workflow_state: "company_name_form")
     end
+    let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
     let(:location) { "england" }
     let(:business_type) { "soleTrader" }
 
     describe "#workflow_state" do
       context ":company_name_form state transitions" do
         context "on next" do
-          include_examples "has next transition", next_state: "company_postcode_form"
+          context "when the registraton is upper tier" do
+            let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
+            include_examples "has next transition", next_state: "main_people_form"
+          end
+
+          context "when the registration is lower tier" do
+            let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
+            include_examples "has next transition", next_state: "company_postcode_form"
+          end
 
           context "when the location is overseas" do
             let(:location) { "overseas" }

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/company_postcode_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/company_postcode_form_spec.rb
@@ -5,10 +5,24 @@ require "rails_helper"
 module WasteCarriersEngine
   RSpec.describe RenewingRegistration do
     describe "#workflow_state" do
-      it_behaves_like "a postcode transition",
-                      previous_state: :company_name_form,
-                      address_type: "company",
-                      factory: :renewing_registration
+
+      context "when the registration is upper tier" do
+        let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
+
+        it_behaves_like "a postcode transition",
+                        previous_state: :main_people_form,
+                        address_type: "company",
+                        factory: :renewing_registration
+      end
+
+      context "when the registration is lower tier" do
+        let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
+
+        it_behaves_like "a postcode transition",
+                        previous_state: :company_name_form,
+                        address_type: "company",
+                        factory: :renewing_registration
+      end
     end
   end
 end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/declare_convictions_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/declare_convictions_form_spec.rb
@@ -30,7 +30,14 @@ module WasteCarriersEngine
         end
 
         context "on back" do
-          include_examples "has back transition", previous_state: "main_people_form"
+          context "when the registered address was manually entered" do
+            let(:registered_address) { build(:address, :registered, :manual_foreign) }
+            subject { build(:renewing_registration, workflow_state: "declare_convictions_form", registered_address: registered_address) }
+
+            include_examples "has back transition", previous_state: "company_address_manual_form"
+          end
+
+          include_examples "has back transition", previous_state: "company_address_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/main_people_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/main_people_form_spec.rb
@@ -15,21 +15,11 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":main_people_form state transitions" do
         context "on next" do
-          include_examples "has next transition", next_state: "declare_convictions_form"
+          include_examples "has next transition", next_state: "company_postcode_form"
         end
 
         context "on back" do
-          context "when the registered address was selected from OS Places" do
-            let(:addresses) { [build(:address, :registered, :from_os_places)] }
-
-            include_examples "has back transition", previous_state: "company_address_form"
-          end
-
-          context "when the registered address was entered manually" do
-            let(:addresses) { [build(:address, :registered, :manual_uk)] }
-
-            include_examples "has back transition", previous_state: "company_address_manual_form"
-          end
+          include_examples "has back transition", previous_state: "company_name_form"
         end
       end
     end

--- a/spec/requests/waste_carriers_engine/company_address_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/company_address_forms_spec.rb
@@ -18,11 +18,13 @@ module WasteCarriersEngine
         end
 
         context "when a valid transient registration exists" do
+          let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
           let(:transient_registration) do
             create(:renewing_registration,
                    :has_required_data,
                    :has_postcode,
                    account_email: user.email,
+                   tier: tier,
                    workflow_state: "company_address_form")
           end
 
@@ -36,12 +38,31 @@ module WasteCarriersEngine
               }
             end
 
-            it "updates the transient registration, returns a 302 response and redirects to the main_people form" do
+            it "updates the transient registration and returns a 302 response" do
               post company_address_forms_path(transient_registration.token), params: { company_address_form: valid_params }
 
               expect(transient_registration.reload.company_address.uprn.to_s).to eq("340116")
               expect(response).to have_http_status(302)
-              expect(response).to redirect_to(new_main_people_form_path(transient_registration[:token]))
+            end
+
+            context "when the registration is upper tier" do
+              let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
+
+              it "redirects to the declare_convictions form" do
+                post company_address_forms_path(transient_registration.token), params: { company_address_form: valid_params }
+
+                expect(response).to redirect_to(new_declare_convictions_form_path(transient_registration[:token]))
+              end
+            end
+
+            context "when the registration is lower tier" do
+              let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
+
+              it "redirects to the contact_name form" do
+                post company_address_forms_path(transient_registration.token), params: { company_address_form: valid_params }
+
+                expect(response).to redirect_to(new_contact_name_form_path(transient_registration[:token]))
+              end
             end
 
             context "when the transient registration already has addresses" do

--- a/spec/requests/waste_carriers_engine/company_postcode_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/company_postcode_forms_spec.rb
@@ -91,18 +91,37 @@ module WasteCarriersEngine
         end
 
         context "when a valid transient registration exists" do
+          let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
           let(:transient_registration) do
             create(:renewing_registration,
                    :has_required_data,
                    account_email: user.email,
+                   tier: tier,
                    workflow_state: "company_postcode_form")
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response and redirects to the company_name form" do
+            it "returns a 302 response" do
               get back_company_postcode_forms_path(transient_registration[:token])
 
               expect(response).to have_http_status(302)
+            end
+          end
+
+          context "when the registration is upper tier" do
+            let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
+            it "redirects to the main_people form" do
+              get back_company_postcode_forms_path(transient_registration[:token])
+
+              expect(response).to redirect_to(new_main_people_form_path(transient_registration[:token]))
+            end
+          end
+
+          context "when the registration is lower tier" do
+            let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
+            it "redirects to the company_name form" do
+              get back_company_postcode_forms_path(transient_registration[:token])
+
               expect(response).to redirect_to(new_company_name_form_path(transient_registration[:token]))
             end
           end

--- a/spec/requests/waste_carriers_engine/declare_convictions_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/declare_convictions_forms_spec.rb
@@ -41,11 +41,11 @@ module WasteCarriersEngine
           end
 
           context "when the back action is triggered" do
-            it "returns a 302 response and redirects to the main_people form" do
+            it "returns a 302 response and redirects to the company_address form" do
               get back_declare_convictions_forms_path(transient_registration[:token])
 
               expect(response).to have_http_status(302)
-              expect(response).to redirect_to(new_main_people_form_path(transient_registration[:token]))
+              expect(response).to redirect_to(new_company_address_form_path(transient_registration[:token]))
             end
           end
         end

--- a/spec/requests/waste_carriers_engine/main_people_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/main_people_forms_spec.rb
@@ -32,7 +32,7 @@ module WasteCarriersEngine
               }
             end
 
-            it "correctly updates the key people, returns a 302 response and redirects to the declare_convictions form" do
+            it "correctly updates the key people, returns a 302 response and redirects to the company_postcode form" do
               key_people_count = transient_registration.key_people.count
 
               post main_people_forms_path(transient_registration.token), params: { main_people_form: valid_params }
@@ -40,7 +40,7 @@ module WasteCarriersEngine
               expect(transient_registration.reload.key_people.count).to eq(key_people_count + 1)
               expect(transient_registration.reload.key_people.last.first_name).to eq(valid_params[:first_name])
               expect(response).to have_http_status(302)
-              expect(response).to redirect_to(new_declare_convictions_form_path(transient_registration[:token]))
+              expect(response).to redirect_to(new_company_postcode_form_path(transient_registration[:token]))
             end
 
             context "when there is already a main person" do
@@ -217,22 +217,9 @@ module WasteCarriersEngine
               expect(response).to have_http_status(302)
             end
 
-            context "when the address was selected from OS places" do
-              before(:each) { transient_registration.update_attributes(addresses: [build(:address, :registered, :from_os_places)]) }
-
-              it "redirects to the company_address form" do
-                get back_main_people_forms_path(transient_registration[:token])
-                expect(response).to redirect_to(new_company_address_form_path(transient_registration[:token]))
-              end
-            end
-
-            context "when the address was manually entered" do
-              before(:each) { transient_registration.update_attributes(addresses: [build(:address, :registered, :manual_uk)]) }
-
-              it "redirects to the company_address_manual form" do
-                get back_main_people_forms_path(transient_registration[:token])
-                expect(response).to redirect_to(new_company_address_manual_form_path(transient_registration[:token]))
-              end
+            it "redirects to the company_name form" do
+              get back_main_people_forms_path(transient_registration[:token])
+              expect(response).to redirect_to(new_company_name_form_path(transient_registration[:token]))
             end
           end
         end

--- a/spec/support/shared_examples/workflow_states/a_manual_address_transition.rb
+++ b/spec/support/shared_examples/workflow_states/a_manual_address_transition.rb
@@ -3,7 +3,10 @@
 RSpec.shared_examples "a manual address transition" do |previous_state_if_overseas:, next_state:, address_type:, factory:|
   describe "#workflow_state" do
     current_state = "#{address_type}_address_manual_form".to_sym
-    subject { build(factory, workflow_state: current_state, location: location) }
+    subject do
+      build(factory, workflow_state: current_state, location: location,
+                     tier: defined?(tier) ? tier : WasteCarriersEngine::Registration::UPPER_TIER)
+    end
 
     context "when subject.overseas? is false" do
       previous_state_if_uk = "#{address_type}_postcode_form".to_sym

--- a/spec/support/shared_examples/workflow_states/a_postcode_transition.rb
+++ b/spec/support/shared_examples/workflow_states/a_postcode_transition.rb
@@ -3,7 +3,10 @@
 RSpec.shared_examples "a postcode transition" do |previous_state:, address_type:, factory:|
   describe "#workflow_state" do
     current_state = "#{address_type}_postcode_form".to_sym
-    subject(:subject) { create(factory, workflow_state: current_state) }
+    subject(:subject) do
+      create(factory, workflow_state: current_state,
+                      tier: defined?(tier) ? tier : WasteCarriersEngine::Registration::UPPER_TIER)
+    end
 
     context "when subject.skip_to_manual_address? is false" do
       next_state = "#{address_type}_address_form".to_sym

--- a/spec/support/shared_examples/workflow_states/an_address_lookup_transition.rb
+++ b/spec/support/shared_examples/workflow_states/an_address_lookup_transition.rb
@@ -4,7 +4,10 @@ RSpec.shared_examples "an address lookup transition" do |next_state_if_not_skipp
   describe "#workflow_state" do
     previous_state = "#{address_type}_postcode_form".to_sym
     current_state = "#{address_type}_address_form".to_sym
-    subject(:subject) { create(factory, workflow_state: current_state) }
+    subject(:subject) do
+      create(factory, workflow_state: current_state,
+                      tier: defined?(tier) ? tier : WasteCarriersEngine::Registration::UPPER_TIER)
+    end
 
     context "when subject.skip_to_manual_address? is false" do
       next_state = next_state_if_not_skipping_to_manual
@@ -13,6 +16,7 @@ RSpec.shared_examples "an address lookup transition" do |next_state_if_not_skipp
       before(:each) { subject.temp_os_places_error = nil }
 
       it "changes to #{next_state} after the 'next' event" do
+
         expect(subject).to transition_from(current_state).to(next_state).on_event(:next)
       end
 


### PR DESCRIPTION
This change moves the main-people form before the company-postcode form for upper-tier businesses.
https://eaflood.atlassian.net/browse/RUBY-1871