### PR TITLE
Fix back navigation from main_people form for companies

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
@@ -383,7 +383,10 @@ module WasteCarriersEngine
 
           transitions from: :company_address_manual_form, to: :company_postcode_form
 
-          transitions from: :main_people_form, to: :cbd_type_form
+          transitions from: :main_people_form, to: :cbd_type_form,
+                      if: :skip_registration_number?
+
+          transitions from: :main_people_form, to: :check_registered_company_name_form
 
           # End registered address
 

--- a/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
@@ -268,7 +268,10 @@ module WasteCarriersEngine
 
           transitions from: :company_address_manual_form, to: :company_postcode_form
 
-          transitions from: :main_people_form, to: :cbd_type_form
+          transitions from: :main_people_form, to: :cbd_type_form,
+                      if: :skip_registration_number?
+
+          transitions from: :main_people_form, to: :check_registered_company_name_form
 
           # End registered address
 

--- a/spec/models/waste_carriers_engine/new_registration_workflow/main_people_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/main_people_form_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe NewRegistration do
-    subject { build(:new_registration, workflow_state: "main_people_form") }
+    let(:business_type) { "limitedCompany" }
+    subject { build(:new_registration, business_type: business_type, workflow_state: "main_people_form") }
 
     describe "#workflow_state" do
       context ":main_people_form state transitions" do
@@ -13,7 +14,17 @@ module WasteCarriersEngine
         end
 
         context "on back" do
-          include_examples "has back transition", previous_state: "cbd_type_form"
+          context "when the business type is limited company" do
+            let(:business_type) { "limitedCompany" }
+
+            include_examples "has back transition", previous_state: "check_registered_company_name_form"
+          end
+
+          context "when the business type is sole trader" do
+            let(:business_type) { "soleTrader" }
+
+            include_examples "has back transition", previous_state: "cbd_type_form"
+          end
         end
       end
     end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/main_people_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/main_people_form_spec.rb
@@ -8,8 +8,10 @@ module WasteCarriersEngine
       build(:renewing_registration,
             :has_required_data,
             addresses: addresses,
+            business_type: business_type,
             workflow_state: "main_people_form")
     end
+    let(:business_type) { "soleTrader" }
     let(:addresses) { [] }
 
     describe "#workflow_state" do
@@ -19,7 +21,17 @@ module WasteCarriersEngine
         end
 
         context "on back" do
-          include_examples "has back transition", previous_state: "cbd_type_form"
+          context "when the business type is limited company" do
+            let(:business_type) { "limitedCompany" }
+
+            include_examples "has back transition", previous_state: "check_registered_company_name_form"
+          end
+
+          context "when the business type is sole trader" do
+            let(:business_type) { "soleTrader" }
+
+            include_examples "has back transition", previous_state: "cbd_type_form"
+          end
         end
       end
     end

--- a/spec/requests/waste_carriers_engine/main_people_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/main_people_forms_spec.rb
@@ -208,6 +208,7 @@ module WasteCarriersEngine
             create(:renewing_registration,
                    :has_required_data,
                    account_email: user.email,
+                   business_type: defined?(business_type) ? business_type : "limitedCompany",
                    workflow_state: "main_people_form")
           end
 
@@ -217,9 +218,20 @@ module WasteCarriersEngine
               expect(response).to have_http_status(302)
             end
 
-            it "redirects to the cbd_type form" do
-              get back_main_people_forms_path(transient_registration[:token])
-              expect(response).to redirect_to(new_cbd_type_form_path(transient_registration[:token]))
+            context "when the business type is limitedCompany" do
+              let(:business_type) { "limitedCompany" }
+              it "redirects to the check_registered_company_name form" do
+                get back_main_people_forms_path(transient_registration[:token])
+                expect(response).to redirect_to(new_check_registered_company_name_form_path(transient_registration[:token]))
+              end
+            end
+
+            context "when the business type is soleTrader" do
+              let(:business_type) { "soleTrader" }
+              it "redirects to the cbd_type form" do
+                get back_main_people_forms_path(transient_registration[:token])
+                expect(response).to redirect_to(new_cbd_type_form_path(transient_registration[:token]))
+              end
             end
           end
         end


### PR DESCRIPTION
This changes the back-navigation from the main-people form from cbd-type to check-registered-company-name.
https://eaflood.atlassian.net/browse/RUBY-1871