### PR TITLE
Fix typo in company_name_form content

### DIFF
--- a/config/locales/forms/company_name_forms/en.yml
+++ b/config/locales/forms/company_name_forms/en.yml
@@ -37,7 +37,7 @@ en:
           limitedLiabilityPartnership: *trade_name_hint
           overseas: Enter your trading name
           partnership: Enter your partnership trading name
-          soleTrader: Enter a business or trading name. The business owner name and trading namme (if provided) will be displayed on the public register.
+          soleTrader: Enter a business or trading name. The business owner name and trading name (if provided) will be displayed on the public register.
           charity: Enter your charity or trust registered name
           authority: Enter your local authority name
           publicBody: Enter your public body name


### PR DESCRIPTION
This fixes a typo in the EN locale file for company_name_form.
https://eaflood.atlassian.net/browse/RUBY-1871