### PR TITLE
Move main_people form before company_name form

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
@@ -156,7 +156,7 @@ module WasteCarriersEngine
 
           # End smart answers
 
-          transitions from: :cbd_type_form, to: :company_name_form,
+          transitions from: :cbd_type_form, to: :main_people_form,
                       if: :skip_registration_number?
 
           transitions from: :cbd_type_form, to: :registration_number_form
@@ -166,15 +166,12 @@ module WasteCarriersEngine
           transitions from: :check_registered_company_name_form, to: :incorrect_company_form,
                       if: :incorrect_company_data?
 
-          transitions from: :check_registered_company_name_form, to: :company_name_form
+          transitions from: :check_registered_company_name_form, to: :main_people_form
 
           transitions from: :incorrect_company_form, to: :registration_number_form
 
           transitions from: :company_name_form, to: :company_address_manual_form,
                       if: :overseas?
-
-          transitions from: :company_name_form, to: :main_people_form,
-                      if: :upper_tier?
 
           transitions from: :company_name_form, to: :company_postcode_form
 
@@ -200,7 +197,7 @@ module WasteCarriersEngine
 
           # End registered address
 
-          transitions from: :main_people_form, to: :company_postcode_form
+          transitions from: :main_people_form, to: :company_name_form
 
           transitions from: :declare_convictions_form, to: :conviction_details_form,
                       if: :declared_convictions?
@@ -326,6 +323,11 @@ module WasteCarriersEngine
           transitions from: :company_name_form, to: :your_tier_form,
                       if: :lower_tier?
 
+          transitions from: :company_name_form, to: :main_people_form,
+                      if: :skip_registration_number?
+
+          transitions from: :company_name_form, to: :check_registered_company_name_form
+
           transitions from: :your_tier_form, to: :business_type_form,
                       if: :switch_to_lower_tier_based_on_business_type?
 
@@ -340,11 +342,6 @@ module WasteCarriersEngine
 
           transitions from: :your_tier_form, to: :construction_demolition_form,
                       if: %i[lower_tier?]
-
-          transitions from: :company_name_form, to: :cbd_type_form,
-                      if: :skip_registration_number?
-
-          transitions from: :company_name_form, to: :check_registered_company_name_form
 
           transitions from: :check_registered_company_name_form, to: :registration_number_form
 
@@ -377,9 +374,6 @@ module WasteCarriersEngine
 
           # Registered address
 
-          transitions from: :company_postcode_form, to: :main_people_form,
-                      if: :upper_tier?
-
           transitions from: :company_postcode_form, to: :company_name_form
 
           transitions from: :company_address_form, to: :company_postcode_form
@@ -389,7 +383,7 @@ module WasteCarriersEngine
 
           transitions from: :company_address_manual_form, to: :company_postcode_form
 
-          transitions from: :main_people_form, to: :company_name_form
+          transitions from: :main_people_form, to: :cbd_type_form
 
           # End registered address
 

--- a/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
@@ -62,195 +62,146 @@ module WasteCarriersEngine
 
         # Transitions
         event :next do
-          transitions from: :renewal_start_form,
-                      to: :location_form
+          transitions from: :renewal_start_form, to: :location_form
 
           # Location
 
-          transitions from: :location_form,
-                      to: :register_in_northern_ireland_form,
+          transitions from: :location_form, to: :register_in_northern_ireland_form,
                       if: :should_register_in_northern_ireland?
 
-          transitions from: :location_form,
-                      to: :register_in_scotland_form,
+          transitions from: :location_form, to: :register_in_scotland_form,
                       if: :should_register_in_scotland?
 
-          transitions from: :location_form,
-                      to: :register_in_wales_form,
+          transitions from: :location_form, to: :register_in_wales_form,
                       if: :should_register_in_wales?
 
-          transitions from: :location_form,
-                      to: :cbd_type_form,
+          transitions from: :location_form, to: :cbd_type_form,
                       if: :based_overseas?
 
-          transitions from: :location_form,
-                      to: :business_type_form
+          transitions from: :location_form, to: :business_type_form
 
