### PR TITLE
Reinstate temp_tier_check attribute skip

### DIFF
--- a/app/services/waste_carriers_engine/registration_completion_service.rb
+++ b/app/services/waste_carriers_engine/registration_completion_service.rb
@@ -121,6 +121,7 @@ module WasteCarriersEngine
         "temp_os_places_error",
         "temp_payment_method",
         "temp_lookup_number",
+        "temp_tier_check",
         "temp_check_your_tier",
         "temp_reuse_registered_address",
         "temp_use_registered_company_details",

--- a/app/services/waste_carriers_engine/renewal_completion_service.rb
+++ b/app/services/waste_carriers_engine/renewal_completion_service.rb
@@ -128,6 +128,7 @@ module WasteCarriersEngine
         "temp_contact_postcode",
         "temp_os_places_error",
         "temp_payment_method",
+        "temp_tier_check",
         "temp_use_registered_company_details",
         "from_magic_link",
         "_type",


### PR DESCRIPTION
This change reinstates temp_tier_check as a transient_registration attribute to skip in the registration and renewal completion services.
Removing this from the skip list as part of a previous change caused issues in production, where some transient_registrations created _before_ the deployment of that change had the attribute, causing conversion of the transient_registration to a registration _after_ the deployment to fail.
https://eaflood.atlassian.net/browse/RUBY-1941