### PR TITLE
Rename non-worldpay-specific model methods

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -113,7 +113,7 @@ module WasteCarriersEngine
         contact_email.blank? || contact_email == WasteCarriersEngine.configuration.assisted_digital_email
       end
 
-      def pending_worldpay_payment?
+      def pending_online_payment?
         return false unless finance_details.present? &&
                             finance_details.orders.present? &&
                             finance_details.orders.first.present?

--- a/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
@@ -265,7 +265,7 @@ module WasteCarriersEngine
                       after: :set_metadata_route
 
           transitions from: :worldpay_form,
-                      to: :registration_received_pending_worldpay_payment_form, if: :pending_worldpay_payment?,
+                      to: :registration_received_pending_worldpay_payment_form, if: :pending_online_payment?,
                       # TODO: This don't get triggered if in the `success`
                       # callback block, hence we went for `after`
                       after: :set_metadata_route

--- a/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
@@ -183,7 +183,7 @@ module WasteCarriersEngine
           transitions from: :payment_summary_form, to: :confirm_bank_transfer_form
 
           transitions from: :worldpay_form, to: :renewal_received_pending_worldpay_payment_form,
-                      if: :pending_worldpay_payment?,
+                      if: :pending_online_payment?,
                       success: :send_renewal_pending_worldpay_payment_email,
                       # TODO: This don't get triggered if in the `success`
                       # callback block, hence we went for `after`

--- a/app/models/waste_carriers_engine/order.rb
+++ b/app/models/waste_carriers_engine/order.rb
@@ -78,7 +78,7 @@ module WasteCarriersEngine
       self.description = generate_description
     end
 
-    def update_after_worldpay(status)
+    def update_after_online_payment(status)
       self.world_pay_status = status
       self.date_last_updated = Time.current
       save!

--- a/app/models/waste_carriers_engine/payment.rb
+++ b/app/models/waste_carriers_engine/payment.rb
@@ -24,7 +24,7 @@ module WasteCarriersEngine
     scope :refundable, -> { where(payment_type: { "$in" => RECEIVABLE_PAYMENT_TYPES }) }
     scope :reversible, -> { where(payment_type: { "$in" => RECEIVABLE_PAYMENT_TYPES }) }
 
-    def self.new_from_worldpay(order, user_email)
+    def self.new_from_online_payment(order, user_email)
       payment = Payment.new
 
       payment[:order_key] = order[:order_code]
@@ -39,7 +39,7 @@ module WasteCarriersEngine
       payment
     end
 
-    def self.new_from_non_worldpay(params, order)
+    def self.new_from_non_online_payment(params, order)
       payment = Payment.new
 
       payment[:amount] = params[:amount]
@@ -60,7 +60,7 @@ module WasteCarriersEngine
       payment
     end
 
-    def update_after_worldpay(params)
+    def update_after_online_payment(params)
       self.world_pay_payment_status = params[:paymentStatus]
       self.mac_code = params[:mac]
 

--- a/app/services/waste_carriers_engine/registration_completion_service.rb
+++ b/app/services/waste_carriers_engine/registration_completion_service.rb
@@ -77,7 +77,7 @@ module WasteCarriersEngine
     # In the case when the registration can be completed, the registration activation email is sent from
     # the RegistrationActivationService.
     def send_confirmation_email
-      if registration.pending_worldpay_payment?
+      if registration.pending_online_payment?
         send_worldpay_pending_payment_email
       elsif registration.unpaid_balance?
         send_pending_payment_email

--- a/app/services/waste_carriers_engine/worldpay_service.rb
+++ b/app/services/waste_carriers_engine/worldpay_service.rb
@@ -62,7 +62,7 @@ module WasteCarriersEngine
       worldpay_validator_service = WorldpayValidatorService.new(@order, @params)
       return false unless worldpay_validator_service.public_send(validation_method)
 
-      @order.update_after_worldpay(@params[:paymentStatus])
+      @order.update_after_online_payment(@params[:paymentStatus])
       true
     end
 