-          transitions from: :register_in_northern_ireland_form,
-                      to: :business_type_form
+          transitions from: :register_in_northern_ireland_form, to: :business_type_form
 
-          transitions from: :register_in_scotland_form,
-                      to: :business_type_form
+          transitions from: :register_in_scotland_form, to: :business_type_form
 
-          transitions from: :register_in_wales_form,
-                      to: :business_type_form
+          transitions from: :register_in_wales_form, to: :business_type_form
 
           # End location
 
-          transitions from: :business_type_form,
-                      to: :cbd_type_form,
+          transitions from: :business_type_form, to: :cbd_type_form,
                       if: :business_type_change_valid?
 
-          transitions from: :business_type_form,
-                      to: :cannot_renew_type_change_form
+          transitions from: :business_type_form, to: :cannot_renew_type_change_form
 
-          transitions from: :cbd_type_form,
-                      to: :renewal_information_form
+          transitions from: :cbd_type_form, to: :renewal_information_form
 
-          transitions from: :renewal_information_form,
-                      to: :company_name_form,
-                      if: :skip_registration_number?
+          transitions from: :renewal_information_form, to: :check_registered_company_name_form,
+                      unless: :skip_registration_number?
 
-          transitions from: :renewal_information_form,
-                      to: :check_registered_company_name_form
-
-          transitions from: :check_registered_company_name_form,
-                      to: :incorrect_company_form,
-                      if: :incorrect_company_data?
-
-          transitions from: :check_registered_company_name_form,
-                      to: :company_name_form
-
-          transitions from: :incorrect_company_form,
-                      to: :registration_number_form
-
-          transitions from: :company_name_form,
-                      to: :company_address_manual_form,
-                      if: :based_overseas?
-
-          transitions from: :company_name_form,
-                      to: :main_people_form,
+          transitions from: :renewal_information_form, to: :main_people_form,
                       if: :upper_tier?
 
-          transitions from: :company_name_form,
-                      to: :company_postcode_form
+          transitions from: :renewal_information_form, to: :company_name_form
+
+          transitions from: :check_registered_company_name_form, to: :incorrect_company_form,
+                      if: :incorrect_company_data?
+
+          transitions from: :check_registered_company_name_form, to: :main_people_form
+
+          transitions from: :incorrect_company_form, to: :registration_number_form
+
+          transitions from: :company_name_form, to: :company_address_manual_form,
+                      if: :based_overseas?
+
+          transitions from: :company_name_form, to: :company_postcode_form
 
           # Registered address
 
-          transitions from: :company_postcode_form,
-                      to: :company_address_manual_form,
+          transitions from: :company_postcode_form, to: :company_address_manual_form,
                       if: :skip_to_manual_address?
 
-          transitions from: :company_postcode_form,
-                      to: :company_address_form
+          transitions from: :company_postcode_form, to: :company_address_form
 
-          transitions from: :company_address_form,
-                      to: :company_address_manual_form,
+          transitions from: :company_address_form, to: :company_address_manual_form,
                       if: :skip_to_manual_address?
 
-          transitions from: :company_address_form,
-                      to: :contact_name_form,
+          transitions from: :company_address_form, to: :contact_name_form,
                       if: :lower_tier?
 
-          transitions from: :company_address_form,
-                      to: :declare_convictions_form
+          transitions from: :company_address_form, to: :declare_convictions_form
 
-          transitions from: :company_address_manual_form,
-                      to: :contact_name_form,
+          transitions from: :company_address_manual_form, to: :contact_name_form,
                       if: :lower_tier?
 
-          transitions from: :company_address_manual_form,
-                      to: :declare_convictions_form
+          transitions from: :company_address_manual_form, to: :declare_convictions_form
 
           # End registered address
 
-          transitions from: :main_people_form,
-                      to: :company_postcode_form
+          transitions from: :main_people_form, to: :company_name_form
 
-          transitions from: :declare_convictions_form,
-                      to: :conviction_details_form,
+          transitions from: :declare_convictions_form, to: :conviction_details_form,
                       if: :declared_convictions?
 
