### PR TITLE
Use trading name form

### DIFF
--- a/app/controllers/waste_carriers_engine/use_trading_name_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/use_trading_name_forms_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class UseTradingNameFormsController < ::WasteCarriersEngine::FormsController
+    def new
+      super(UseTradingNameForm, "use_trading_name_form")
+    end
+
+    def create
+      super(UseTradingNameForm, "use_trading_name_form")
+    end
+
+    private
+
+    def transient_registration_attributes
+      params.fetch(:use_trading_name_form, {}).permit(:temp_use_trading_name)
+    end
+  end
+end

--- a/app/forms/waste_carriers_engine/check_your_answers_form.rb
+++ b/app/forms/waste_carriers_engine/check_your_answers_form.rb
@@ -8,7 +8,7 @@ module WasteCarriersEngine
     delegate :business_type, :company_name, :company_no, :contact_address, :contact_email, to: :transient_registration
     delegate :first_name, :last_name, :location, :main_people, :phone_number, to: :transient_registration
     delegate :registered_company_name, :registration_type, :relevant_people, :tier, to: :transient_registration
-    delegate :registered_address, :declared_convictions, to: :transient_registration
+    delegate :temp_use_trading_name, :registered_address, :declared_convictions, to: :transient_registration
     delegate :lower_tier?, :upper_tier?, :company_no_required?, :company_name_required?, to: :transient_registration
 
     validates :business_type, "defra_ruby/validators/business_type": {

--- a/app/forms/waste_carriers_engine/company_name_form.rb
+++ b/app/forms/waste_carriers_engine/company_name_form.rb
@@ -3,7 +3,8 @@
 module WasteCarriersEngine
   class CompanyNameForm < ::WasteCarriersEngine::BaseForm
     delegate :business_type, :company_name, :company_name_required?,
-             :registered_company_name, :tier, to: :transient_registration
+             :registered_company_name, :temp_use_trading_name, :tier,
+             to: :transient_registration
 
     validates :company_name, "waste_carriers_engine/company_name": true
   end

--- a/app/forms/waste_carriers_engine/use_trading_name_form.rb
+++ b/app/forms/waste_carriers_engine/use_trading_name_form.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class UseTradingNameForm < ::WasteCarriersEngine::BaseForm
+    delegate :company_no, to: :transient_registration
+    delegate :temp_use_trading_name, to: :transient_registration
+
+    validates :temp_use_trading_name, "waste_carriers_engine/yes_no": true
+
+  end
+end

--- a/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
@@ -42,6 +42,7 @@ module WasteCarriersEngine
         state :check_registered_company_name_form
         state :incorrect_company_form
 
+        state :use_trading_name_form
         state :company_name_form
         state :company_postcode_form
         state :company_address_form
@@ -114,7 +115,7 @@ module WasteCarriersEngine
           transitions from: :check_your_tier_form, to: :other_businesses_form,
                       if: :check_your_tier_unknown?
 
-          transitions from: :check_your_tier_form, to: :company_name_form,
+          transitions from: :check_your_tier_form, to: :use_trading_name_form,
                       if: :check_your_tier_lower?,
                       after: :set_tier_from_check_your_tier_form
 
@@ -122,8 +123,16 @@ module WasteCarriersEngine
                       if: :check_your_tier_upper?,
                       after: :set_tier_from_check_your_tier_form
 
-          transitions from: :your_tier_form, to: :company_name_form,
+          transitions from: :your_tier_form, to: :use_trading_name_form,
                       if: :lower_tier?
+
+          transitions from: :use_trading_name_form, to: :company_name_form,
+                      if: :use_trading_name?
+
+          transitions from: :use_trading_name_form, to: :company_address_manual_form,
+                      if: :overseas?
+
+          transitions from: :use_trading_name_form, to: :company_postcode_form
 
           # Smart answers
 
@@ -197,7 +206,7 @@ module WasteCarriersEngine
 
           # End registered address
 
-          transitions from: :main_people_form, to: :company_name_form
+          transitions from: :main_people_form, to: :use_trading_name_form
 
           transitions from: :declare_convictions_form, to: :conviction_details_form,
                       if: :declared_convictions?
@@ -396,6 +405,10 @@ module WasteCarriersEngine
 
       def incorrect_company_data?
         temp_use_registered_company_details == "no"
+      end
+
+      def use_trading_name?
+        temp_use_trading_name == "yes"
       end
     end
     # rubocop:enable Metrics/BlockLength

--- a/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
@@ -29,6 +29,7 @@ module WasteCarriersEngine
         state :check_registered_company_name_form
         state :incorrect_company_form
 
+        state :use_trading_name_form
         state :company_name_form
         state :company_postcode_form
         state :company_address_form
@@ -101,7 +102,18 @@ module WasteCarriersEngine
           transitions from: :renewal_information_form, to: :main_people_form,
                       if: :upper_tier?
 
-          transitions from: :renewal_information_form, to: :company_name_form
+          transitions from: :renewal_information_form, to: :company_name_form,
+                      if: :company_name_required?
+
+          transitions from: :renewal_information_form, to: :use_trading_name_form
+
+          transitions from: :use_trading_name_form, to: :company_name_form,
+                      if: :use_trading_name?
+
+          transitions from: :use_trading_name_form, to: :company_address_manual_form,
+                      if: :overseas?
+
+          transitions from: :use_trading_name_form, to: :company_postcode_form
 
           transitions from: :check_registered_company_name_form, to: :incorrect_company_form,
                       if: :incorrect_company_data?
@@ -137,7 +149,10 @@ module WasteCarriersEngine
 
           # End registered address
 
-          transitions from: :main_people_form, to: :company_name_form
+          transitions from: :main_people_form, to: :company_name_form,
+                      if: :company_name_required?
+
+          transitions from: :main_people_form, to: :use_trading_name_form
 
           transitions from: :declare_convictions_form, to: :conviction_details_form,
                       if: :declared_convictions?
@@ -261,6 +276,10 @@ module WasteCarriersEngine
 
     def paying_by_card?
       temp_payment_method == "card"
+    end
+
+    def use_trading_name?
+      temp_use_trading_name == "yes"
     end
 
     def incorrect_company_data?

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -24,6 +24,7 @@ module WasteCarriersEngine
     field :temp_payment_method, type: String
     field :temp_reuse_registered_address, type: String
     field :temp_use_registered_company_details, type: String
+    field :temp_use_trading_name, type: String
     field :workflow_history, type: Array, default: []
 
     scope :in_progress, -> { where(:workflow_state.nin => RenewingRegistration::SUBMITTED_STATES) }

--- a/app/services/waste_carriers_engine/registration_completion_service.rb
+++ b/app/services/waste_carriers_engine/registration_completion_service.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module WasteCarriersEngine
+  # rubocop:disable Metrics/ClassLength
   class RegistrationCompletionService < BaseService
     attr_reader :transient_registration
 
@@ -125,6 +126,7 @@ module WasteCarriersEngine
         "temp_check_your_tier",
         "temp_reuse_registered_address",
         "temp_use_registered_company_details",
+        "temp_use_trading_name",
         "_type",
         "workflow_state",
         "workflow_history",
@@ -137,4 +139,5 @@ module WasteCarriersEngine
     end
     # rubocop:enable Metrics/MethodLength
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/app/services/waste_carriers_engine/renewal_completion_service.rb
+++ b/app/services/waste_carriers_engine/renewal_completion_service.rb
@@ -130,6 +130,7 @@ module WasteCarriersEngine
         "temp_payment_method",
         "temp_tier_check",
         "temp_use_registered_company_details",
+        "temp_use_trading_name",
         "from_magic_link",
         "_type",
         "workflow_state",

--- a/app/validators/waste_carriers_engine/company_name_validator.rb
+++ b/app/validators/waste_carriers_engine/company_name_validator.rb
@@ -31,7 +31,9 @@ module WasteCarriersEngine
     end
 
     def valid_company_name?(record, attribute, value)
-      !record.company_name_required? || value_is_present?(record, attribute, value)
+      return true unless record.company_name_required? || record.temp_use_trading_name
+
+      value_is_present?(record, attribute, value)
     end
   end
 end

--- a/app/views/waste_carriers_engine/use_trading_name_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/use_trading_name_forms/new.html.erb
@@ -1,0 +1,37 @@
+<%= render("waste_carriers_engine/shared/back", token: @use_trading_name_form.token) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <%= t(".heading") %>
+    </h1>
+    <legend class="govuk-visually-hidden">
+      <%= t(".heading") %>
+    </legend>
+    
+    <%= form_for @use_trading_name_form do |f| %>
+      <%= render partial: "waste_carriers_engine/shared/error_summary", locals: { f: f } %>
+
+        <%= 
+          f.govuk_collection_radio_buttons :temp_use_trading_name,
+          [
+            OpenStruct.new(
+                     id: "yes",
+                     name: t(".options.yes")
+                   ),
+            OpenStruct.new(
+                      id: "no",
+                      name: t(".options.no")
+            )
+          ],
+          :id,
+          :name,
+          inline: true,
+          legend: -> do %>
+
+        <% end %>
+      <%= f.govuk_submit t(".next_button") %>
+    <% end %>
+
+  </div>
+</div>

--- a/config/locales/forms/company_name_forms/en.yml
+++ b/config/locales/forms/company_name_forms/en.yml
@@ -8,7 +8,7 @@ en:
             UPPER: &value "What's the name of the local authority or public body?"
             LOWER: *value
           limitedCompany:
-            UPPER: &optional_trade_name Do you trade under a different name? (optional)
+            UPPER: &optional_trade_name Enter your trading name
             LOWER: What's the name of the company?
           limitedLiabilityPartnership:
             UPPER: *optional_trade_name

--- a/config/locales/forms/use_trading_name_forms/en.yml
+++ b/config/locales/forms/use_trading_name_forms/en.yml
@@ -1,0 +1,19 @@
+en:
+  waste_carriers_engine:
+    use_trading_name_forms:
+      new:
+        title: Do you trade under a different name?
+        heading: Do you trade under a different name?
+        options:
+          "yes": "Yes"
+          "no": "No"
+        error_heading: Something is wrong
+        next_button: Continue
+
+  activemodel:
+    errors:
+      models:
+        waste_carriers_engine/use_trading_name_form:
+          attributes:
+            temp_use_trading_name:
+              inclusion: "You must select yes or no"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -261,6 +261,11 @@ WasteCarriersEngine::Engine.routes.draw do
               path: "incorrect-company",
               path_names: { new: "" }
 
+    resources :use_trading_name_forms,
+              only: %i[new create],
+              path: "use-trading-name",
+              path_names: { new: "" }
+
     resources :company_name_forms,
               only: %i[new create],
               path: "company-name",

--- a/spec/factories/forms/use_trading_name_form.rb
+++ b/spec/factories/forms/use_trading_name_form.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :use_trading_name_form, class: WasteCarriersEngine::UseTradingNameForm do
+
+    # set a default type
+    transient do
+      registration_type { :new_registration }
+    end
+
+    trait :new_registration do
+      registration_type { :new_registration }
+    end
+
+    trait :renewing_registration do
+      registration_type { :renewing_registration }
+    end
+
+    trait :has_required_data do
+      initialize_with { new(create(registration_type, :has_required_data, workflow_state: "use_trading_name_form")) }
+    end
+  end
+end

--- a/spec/forms/waste_carriers_engine/use_trading_name_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/use_trading_name_forms_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "defra_ruby_companies_house"
+
+module WasteCarriersEngine
+  RSpec.describe UseTradingNameForm, type: :model do
+
+    describe "#submit" do
+      let(:use_trading_name_form) { build(:use_trading_name_form, :new_registration, :has_required_data) }
+
+      context "when the form is valid" do
+        subject { use_trading_name_form.submit(valid_params) }
+
+        context "when the user selects yes" do
+          let(:valid_params) { { token: use_trading_name_form.token, temp_use_trading_name: "yes" } }
+          let(:transient_registration) { use_trading_name_form.transient_registration }
+
+          it "submits the form" do
+            expect(subject).to be_truthy
+          end
+
+          it "updates the transient registration" do
+            expect { subject }.to change { transient_registration.reload.attributes["temp_use_trading_name"] }.to("yes")
+          end
+        end
+
+        context "when the user selects no" do
+          let(:valid_params) { { token: use_trading_name_form.token, temp_use_trading_name: "no" } }
+
+          it "submits the form" do
+            expect(subject).to be_truthy
+          end
+        end
+      end
+
+      context "when the form is not valid" do
+        before do
+          expect(use_trading_name_form).to receive(:valid?).and_return(false)
+        end
+
+        it "does not submit the form" do
+          expect(use_trading_name_form.submit({})).to be_falsey
+        end
+      end
+    end
+
+    include_examples "validate yes no", :use_trading_name_form, :temp_use_trading_name
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/check_your_tier_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/check_your_tier_form_spec.rb
@@ -28,7 +28,7 @@ module WasteCarriersEngine
           context "when the check your tier answer is lower" do
             subject { build(:new_registration, workflow_state: "check_your_tier_form", temp_check_your_tier: "lower") }
 
-            include_examples "has next transition", next_state: "company_name_form"
+            include_examples "has next transition", next_state: "use_trading_name_form"
 
             it "updates the tier of the object to LOWER" do
               expect { subject.next }.to change { subject.tier }.to(WasteCarriersEngine::NewRegistration::LOWER_TIER)

--- a/spec/models/waste_carriers_engine/new_registration_workflow/company_address_manual_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/company_address_manual_form_spec.rb
@@ -4,36 +4,6 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe NewRegistration do
-    describe "#workflow_state" do
-      context "when the registration is upper tier" do
-        let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
-
-        it_behaves_like "a manual address transition",
-                        next_state: :declare_convictions_form,
-                        address_type: "company",
-                        factory: :new_registration
-      end
-
-      context "when the registration is lower tier" do
-        let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
-
-        it_behaves_like "a manual address transition",
-                        next_state: :contact_name_form,
-                        address_type: "company",
-                        factory: :new_registration
-      end
-
-      describe "#workflow_state" do
-        context ":company_address_manual_form state transitions" do
-          context "on next" do
-            context "when the registration is a lower tier" do
-              subject { build(:new_registration, :lower, workflow_state: "company_address_manual_form") }
-
-              include_examples "has next transition", next_state: "contact_name_form"
-            end
-          end
-        end
-      end
-    end
+    include_examples "company_address_manual_form workflow", factory: :new_registration
   end
 end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/company_name_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/company_name_form_spec.rb
@@ -4,20 +4,6 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe NewRegistration do
-    subject { build(:new_registration, workflow_state: "company_name_form") }
-
-    describe "#workflow_state" do
-      context ":company_name_form state transitions" do
-        context "on next" do
-          context "when the business is based overseas" do
-            subject { build(:new_registration, workflow_state: "company_name_form", location: "overseas") }
-
-            include_examples "has next transition", next_state: "company_address_manual_form"
-          end
-
-          include_examples "has next transition", next_state: "company_postcode_form"
-        end
-      end
-    end
+    include_examples "company_name_form workflow", factory: :new_registration
   end
 end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/company_postcode_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/company_postcode_form_spec.rb
@@ -4,12 +4,6 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe NewRegistration do
-    describe "#workflow_state" do
-
-      it_behaves_like "a postcode transition",
-                      address_type: "company",
-                      factory: :new_registration
-
-    end
+    include_examples "company_postcode_form workflow", factory: :new_registration
   end
 end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/main_people_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/main_people_form_spec.rb
@@ -10,7 +10,7 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":main_people_form state transitions" do
         context "on next" do
-          include_examples "has next transition", next_state: "company_name_form"
+          include_examples "has next transition", next_state: "use_trading_name_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/use_trading_name_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/use_trading_name_form_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NewRegistration do
+    include_examples "use_trading_name_form workflow", factory: :new_registration
+  end
+end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/your_tier_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/your_tier_form_spec.rb
@@ -12,7 +12,7 @@ module WasteCarriersEngine
           context "when the registration is a lower tier registration" do
             subject { build(:new_registration, :lower, workflow_state: "your_tier_form") }
 
-            include_examples "has next transition", next_state: "company_name_form"
+            include_examples "has next transition", next_state: "use_trading_name_form"
           end
 
           context "when the registration is an upper tier registration" do

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/company_address_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/company_address_form_spec.rb
@@ -4,40 +4,6 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe RenewingRegistration do
-    context "when the registration is upper tier" do
-      let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
-
-      it_behaves_like "an address lookup transition",
-                      next_state_if_not_skipping_to_manual: :declare_convictions_form,
-                      address_type: "company",
-                      factory: :renewing_registration
-    end
-
-    context "when the registration is lower tier" do
-      let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
-
-      it_behaves_like "an address lookup transition",
-                      next_state_if_not_skipping_to_manual: :contact_name_form,
-                      address_type: "company",
-                      factory: :renewing_registration
-    end
-
-    describe "#workflow_state" do
-      context ":company_address_form state transitions" do
-        context "on next" do
-          context "when the registration is upper tier" do
-            subject { build(:renewing_registration, tier: "UPPER", workflow_state: "company_address_form") }
-
-            include_examples "has next transition", next_state: "declare_convictions_form"
-          end
-
-          context "when the registration is lower tier" do
-            subject { build(:renewing_registration, tier: "LOWER", workflow_state: "company_address_form") }
-
-            include_examples "has next transition", next_state: "contact_name_form"
-          end
-        end
-      end
-    end
+    include_examples "company_address_manual_form workflow", factory: :renewing_registration
   end
 end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/company_name_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/company_name_form_spec.rb
@@ -4,30 +4,6 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe RenewingRegistration, type: :model do
-    subject do
-      build(:renewing_registration,
-            :has_required_data,
-            business_type: business_type,
-            location: location,
-            tier: tier,
-            workflow_state: "company_name_form")
-    end
-    let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
-    let(:location) { "england" }
-    let(:business_type) { "soleTrader" }
-
-    describe "#workflow_state" do
-      context ":company_name_form state transitions" do
-        context "on next" do
-          include_examples "has next transition", next_state: "company_postcode_form"
-
-          context "when the location is overseas" do
-            let(:location) { "overseas" }
-
-            include_examples "has next transition", next_state: "company_address_manual_form"
-          end
-        end
-      end
-    end
+    include_examples "company_name_form workflow", factory: :renewing_registration
   end
 end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/company_postcode_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/company_postcode_form_spec.rb
@@ -4,12 +4,6 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe RenewingRegistration do
-    describe "#workflow_state" do
-
-      it_behaves_like "a postcode transition",
-                      address_type: "company",
-                      factory: :renewing_registration
-
-    end
+    include_examples "company_postcode_form workflow", factory: :renewing_registration
   end
 end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/main_people_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/main_people_form_spec.rb
@@ -17,7 +17,7 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":main_people_form state transitions" do
         context "on next" do
-          include_examples "has next transition", next_state: "company_name_form"
+          include_examples "has next transition", next_state: "use_trading_name_form"
         end
       end
     end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/use_trading_name_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/use_trading_name_form_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe RenewingRegistration do
+    include_examples "use_trading_name_form workflow", factory: :renewing_registration
+  end
+end

--- a/spec/requests/waste_carriers_engine/main_people_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/main_people_forms_spec.rb
@@ -32,7 +32,7 @@ module WasteCarriersEngine
               }
             end
 