@@ -93,13 +93,13 @@ module WasteCarriersEngine
     end
 
     def new_payment_object(order)
-      Payment.new_from_worldpay(order, user_email)
+      Payment.new_from_online_payment(order, user_email)
     end
 
     def update_saved_data
-      payment = Payment.new_from_worldpay(@order, user_email)
-      payment.update_after_worldpay(@params)
-      @order.update_after_worldpay(@params[:paymentStatus])
+      payment = Payment.new_from_online_payment(@order, user_email)
+      payment.update_after_online_payment(@params)
+      @order.update_after_online_payment(@params[:paymentStatus])
 
       @transient_registration.finance_details.update_balance
       @transient_registration.finance_details.save!

--- a/spec/models/waste_carriers_engine/order_spec.rb
+++ b/spec/models/waste_carriers_engine/order_spec.rb
@@ -154,12 +154,12 @@ module WasteCarriersEngine
       end
     end
 
-    describe "update_after_worldpay" do
+    describe "update_after_online_payment" do
       let(:finance_details) { transient_registration.prepare_for_payment(:worldpay, current_user) }
       let(:order) { finance_details.orders.first }
 
       it "copies the worldpay status to the order" do
-        order.update_after_worldpay("AUTHORISED")
+        order.update_after_online_payment("AUTHORISED")
         expect(order.world_pay_status).to eq("AUTHORISED")
       end
 
@@ -168,7 +168,7 @@ module WasteCarriersEngine
           # Wipe the date first so we know the value has been added
           order.update_attributes(date_last_updated: nil)
 
-          order.update_after_worldpay("AUTHORISED")
+          order.update_after_online_payment("AUTHORISED")
           expect(order.date_last_updated).to eq(Time.new(2004, 8, 15, 16, 23, 42))
         end
       end

--- a/spec/models/waste_carriers_engine/payment_spec.rb
+++ b/spec/models/waste_carriers_engine/payment_spec.rb
@@ -59,7 +59,7 @@ module WasteCarriersEngine
       end
     end
 
-    describe "new_from_worldpay" do
+    describe "new_from_online_payment" do
       before do
         Timecop.freeze(Time.new(2018, 1, 1)) do
           transient_registration.prepare_for_payment(:worldpay, current_user)
@@ -67,7 +67,7 @@ module WasteCarriersEngine
       end
 
       let(:order) { transient_registration.finance_details.orders.first }
-      let(:payment) { Payment.new_from_worldpay(order, current_user.email) }
+      let(:payment) { Payment.new_from_online_payment(order, current_user.email) }
 
       it "should set the correct order_key" do
         expect(payment.order_key).to eq("1514764800")
@@ -98,7 +98,7 @@ module WasteCarriersEngine
       end
     end
 
-    describe "new_from_non_worldpay" do
+    describe "new_from_non_online_payment" do
       before do
         Timecop.freeze(Time.new(2018, 1, 1)) do
           transient_registration.prepare_for_payment(:worldpay, current_user)
@@ -120,7 +120,7 @@ module WasteCarriersEngine
       end
 
       let(:order) { transient_registration.finance_details.orders.first }
-      let(:payment) { Payment.new_from_non_worldpay(params, order) }
+      let(:payment) { Payment.new_from_non_online_payment(params, order) }
 
       it "should set the correct amount" do
         expect(payment.amount).to eq(params[:amount])
@@ -175,14 +175,14 @@ module WasteCarriersEngine
       end
     end
 
-    describe "update_after_worldpay" do
+    describe "update_after_online_payment" do
       let(:order) { transient_registration.finance_details.orders.first }
-      let(:payment) { Payment.new_from_worldpay(order, current_user.email) }
+      let(:payment) { Payment.new_from_online_payment(order, current_user.email) }
 
       before do
         Timecop.freeze(Time.new(2018, 3, 4)) do
           transient_registration.prepare_for_payment(:worldpay, current_user)
-          payment.update_after_worldpay(paymentStatus: "AUTHORISED", mac: "foo")
+          payment.update_after_online_payment(paymentStatus: "AUTHORISED", mac: "foo")
         end
       end
 