-          transitions from: :declare_convictions_form,
-                      to: :contact_name_form
+          transitions from: :declare_convictions_form, to: :contact_name_form
 
-          transitions from: :conviction_details_form,
-                      to: :contact_name_form
+          transitions from: :conviction_details_form, to: :contact_name_form
 
-          transitions from: :contact_name_form,
-                      to: :contact_phone_form
+          transitions from: :contact_name_form, to: :contact_phone_form
 
-          transitions from: :contact_phone_form,
-                      to: :contact_email_form
+          transitions from: :contact_phone_form, to: :contact_email_form
 
-          transitions from: :contact_email_form,
-                      to: :contact_address_manual_form,
+          transitions from: :contact_email_form, to: :contact_address_manual_form,
                       if: :based_overseas?
 
-          transitions from: :contact_email_form,
-                      to: :contact_postcode_form
+          transitions from: :contact_email_form, to: :contact_postcode_form
 
           # Contact address
 
-          transitions from: :contact_postcode_form,
-                      to: :contact_address_manual_form,
+          transitions from: :contact_postcode_form, to: :contact_address_manual_form,
                       if: :skip_to_manual_address?
 
-          transitions from: :contact_postcode_form,
-                      to: :contact_address_form
+          transitions from: :contact_postcode_form, to: :contact_address_form
 
-          transitions from: :contact_address_form,
-                      to: :contact_address_manual_form,
+          transitions from: :contact_address_form, to: :contact_address_manual_form,
                       if: :skip_to_manual_address?
 
-          transitions from: :contact_address_form,
-                      to: :check_your_answers_form
+          transitions from: :contact_address_form, to: :check_your_answers_form
 
-          transitions from: :contact_address_manual_form,
-                      to: :check_your_answers_form
+          transitions from: :contact_address_manual_form, to: :check_your_answers_form
 
           # End contact address
 
-          transitions from: :check_your_answers_form,
-                      to: :declaration_form
+          transitions from: :check_your_answers_form, to: :declaration_form
 
-          transitions from: :declaration_form,
-                      to: :cards_form
+          transitions from: :declaration_form, to: :cards_form
 
-          transitions from: :cards_form,
-                      to: :payment_summary_form
+          transitions from: :cards_form, to: :payment_summary_form
 
-          transitions from: :payment_summary_form,
-                      to: :worldpay_form,
+          transitions from: :payment_summary_form, to: :worldpay_form,
                       if: :paying_by_card?
 
-          transitions from: :payment_summary_form,
-                      to: :confirm_bank_transfer_form
+          transitions from: :payment_summary_form, to: :confirm_bank_transfer_form
 
-          transitions from: :worldpay_form,
-                      to: :renewal_received_pending_worldpay_payment_form,
+          transitions from: :worldpay_form, to: :renewal_received_pending_worldpay_payment_form,
                       if: :pending_worldpay_payment?,
                       success: :send_renewal_pending_worldpay_payment_email,
                       # TODO: This don't get triggered if in the `success`
                       # callback block, hence we went for `after`
                       after: :set_metadata_route
 
-          transitions from: :worldpay_form,
-                      to: :renewal_received_pending_conviction_form,
+          transitions from: :worldpay_form, to: :renewal_received_pending_conviction_form,
                       if: :conviction_check_required?,
                       success: :send_renewal_pending_checks_email,
                       # TODO: This don't get triggered if in the `success`
                       # callback block, hence we went for `after`
                       after: :set_metadata_route
 
-          transitions from: :worldpay_form,
-                      to: :renewal_complete_form,
+          transitions from: :worldpay_form, to: :renewal_complete_form,
                       # TODO: This don't get triggered if in the `success`
                       # callback block, hence we went for `after`
                       after: :set_metadata_route
 
-          transitions from: :confirm_bank_transfer_form,
-                      to: :renewal_received_pending_payment_form,
+          transitions from: :confirm_bank_transfer_form, to: :renewal_received_pending_payment_form,
                       success: :send_renewal_received_pending_payment_email,
                       # TODO: This don't get triggered if in the `success`
                       # callback block, hence we went for `after`
