### PR TITLE
Reset company details when location changes to overseas

### DIFF
--- a/app/controllers/concerns/waste_carriers_engine/can_reset_company_details.rb
+++ b/app/controllers/concerns/waste_carriers_engine/can_reset_company_details.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  module CanResetCompanyDetails
+    extend ActiveSupport::Concern
+
+    included do
+
+      # Clear any previous business-type specific attributes to handle cases where the user
+      # starts with one business type and then navigates back and changes the business type.
+      def reset_company_attributes
+        @transient_registration.company_no = nil
+        @transient_registration.registered_company_name = nil
+        @transient_registration.temp_use_registered_company_details = nil
+        @transient_registration.save!
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/waste_carriers_engine/can_reset_company_details.rb
+++ b/app/controllers/concerns/waste_carriers_engine/can_reset_company_details.rb
@@ -9,6 +9,9 @@ module WasteCarriersEngine
       # Clear any previous business-type specific attributes to handle cases where the user
       # starts with one business type and then navigates back and changes the business type.
       def reset_company_attributes
+        # The renewals flow has its own logic to handle such changes
+        return unless @transient_registration.is_a?(NewRegistration)
+
         @transient_registration.company_no = nil
         @transient_registration.registered_company_name = nil
         @transient_registration.temp_use_registered_company_details = nil

--- a/app/controllers/waste_carriers_engine/business_type_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/business_type_forms_controller.rb
@@ -2,6 +2,8 @@
 
 module WasteCarriersEngine
   class BusinessTypeFormsController < ::WasteCarriersEngine::FormsController
+    include CanResetCompanyDetails
+
     def new
       super(BusinessTypeForm, "business_type_form")
     end
@@ -15,15 +17,6 @@ module WasteCarriersEngine
 
     def transient_registration_attributes
       params.fetch(:business_type_form, {}).permit(:business_type, :token)
-    end
-
-    # Clear any previous business-type specific attributes to handle cases where the user
-    # starts with one business type and then navigates back and changes the business type.
-    def reset_company_attributes
-      @transient_registration.company_no = nil
-      @transient_registration.registered_company_name = nil
-      @transient_registration.temp_use_registered_company_details = nil
-      @transient_registration.save!
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/business_type_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/business_type_forms_controller.rb
@@ -7,6 +7,7 @@ module WasteCarriersEngine
     end
 
     def create
+      reset_business_type_attributes
       super(BusinessTypeForm, "business_type_form")
       reset_company_attributes unless @transient_registration.company_no_required?
     end

--- a/app/controllers/waste_carriers_engine/business_type_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/business_type_forms_controller.rb
@@ -7,7 +7,6 @@ module WasteCarriersEngine
     end
 
     def create
-      reset_business_type_attributes
       super(BusinessTypeForm, "business_type_form")
       reset_company_attributes unless @transient_registration.company_no_required?
     end

--- a/app/controllers/waste_carriers_engine/location_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/location_forms_controller.rb
@@ -2,12 +2,15 @@
 
 module WasteCarriersEngine
   class LocationFormsController < ::WasteCarriersEngine::FormsController
+    include CanResetCompanyDetails
+
     def new
       super(LocationForm, "location_form")
     end
 
     def create
       super(LocationForm, "location_form")
+      reset_company_attributes unless @transient_registration.company_no_required?
     end
 
     private

--- a/spec/requests/waste_carriers_engine/location_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/location_forms_spec.rb
@@ -22,6 +22,32 @@ module WasteCarriersEngine
                          "location_form",
                          valid_params: { location: "england" },
                          invalid_params: { location: "foo" }
+
+        # When the user starts with a UK company type and then navigates back and changes the location to non-UK
+        context "when the transient_registration already has company attributes" do
+          let(:company_no) { Faker::Number.number(digits: 8).to_s }
+          let(:registered_company_name) { Faker::Company.name }
+          let(:temp_use_registered_company_details) { "yes" }
+
+          before do
+            transient_registration.company_no = company_no
+            transient_registration.registered_company_name = registered_company_name
+            transient_registration.temp_use_registered_company_details = temp_use_registered_company_details
+            transient_registration.save!
+          end
+
+          context "and the location is no longer in the UK" do
+            subject { post_form_with_params("location_form", transient_registration.token, { location: "overseas" }) }
+
+            it "removes the company attributes" do
+              subject
+              transient_registration.reload
+              expect(transient_registration.company_no).to be_nil
+              expect(transient_registration.registered_company_name).to be_nil
+              expect(transient_registration.temp_use_registered_company_details).to be_nil
+            end
+          end
+        end
       end
     end
 


### PR DESCRIPTION
This change extends the resetting of company details to the location_form, when a user changes location from UK (with a company) to overseas.
https://eaflood.atlassian.net/browse/RUBY-1254