-            it "correctly updates the key people, returns a 302 response and redirects to the company_name form" do
+            it "correctly updates the key people, returns a 302 response and redirects to the use_trading_name form" do
               key_people_count = transient_registration.key_people.count
 
               post main_people_forms_path(transient_registration.token), params: { main_people_form: valid_params }
@@ -40,7 +40,7 @@ module WasteCarriersEngine
               expect(transient_registration.reload.key_people.count).to eq(key_people_count + 1)
               expect(transient_registration.reload.key_people.last.first_name).to eq(valid_params[:first_name])
               expect(response).to have_http_status(302)
-              expect(response).to redirect_to(new_company_name_form_path(transient_registration[:token]))
+              expect(response).to redirect_to(new_use_trading_name_form_path(transient_registration[:token]))
             end
 
             context "when there is already a main person" do

--- a/spec/requests/waste_carriers_engine/use_trading_name_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/use_trading_name_forms_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "UseTradingNameForms", type: :request do
+    include_examples "GET flexible form", "use_trading_name_form"
+
+    describe "POST use_trading_name_form_path" do
+      include_examples "POST renewal form",
+                       "use_trading_name_form",
+                       valid_params: { temp_use_trading_name: "no" },
+                       invalid_params: { temp_use_trading_name: "" },
+                       test_attribute: :temp_use_trading_name
+
+      context "When the transient_registration is a new registration" do
+        let(:transient_registration) do
+          create(:new_registration, :has_required_data, tier: "LOWER", workflow_state: "use_trading_name_form")
+        end
+
+        include_examples "POST form",
+                         "use_trading_name_form",
+                         valid_params: { temp_use_trading_name: "yes" },
+                         invalid_params: { temp_use_trading_name: "" }
+      end
+    end
+  end
+end