@@ -260,169 +211,124 @@ module WasteCarriersEngine
         event :back do
           # Location
 
-          transitions from: :location_form,
-                      to: :renewal_start_form
+          transitions from: :location_form, to: :renewal_start_form
 
-          transitions from: :register_in_northern_ireland_form,
-                      to: :location_form
+          transitions from: :register_in_northern_ireland_form, to: :location_form
 
-          transitions from: :register_in_scotland_form,
-                      to: :location_form
+          transitions from: :register_in_scotland_form, to: :location_form
 
-          transitions from: :register_in_wales_form,
-                      to: :location_form
+          transitions from: :register_in_wales_form, to: :location_form
 
           # End location
 
-          transitions from: :business_type_form,
-                      to: :register_in_northern_ireland_form,
+          transitions from: :business_type_form, to: :register_in_northern_ireland_form,
                       if: :should_register_in_northern_ireland?
 
-          transitions from: :business_type_form,
-                      to: :register_in_scotland_form,
+          transitions from: :business_type_form, to: :register_in_scotland_form,
                       if: :should_register_in_scotland?
 
-          transitions from: :business_type_form,
-                      to: :register_in_wales_form,
+          transitions from: :business_type_form, to: :register_in_wales_form,
                       if: :should_register_in_wales?
 
-          transitions from: :business_type_form,
-                      to: :location_form
+          transitions from: :business_type_form, to: :location_form
 
           # Smart answers
 
-          transitions from: :cbd_type_form,
-                      to: :location_form,
+          transitions from: :cbd_type_form, to: :location_form,
                       if: :based_overseas?
 
-          transitions from: :cbd_type_form,
-                      to: :business_type_form
+          transitions from: :cbd_type_form, to: :business_type_form
 
           # End smart answers
 
-          transitions from: :renewal_information_form,
-                      to: :cbd_type_form
+          transitions from: :renewal_information_form, to: :cbd_type_form
 
-          transitions from: :registration_number_form,
-                      to: :renewal_information_form
+          transitions from: :registration_number_form, to: :renewal_information_form
 
-          transitions from: :company_name_form,
-                      to: :renewal_information_form,
+          transitions from: :company_name_form, to: :renewal_information_form,
+                      if: :lower_tier?
+
+          transitions from: :company_name_form, to: :main_people_form,
                       if: :skip_registration_number?
 
-          transitions from: :company_name_form,
-                      to: :check_registered_company_name_form
+          transitions from: :company_name_form, to: :check_registered_company_name_form
 
-          transitions from: :check_registered_company_name_form,
-                      to: :renewal_information_form
+          transitions from: :check_registered_company_name_form, to: :renewal_information_form
 
-          transitions from: :incorrect_company_form,
-                      to: :check_registered_company_name_form
+          transitions from: :incorrect_company_form, to: :check_registered_company_name_form
 
           # Registered address
 
-          transitions from: :company_postcode_form,
-                      to: :main_people_form,
-                      if: :upper_tier?
+          transitions from: :company_postcode_form, to: :company_name_form
 
-          transitions from: :company_postcode_form,
-                      to: :company_name_form
+          transitions from: :company_address_form, to: :company_postcode_form
 
-          transitions from: :company_address_form,
-                      to: :company_postcode_form
-
-          transitions from: :company_address_manual_form,
-                      to: :company_name_form,
+          transitions from: :company_address_manual_form, to: :company_name_form,
                       if: :based_overseas?
 
-          transitions from: :company_address_manual_form,
-                      to: :company_postcode_form
+          transitions from: :company_address_manual_form, to: :company_postcode_form
 
-          transitions from: :main_people_form,
-                      to: :company_name_form
+          transitions from: :main_people_form, to: :cbd_type_form
 
           # End registered address
 
-          transitions from: :declare_convictions_form,
-                      to: :company_address_manual_form,
+          transitions from: :declare_convictions_form, to: :company_address_manual_form,
                       if: :registered_address_was_manually_entered?
 
-          transitions from: :declare_convictions_form,
-                      to: :company_address_form
+          transitions from: :declare_convictions_form, to: :company_address_form
 
