### PR TITLE
Move valid_world_pay_status? method from the Order model to the World…

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -118,7 +118,7 @@ module WasteCarriersEngine
                             finance_details.orders.present? &&
                             finance_details.orders.first.present?
 
-        Order.valid_world_pay_status?(:pending, finance_details.orders.first.world_pay_status)
+        WorldpayValidatorService.valid_world_pay_status?(:pending, finance_details.orders.first.world_pay_status)
       end
 
       # Some business types should not have a company_no

--- a/app/models/waste_carriers_engine/order.rb
+++ b/app/models/waste_carriers_engine/order.rb
@@ -60,19 +60,6 @@ module WasteCarriersEngine
       order
     end
 
-    def self.valid_world_pay_status?(response_type, status)
-      allowed_statuses = {
-        success: %w[AUTHORISED],
-        failure: %w[EXPIRED
-                    REFUSED],
-        pending: %w[SENT_FOR_AUTHORISATION
-                    SHOPPER_REDIRECTED],
-        cancel: %w[CANCELLED],
-        error: %w[ERROR]
-      }
-      allowed_statuses[response_type].include?(status)
-    end
-
     def add_bank_transfer_attributes
       self.payment_method = "OFFLINE"
     end

--- a/app/services/waste_carriers_engine/worldpay_validator_service.rb
+++ b/app/services/waste_carriers_engine/worldpay_validator_service.rb
@@ -39,6 +39,19 @@ module WasteCarriersEngine
       valid?(:error)
     end
 
+    def self.valid_world_pay_status?(response_type, status)
+      allowed_statuses = {
+        success: %w[AUTHORISED],
+        failure: %w[EXPIRED
+                    REFUSED],
+        pending: %w[SENT_FOR_AUTHORISATION
+                    SHOPPER_REDIRECTED],
+        cancel: %w[CANCELLED],
+        error: %w[ERROR]
+      }
+      allowed_statuses[response_type].include?(status)
+    end
+
     private
 
     def valid?(action)
@@ -101,7 +114,7 @@ module WasteCarriersEngine
     end
 
     def valid_status?(response_type)
-      return true if Order.valid_world_pay_status?(response_type, @status)
+      return true if WorldpayValidatorService.valid_world_pay_status?(response_type, @status)
 
       Rails.logger.error "Invalid WorldPay response: #{@status} is not valid payment status for #{response_type}"
       false

--- a/spec/models/waste_carriers_engine/order_spec.rb
+++ b/spec/models/waste_carriers_engine/order_spec.rb
@@ -173,15 +173,5 @@ module WasteCarriersEngine
         end
       end
     end
-
-    describe "valid_world_pay_status?" do
-      it "returns true when the status matches the values for the response type" do
-        expect(Order.valid_world_pay_status?(:success, "AUTHORISED")).to eq(true)
-      end
-
-      it "returns false when the status does not match the values for the response type" do
-        expect(Order.valid_world_pay_status?(:success, "FOO")).to eq(false)
-      end
-    end
   end
 end

--- a/spec/models/waste_carriers_engine/transient_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/transient_registration_spec.rb
@@ -124,7 +124,7 @@ module WasteCarriersEngine
 
         context "when the order's world_pay_status is pending" do
           before do
-            allow(Order).to receive(:valid_world_pay_status?).and_return(true)
+            allow(WorldpayValidatorService).to receive(:valid_world_pay_status?).and_return(true)
           end
 
           it "returns true" do
@@ -134,7 +134,7 @@ module WasteCarriersEngine
 
         context "when the order's world_pay_status is not pending" do
           before do
-            allow(Order).to receive(:valid_world_pay_status?).and_return(false)
+            allow(WorldpayValidatorService).to receive(:valid_world_pay_status?).and_return(false)
           end
 
           it "returns false" do

--- a/spec/services/waste_carriers_engine/worldpay_validator_service_spec.rb
+++ b/spec/services/waste_carriers_engine/worldpay_validator_service_spec.rb
@@ -71,7 +71,7 @@ module WasteCarriersEngine
 
       context "when the paymentStatus is invalid" do
         before do
-          allow(Order).to receive(:valid_world_pay_status?).and_return(false)
+          allow(WorldpayValidatorService).to receive(:valid_world_pay_status?).and_return(false)
         end
 
         it "returns false" do
@@ -125,7 +125,7 @@ module WasteCarriersEngine
 
       context "when the paymentStatus is invalid" do
         before do
-          allow(Order).to receive(:valid_world_pay_status?).and_return(false)
+          allow(WorldpayValidatorService).to receive(:valid_world_pay_status?).and_return(false)
         end
 
         it "returns false" do
@@ -147,7 +147,7 @@ module WasteCarriersEngine
 
       context "when the paymentStatus is invalid" do
         before do
-          allow(Order).to receive(:valid_world_pay_status?).and_return(false)
+          allow(WorldpayValidatorService).to receive(:valid_world_pay_status?).and_return(false)
         end
 
         it "returns false" do
@@ -176,7 +176,7 @@ module WasteCarriersEngine
 
         context "when the paymentStatus is invalid" do
           before do
-            allow(Order).to receive(:valid_world_pay_status?).and_return(false)
+            allow(WorldpayValidatorService).to receive(:valid_world_pay_status?).and_return(false)
           end
 
           it "returns false" do
@@ -199,12 +199,22 @@ module WasteCarriersEngine
 
       context "when the paymentStatus is invalid" do
         before do
-          allow(Order).to receive(:valid_world_pay_status?).and_return(false)
+          allow(WorldpayValidatorService).to receive(:valid_world_pay_status?).and_return(false)
         end
 
         it "returns false" do
           expect(worldpay_validator_service.valid_error?).to eq(false)
         end
+      end
+    end
+
+    describe "valid_world_pay_status?" do
+      it "returns true when the status matches the values for the response type" do
+        expect(described_class.valid_world_pay_status?(:success, "AUTHORISED")).to eq(true)
+      end
+
+      it "returns false when the status does not match the values for the response type" do
+        expect(described_class.valid_world_pay_status?(:success, "FOO")).to eq(false)
       end
     end
   end


### PR DESCRIPTION
This moves the `valid_world_pay_status?` method from the `Order` model to the `WorldpayValidatorService`. This is to reduce the spread of Worldpay-specific code throughout the code base.