### PR TITLE
Skip duplicated steps on back navigation

### DIFF
--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -78,7 +78,7 @@ module WasteCarriersEngine
       last_popped = nil
       until workflow_history.empty?
         last_popped = workflow_history.pop
-        break if valid_state?(last_popped)
+        break if valid_state?(last_popped) && last_popped != workflow_state
 
         last_popped = nil
       end

--- a/spec/models/waste_carriers_engine/transient_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/transient_registration_spec.rb
@@ -287,6 +287,21 @@ module WasteCarriersEngine
           expect { subject }.to change { new_registration.workflow_history.length }.by(-1)
         end
       end
+
+      context "when the current state is also in the workflow history" do
+        before do
+          new_registration.workflow_history = %w[start_form location_form location_form]
+          new_registration.workflow_state = "location_form"
+        end
+
+        it "skips the duplicated state" do
+          expect { subject }.to change { new_registration.workflow_state }.to("start_form")
+        end
+
+        it "deletes from workflow history" do
+          expect { subject }.to change { new_registration.workflow_history.length }.to(0)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Using the browser's back button may result in duplicate entries in the workflow history, so that clicking the back link brings the user back to the same form. This change skips any history entries which match the workflow state.
https://eaflood.atlassian.net/browse/RUBY-1950