-          transitions from: :conviction_details_form,
-                      to: :declare_convictions_form
+          transitions from: :conviction_details_form, to: :declare_convictions_form
 
-          transitions from: :contact_name_form,
-                      to: :conviction_details_form,
+          transitions from: :contact_name_form, to: :conviction_details_form,
                       if: :declared_convictions?
 
-          transitions from: :contact_name_form,
-                      to: :declare_convictions_form
+          transitions from: :contact_name_form, to: :declare_convictions_form
 
-          transitions from: :contact_phone_form,
-                      to: :contact_name_form
+          transitions from: :contact_phone_form, to: :contact_name_form
 
-          transitions from: :contact_email_form,
-                      to: :contact_phone_form
+          transitions from: :contact_email_form, to: :contact_phone_form
 
           # Contact address
 
-          transitions from: :contact_postcode_form,
-                      to: :contact_email_form
+          transitions from: :contact_postcode_form, to: :contact_email_form
 
-          transitions from: :contact_address_form,
-                      to: :contact_postcode_form
+          transitions from: :contact_address_form, to: :contact_postcode_form
 
-          transitions from: :contact_address_manual_form,
-                      to: :contact_email_form,
+          transitions from: :contact_address_manual_form, to: :contact_email_form,
                       if: :based_overseas?
 
-          transitions from: :contact_address_manual_form,
-                      to: :contact_postcode_form
+          transitions from: :contact_address_manual_form, to: :contact_postcode_form
 
-          transitions from: :check_your_answers_form,
-                      to: :contact_address_manual_form,
+          transitions from: :check_your_answers_form, to: :contact_address_manual_form,
                       if: :contact_address_was_manually_entered?
 
-          transitions from: :check_your_answers_form,
-                      to: :contact_address_form
+          transitions from: :check_your_answers_form, to: :contact_address_form
 
           # End contact address
 
-          transitions from: :declaration_form,
-                      to: :check_your_answers_form
+          transitions from: :declaration_form, to: :check_your_answers_form
 
-          transitions from: :cards_form,
-                      to: :declaration_form
+          transitions from: :cards_form, to: :declaration_form
 
-          transitions from: :payment_summary_form,
-                      to: :cards_form
+          transitions from: :payment_summary_form, to: :cards_form
 
-          transitions from: :worldpay_form,
-                      to: :payment_summary_form
+          transitions from: :worldpay_form, to: :payment_summary_form
 
-          transitions from: :confirm_bank_transfer_form,
-                      to: :payment_summary_form
+          transitions from: :confirm_bank_transfer_form, to: :payment_summary_form
 
           # Exit routes from renewals process
 
-          transitions from: :cannot_renew_type_change_form,
-                      to: :business_type_form
+          transitions from: :cannot_renew_type_change_form, to: :business_type_form
         end
 
         event :skip_to_manual_address do
-          transitions from: :company_postcode_form,
-                      to: :company_address_manual_form
+          transitions from: :company_postcode_form, to: :company_address_manual_form
 
-          transitions from: :company_address_form,
-                      to: :company_address_manual_form
+          transitions from: :company_address_form, to: :company_address_manual_form
 
-          transitions from: :contact_postcode_form,
-                      to: :contact_address_manual_form
+          transitions from: :contact_postcode_form, to: :contact_address_manual_form
 
-          transitions from: :contact_address_form,
-                      to: :contact_address_manual_form
+          transitions from: :contact_address_form, to: :contact_address_manual_form
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/cbd_type_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/cbd_type_form_spec.rb
@@ -15,7 +15,7 @@ module WasteCarriersEngine
             include_examples "has next transition", next_state: "registration_number_form"
           end
 
-          include_examples "has next transition", next_state: "company_name_form"
+          include_examples "has next transition", next_state: "main_people_form"
         end
 
         context "on back" do

--- a/spec/models/waste_carriers_engine/new_registration_workflow/check_registered_company_name_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/check_registered_company_name_form_spec.rb
@@ -12,7 +12,7 @@ module WasteCarriersEngine
           context "when the user confirms their company house details are correct" do
             subject { build(:new_registration, workflow_state: "check_registered_company_name_form", temp_use_registered_company_details: "yes") }
 