--- a/spec/requests/waste_carriers_engine/your_tier_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/your_tier_forms_spec.rb
@@ -21,14 +21,14 @@ module WasteCarriersEngine
       context "when the new registration is a lower tier registration" do
         let(:new_registration) { create(:new_registration, :lower, workflow_state: "your_tier_form") }
 
-        it "updates the transient registration workflow and redirects to the company_name_form with a 302 status code" do
+        it "updates the transient registration workflow and redirects to the use_trading_name_form with a 302 status code" do
           post new_your_tier_form_path(params)
 
           new_registration.reload
 
-          expect(response).to redirect_to(new_company_name_form_path(new_registration.token))
+          expect(response).to redirect_to(new_use_trading_name_form_path(new_registration.token))
           expect(response).to have_http_status(302)
-          expect(new_registration.workflow_state).to eq("company_name_form")
+          expect(new_registration.workflow_state).to eq("use_trading_name_form")
         end
       end
 

--- a/spec/support/shared_examples/form_workflows/company_address_manual_form_workflow.rb
+++ b/spec/support/shared_examples/form_workflows/company_address_manual_form_workflow.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "company_address_manual_form workflow" do |factory:|
+  describe "#workflow_state" do
+    context "when the registration is upper tier" do
+      let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
+
+      context "when the user has opted to provide a trading name" do
+        let(:temp_use_trading_name) { "yes" }
+
+        it_behaves_like "a manual address transition",
+                        next_state: :declare_convictions_form,
+                        address_type: "company",
+                        factory: factory
+      end
+
+      context "when the user has opted to not provide a trading name" do
+        let(:temp_use_trading_name) { "no" }
+
+        it_behaves_like "a manual address transition",
+                        next_state: :declare_convictions_form,
+                        address_type: "company",
+                        factory: factory
+      end
+    end
+
+    context "when the registration is lower tier" do
+      let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
+
+      context "when the user has opted to provide a trading name" do
+        let(:temp_use_trading_name) { "yes" }
+
+        it_behaves_like "a manual address transition",
+                        next_state: :contact_name_form,
+                        address_type: "company",
+                        factory: factory
+      end
+
+      context "when the user has opted to not provide a trading name" do
+        let(:temp_use_trading_name) { "no" }
+
+        it_behaves_like "a manual address transition",
+                        next_state: :contact_name_form,
+                        address_type: "company",
+                        factory: factory
+      end
+    end
+
+    describe "#workflow_state" do
+      context ":company_address_manual_form state transitions" do
+        context "on next" do
+          context "when the registration is a lower tier" do
+            subject { build(:new_registration, :lower, workflow_state: "company_address_manual_form") }
+
+            include_examples "has next transition", next_state: "contact_name_form"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/form_workflows/company_name_form_workflow.rb
+++ b/spec/support/shared_examples/form_workflows/company_name_form_workflow.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "company_name_form workflow" do |factory:|
+  subject { build(factory, workflow_state: "company_name_form") }
+
+  describe "#workflow_state" do
+    context ":company_name_form state transitions" do
+      context "on next" do
+        include_examples "has next transition", next_state: "company_postcode_form"
+
+        context "when the business is based overseas" do
+          subject { build(factory, workflow_state: "company_name_form", location: "overseas") }
+
+          include_examples "has next transition", next_state: "company_address_manual_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/form_workflows/company_postcode_form_workflow.rb
+++ b/spec/support/shared_examples/form_workflows/company_postcode_form_workflow.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "company_postcode_form workflow" do |factory:|
+  describe "#workflow_state" do
+
+    context "when the user has opted to provide a trading name" do
+      let(:temp_use_trading_name) { "yes" }
+
+      it_behaves_like "a postcode transition",
+                      address_type: "company",
+                      factory: factory
+    end
+
+    context "when the user has opted not to provide a trading name" do
+      let(:temp_use_trading_name) { "no" }
+
+      it_behaves_like "a postcode transition",
+                      address_type: "company",
+                      factory: factory
+    end
+  end
+end