--- a/spec/models/waste_carriers_engine/renewing_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_spec.rb
@@ -31,7 +31,7 @@ module WasteCarriersEngine
       context "when transitioning from worldpay_form to renewal_complete_form successfully" do
         it "set the transient registration metadata route" do
           expect(renewing_registration).to receive(:set_metadata_route).once
-          expect(renewing_registration).to receive(:pending_worldpay_payment?).and_return(false)
+          expect(renewing_registration).to receive(:pending_online_payment?).and_return(false)
           expect(renewing_registration).to receive(:conviction_check_required?).and_return(false)
 
           renewing_registration.update_attributes(workflow_state: :worldpay_form)
@@ -42,7 +42,7 @@ module WasteCarriersEngine
       context "when transitioning from worldpay_form to renewal_received_pending_conviction_form succesfully" do
         it "set the transient registration metadata route" do
           expect(renewing_registration).to receive(:set_metadata_route).once
-          expect(renewing_registration).to receive(:pending_worldpay_payment?).and_return(false)
+          expect(renewing_registration).to receive(:pending_online_payment?).and_return(false)
           expect(renewing_registration).to receive(:conviction_check_required?).and_return(true)
 
           renewing_registration.update_attributes(workflow_state: :worldpay_form)

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/worldpay_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/worldpay_form_spec.rb
@@ -23,7 +23,7 @@ module WasteCarriersEngine
 
             context "when there is no pending WorldPay payment" do
               before do
-                allow(subject).to receive(:pending_worldpay_payment?).and_return(false)
+                allow(subject).to receive(:pending_online_payment?).and_return(false)
               end
 
               include_examples "has next transition", next_state: "renewal_complete_form"
@@ -41,7 +41,7 @@ module WasteCarriersEngine
 
             context "when there is a pending WorldPay payment" do
               before do
-                allow(subject).to receive(:pending_worldpay_payment?).and_return(true)
+                allow(subject).to receive(:pending_online_payment?).and_return(true)
               end
 
               include_examples "has next transition", next_state: "renewal_received_pending_worldpay_payment_form"

--- a/spec/models/waste_carriers_engine/transient_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/transient_registration_spec.rb
@@ -116,7 +116,7 @@ module WasteCarriersEngine
       end
     end
 
-    describe "#pending_worldpay_payment?" do
+    describe "#pending_online_payment?" do
       context "when the renewal has an order" do
         before do
           transient_registration.finance_details = build(:finance_details, :has_order)
@@ -128,7 +128,7 @@ module WasteCarriersEngine
           end
 
           it "returns true" do
-            expect(transient_registration.pending_worldpay_payment?).to eq(true)
+            expect(transient_registration.pending_online_payment?).to eq(true)
           end
         end
 
@@ -138,7 +138,7 @@ module WasteCarriersEngine
           end
 
           it "returns false" do
-            expect(transient_registration.pending_worldpay_payment?).to eq(false)
+            expect(transient_registration.pending_online_payment?).to eq(false)
           end
         end
       end
@@ -149,7 +149,7 @@ module WasteCarriersEngine
         end
 
         it "returns false" do
-          expect(transient_registration.pending_worldpay_payment?).to eq(false)
+          expect(transient_registration.pending_online_payment?).to eq(false)
         end
       end
     end

--- a/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
@@ -212,7 +212,7 @@ module WasteCarriersEngine
           context "when the params are valid" do
             before do
               allow_any_instance_of(WorldpayService).to receive(:valid_pending?).and_return(true)
-              allow_any_instance_of(RenewingRegistration).to receive(:pending_worldpay_payment?).and_return(true)
+              allow_any_instance_of(RenewingRegistration).to receive(:pending_online_payment?).and_return(true)
             end
 
             it "redirects to renewal_received_pending_payment_form" do


### PR DESCRIPTION
This change renames some non-worldpay-specific model methods to `online_payment` in preparation for GovPay changes.
https://eaflood.atlassian.net/browse/RUBY-1891