-            include_examples "has next transition", next_state: "company_name_form"
+            include_examples "has next transition", next_state: "main_people_form"
           end
 
           context "when the user confirms their company house details are wrong" do

--- a/spec/models/waste_carriers_engine/new_registration_workflow/company_name_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/company_name_form_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe NewRegistration do
-    subject { build(:new_registration, workflow_state: "company_name_form", tier: tier) }
+    subject { build(:new_registration, workflow_state: "company_name_form") }
 
     describe "#workflow_state" do
       context ":company_name_form state transitions" do
@@ -15,22 +15,14 @@ module WasteCarriersEngine
             include_examples "has next transition", next_state: "company_address_manual_form"
           end
 
-          context "when the registration is upper tier" do
-            let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
-            include_examples "has next transition", next_state: "main_people_form"
-          end
-
-          context "when the registration is lower tier" do
-            let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
-            include_examples "has next transition", next_state: "company_postcode_form"
-          end
+          include_examples "has next transition", next_state: "company_postcode_form"
         end
 
         context "on back" do
           context "when the business does not require a registration number and the registration is upper tier" do
             subject { build(:new_registration, :upper, workflow_state: "company_name_form", location: "overseas") }
 
-            include_examples "has back transition", previous_state: "cbd_type_form"
+            include_examples "has back transition", previous_state: "main_people_form"
           end
 
           context "when the registration is lower tier" do

--- a/spec/models/waste_carriers_engine/new_registration_workflow/company_postcode_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/company_postcode_form_spec.rb
@@ -6,23 +6,11 @@ module WasteCarriersEngine
   RSpec.describe NewRegistration do
     describe "#workflow_state" do
 
-      context "when the registration is upper tier" do
-        let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
+      it_behaves_like "a postcode transition",
+                      previous_state: :company_name_form,
+                      address_type: "company",
+                      factory: :new_registration
 
-        it_behaves_like "a postcode transition",
-                        previous_state: :main_people_form,
-                        address_type: "company",
-                        factory: :new_registration
-      end
-
-      context "when the registration is lower tier" do
-        let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
-
-        it_behaves_like "a postcode transition",
-                        previous_state: :company_name_form,
-                        address_type: "company",
-                        factory: :new_registration
-      end
     end
   end
 end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/main_people_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/main_people_form_spec.rb
@@ -9,11 +9,11 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":main_people_form state transitions" do
         context "on next" do
-          include_examples "has next transition", next_state: "company_postcode_form"
+          include_examples "has next transition", next_state: "company_name_form"
         end
 
         context "on back" do
-          include_examples "has back transition", previous_state: "company_name_form"
+          include_examples "has back transition", previous_state: "cbd_type_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/check_registered_company_name_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/check_registered_company_name_form_spec.rb
@@ -12,7 +12,7 @@ module WasteCarriersEngine
           context "when the user confirms their company house details are correct" do
             subject { build(:new_registration, workflow_state: "check_registered_company_name_form", temp_use_registered_company_details: "yes") }
 
-            include_examples "has next transition", next_state: "company_name_form"
+            include_examples "has next transition", next_state: "main_people_form"
           end
 
           context "when the user confirms their company house details are wrong" do

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/company_name_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/company_name_form_spec.rb
@@ -19,15 +19,7 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":company_name_form state transitions" do
         context "on next" do
-          context "when the registraton is upper tier" do
-            let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
-            include_examples "has next transition", next_state: "main_people_form"
-          end
-
-          context "when the registration is lower tier" do
-            let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
-            include_examples "has next transition", next_state: "company_postcode_form"
-          end
+          include_examples "has next transition", next_state: "company_postcode_form"
 
           context "when the location is overseas" do
             let(:location) { "overseas" }
@@ -37,10 +29,41 @@ module WasteCarriersEngine
         end
 
         context "on back" do