--- a/spec/support/shared_examples/form_workflows/use_trading_name_form_workflow.rb
+++ b/spec/support/shared_examples/form_workflows/use_trading_name_form_workflow.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "use_trading_name_form workflow" do |factory:|
+  describe "#workflow_state" do
+    context ":use_trading_name_form state transitions" do
+
+      subject { build(factory, workflow_state: "use_trading_name_form", **params) }
+
+      context "on next" do
+        context "when the user selects Yes" do
+          let(:params) { { temp_use_trading_name: "yes" } }
+
+          include_examples "has next transition", next_state: "company_name_form"
+        end
+
+        context "when the user selects No" do
+          let(:params) { { temp_use_trading_name: "no" } }
+
+          context "when the business is based overseas" do
+            let(:params) { { temp_use_trading_name: "no", location: "overseas" } }
+
+            include_examples "has next transition", next_state: "company_address_manual_form"
+          end
+
+          include_examples "has next transition", next_state: "company_postcode_form"
+        end
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/validate_company_name.rb
+++ b/spec/support/shared_examples/validate_company_name.rb
@@ -7,6 +7,14 @@ RSpec.shared_examples "valid only if company_name is not required" do
     it "is valid" do
       expect(form).to be_valid
     end
+
+    context "and the user has opted to provide a trading name" do
+      before { form.transient_registration.temp_use_trading_name = "yes" }
+
+      it "is not valid" do
+        expect(form).to_not be_valid
+      end
+    end
   end
 
   context "when the company name is required" do


### PR DESCRIPTION
This change adds a new form to ask the user whether they wish to provide a trading name, and shows the existing company_name form only if they select "Yes".
https://eaflood.atlassian.net/browse/RUBY-1942