+
+          shared_examples "main_people_form or renewal_information_form depending on tier" do
+            context "when the registraton is upper tier" do
+              let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
+              include_examples "has back transition", previous_state: "main_people_form"
+            end
+
+            context "when the registration is lower tier" do
+              let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
+              include_examples "has back transition", previous_state: "renewal_information_form"
+            end
+          end
+
+          context "when the business type is partnership" do
+            let(:business_type) { "partnership" }
+
+            it_behaves_like "main_people_form or renewal_information_form depending on tier"
+          end
+
+          context "when the business type is soleTrader" do
+            let(:business_type) { "soleTrader" }
+
+            it_behaves_like "main_people_form or renewal_information_form depending on tier"
+          end
+
           context "when the business type is localAuthority" do
             let(:business_type) { "localAuthority" }
 
-            include_examples "has back transition", previous_state: "renewal_information_form"
+            it_behaves_like "main_people_form or renewal_information_form depending on tier"
+          end
+
+          context "when the location is overseas" do
+            let(:location) { "overseas" }
+
+            it_behaves_like "main_people_form or renewal_information_form depending on tier"
           end
 
           context "when the business type is limitedCompany" do
@@ -53,24 +76,6 @@ module WasteCarriersEngine
             let(:business_type) { "limitedLiabilityPartnership" }
 
             include_examples "has back transition", previous_state: "check_registered_company_name_form"
-          end
-
-          context "when the business type is partnership" do
-            let(:business_type) { "partnership" }
-
-            include_examples "has back transition", previous_state: "renewal_information_form"
-          end
-
-          context "when the business type is soleTrader" do
-            let(:business_type) { "soleTrader" }
-
-            include_examples "has back transition", previous_state: "renewal_information_form"
-          end
-
-          context "when the location is overseas" do
-            let(:location) { "overseas" }
-
-            include_examples "has back transition", previous_state: "renewal_information_form"
           end
         end
       end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/company_postcode_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/company_postcode_form_spec.rb
@@ -6,23 +6,11 @@ module WasteCarriersEngine
   RSpec.describe RenewingRegistration do
     describe "#workflow_state" do
 
-      context "when the registration is upper tier" do
-        let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
+      it_behaves_like "a postcode transition",
+                      previous_state: :company_name_form,
+                      address_type: "company",
+                      factory: :renewing_registration
 
-        it_behaves_like "a postcode transition",
-                        previous_state: :main_people_form,
-                        address_type: "company",
-                        factory: :renewing_registration
-      end
-
-      context "when the registration is lower tier" do
-        let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
-
-        it_behaves_like "a postcode transition",
-                        previous_state: :company_name_form,
-                        address_type: "company",
-                        factory: :renewing_registration
-      end
     end
   end
 end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/main_people_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/main_people_form_spec.rb
@@ -15,11 +15,11 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":main_people_form state transitions" do
         context "on next" do
-          include_examples "has next transition", next_state: "company_postcode_form"
+          include_examples "has next transition", next_state: "company_name_form"
         end
 
         context "on back" do
-          include_examples "has back transition", previous_state: "company_name_form"
+          include_examples "has back transition", previous_state: "cbd_type_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/renewal_information_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/renewal_information_form_spec.rb
@@ -9,18 +9,51 @@ module WasteCarriersEngine
             :has_required_data,
             business_type: business_type,
             location: location,
+            tier: tier,
             workflow_state: "renewal_information_form")
     end
+    let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
     let(:business_type) {}
     let(:location) { "england" }
 
     describe "#workflow_state" do
       context ":renewal_information_form state transitions" do
         context "on next" do
+
+          shared_examples "main_people_form or company_name_form based on tier" do
+            context "when upper tier" do
+              let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
+              include_examples "has next transition", next_state: "main_people_form"
+            end
+
+            context "when lower tier" do
+              let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
+              include_examples "has next transition", next_state: "company_name_form"
+            end
+          end
+
+          context "when the location is overseas" do
+            let(:location) { "overseas" }
+
+            it_behaves_like "main_people_form or company_name_form based on tier"
+          end
+
           context "when the business type is localAuthority" do
             let(:business_type) { "localAuthority" }
 
-            include_examples "has next transition", next_state: "company_name_form"
+            it_behaves_like "main_people_form or company_name_form based on tier"
+          end
+
+          context "when the business type is partnership" do
+            let(:business_type) { "partnership" }
+
+            it_behaves_like "main_people_form or company_name_form based on tier"
+          end
+
+          context "when the business type is soleTrader" do
+            let(:business_type) { "soleTrader" }
+
+            it_behaves_like "main_people_form or company_name_form based on tier"
           end
 
           context "when the business type is limitedCompany" do
@@ -33,24 +66,6 @@ module WasteCarriersEngine
             let(:business_type) { "limitedLiabilityPartnership" }
 
             include_examples "has next transition", next_state: "check_registered_company_name_form"
-          end
-
-          context "when the location is overseas" do
-            let(:location) { "overseas" }
-
-            include_examples "has next transition", next_state: "company_name_form"
-          end
-
-          context "when the business type is partnership" do
-            let(:business_type) { "partnership" }
-
-            include_examples "has next transition", next_state: "company_name_form"
-          end
-
-          context "when the business type is soleTrader" do
-            let(:business_type) { "soleTrader" }
-
-            include_examples "has next transition", next_state: "company_name_form"
           end
         end
 

--- a/spec/requests/waste_carriers_engine/company_postcode_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/company_postcode_forms_spec.rb
@@ -91,12 +91,10 @@ module WasteCarriersEngine
         end
 
         context "when a valid transient registration exists" do
-          let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
           let(:transient_registration) do
             create(:renewing_registration,
                    :has_required_data,
                    account_email: user.email,
-                   tier: tier,
                    workflow_state: "company_postcode_form")
           end
 
@@ -108,22 +106,10 @@ module WasteCarriersEngine
             end
           end
 
-          context "when the registration is upper tier" do
-            let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
-            it "redirects to the main_people form" do
-              get back_company_postcode_forms_path(transient_registration[:token])
+          it "redirects to the company_name form" do
+            get back_company_postcode_forms_path(transient_registration[:token])
 
-              expect(response).to redirect_to(new_main_people_form_path(transient_registration[:token]))
-            end
-          end
-
-          context "when the registration is lower tier" do
-            let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
-            it "redirects to the company_name form" do
-              get back_company_postcode_forms_path(transient_registration[:token])
-
-              expect(response).to redirect_to(new_company_name_form_path(transient_registration[:token]))
-            end
+            expect(response).to redirect_to(new_company_name_form_path(transient_registration[:token]))
           end
         end
 

--- a/spec/requests/waste_carriers_engine/main_people_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/main_people_forms_spec.rb
@@ -32,7 +32,7 @@ module WasteCarriersEngine
               }
             end
 
-            it "correctly updates the key people, returns a 302 response and redirects to the company_postcode form" do
+            it "correctly updates the key people, returns a 302 response and redirects to the company_name form" do
               key_people_count = transient_registration.key_people.count
 
               post main_people_forms_path(transient_registration.token), params: { main_people_form: valid_params }
@@ -40,7 +40,7 @@ module WasteCarriersEngine
               expect(transient_registration.reload.key_people.count).to eq(key_people_count + 1)
               expect(transient_registration.reload.key_people.last.first_name).to eq(valid_params[:first_name])
               expect(response).to have_http_status(302)
-              expect(response).to redirect_to(new_company_postcode_form_path(transient_registration[:token]))
+              expect(response).to redirect_to(new_company_name_form_path(transient_registration[:token]))
             end
 
             context "when there is already a main person" do
@@ -217,9 +217,9 @@ module WasteCarriersEngine
               expect(response).to have_http_status(302)
             end
 
-            it "redirects to the company_name form" do
+            it "redirects to the cbd_type form" do
               get back_main_people_forms_path(transient_registration[:token])
-              expect(response).to redirect_to(new_company_name_form_path(transient_registration[:token]))
+              expect(response).to redirect_to(new_cbd_type_form_path(transient_registration[:token]))
             end
           end
         end


### PR DESCRIPTION
This change updates the form sequence for upper-tier new registrations and renewals to put the main_people form before the company_name form.
https://eaflood.atlassian.net/browse/RUBY-1871