### PR TITLE
Fix navigation where company name is mandatory

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -130,6 +130,8 @@ module WasteCarriersEngine
       end
 
       def company_name_required?
+        return true if overseas?
+
         case business_type
         when "limitedCompany", "limitedLiabilityPartnership", "soleTrader"
           # mandatory for lower tier, optional for upper tier

--- a/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
@@ -103,22 +103,27 @@ module WasteCarriersEngine
 
           transitions from: :register_in_wales_form, to: :business_type_form
 
-          # Business type & tier
+          # Business type
           transitions from: :business_type_form, to: :your_tier_form,
                       if: :switch_to_lower_tier_based_on_business_type?,
                       after: :switch_to_lower_tier
 
           transitions from: :business_type_form, to: :check_your_tier_form
 
+          # Tier
           transitions from: :check_your_tier_form, to: :other_businesses_form,
                       if: :check_your_tier_unknown?
 
-          transitions from: :check_your_tier_form, to: :use_trading_name_form,
-                      if: :check_your_tier_lower?,
-                      after: :set_tier_from_check_your_tier_form
-
           transitions from: :check_your_tier_form, to: :cbd_type_form,
                       if: :check_your_tier_upper?,
+                      after: :set_tier_from_check_your_tier_form
+
+          transitions from: :check_your_tier_form, to: :company_name_form,
+                      if: :set_tier_and_company_name_required?,
+                      after: :set_tier_from_check_your_tier_form
+
+          transitions from: :check_your_tier_form, to: :use_trading_name_form,
+                      if: :upper_tier?,
                       after: :set_tier_from_check_your_tier_form
 
           # Smart answers
@@ -139,8 +144,11 @@ module WasteCarriersEngine
           transitions from: :waste_types_form, to: :your_tier_form,
                       after: :switch_to_upper_tier
 
+          transitions from: :your_tier_form, to: :company_name_form,
+                      if: :company_name_required?
+
           transitions from: :your_tier_form, to: :use_trading_name_form,
-                      if: :lower_tier?
+                      if: :upper_tier?
 
           transitions from: :your_tier_form, to: :cbd_type_form
 
@@ -200,9 +208,14 @@ module WasteCarriersEngine
 
           transitions from: :company_address_manual_form, to: :declare_convictions_form
 
-          # Main people & convictions
+          # Main people
+
+          transitions from: :main_people_form, to: :company_name_form,
+                      if: :company_name_required?
+
           transitions from: :main_people_form, to: :use_trading_name_form
 
+          # Convictions
           transitions from: :declare_convictions_form, to: :conviction_details_form,
                       if: :declared_convictions?
 
@@ -210,6 +223,7 @@ module WasteCarriersEngine
 
           transitions from: :conviction_details_form, to: :contact_name_form
 
+          # Contact details
           transitions from: :contact_name_form, to: :contact_phone_form
 
           transitions from: :contact_phone_form, to: :contact_email_form
@@ -386,6 +400,11 @@ module WasteCarriersEngine
         return switch_to_upper_tier if temp_check_your_tier == "upper"
 
         switch_to_lower_tier
+      end
+
+      def set_tier_and_company_name_required?
+        set_tier_from_check_your_tier_form
+        company_name_required?
       end
 
       def reuse_registered_address?

--- a/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
@@ -83,7 +83,6 @@ module WasteCarriersEngine
                       if: :should_renew?
 
           # Location
-
           transitions from: :location_form, to: :register_in_northern_ireland_form,
                       if: :should_register_in_northern_ireland?
 
@@ -104,8 +103,7 @@ module WasteCarriersEngine
 
           transitions from: :register_in_wales_form, to: :business_type_form
 
-          # End location
-
+          # Business type & tier
           transitions from: :business_type_form, to: :your_tier_form,
                       if: :switch_to_lower_tier_based_on_business_type?,
                       after: :switch_to_lower_tier
@@ -123,19 +121,7 @@ module WasteCarriersEngine
                       if: :check_your_tier_upper?,
                       after: :set_tier_from_check_your_tier_form
 
-          transitions from: :your_tier_form, to: :use_trading_name_form,
-                      if: :lower_tier?
-
-          transitions from: :use_trading_name_form, to: :company_name_form,
-                      if: :use_trading_name?
-
-          transitions from: :use_trading_name_form, to: :company_address_manual_form,
-                      if: :overseas?
-
-          transitions from: :use_trading_name_form, to: :company_postcode_form
-
           # Smart answers
-
           transitions from: :other_businesses_form, to: :construction_demolition_form,
                       if: :only_carries_own_waste?
 
@@ -153,8 +139,10 @@ module WasteCarriersEngine
           transitions from: :waste_types_form, to: :your_tier_form,
                       after: :switch_to_upper_tier
 
-          transitions from: :your_tier_form, to: :cbd_type_form,
-                      if: :upper_tier?
+          transitions from: :your_tier_form, to: :use_trading_name_form,
+                      if: :lower_tier?
+
+          transitions from: :your_tier_form, to: :cbd_type_form
 
           transitions from: :construction_demolition_form, to: :your_tier_form,
                       if: :switch_to_lower_tier_based_on_smart_answers?,
@@ -163,13 +151,13 @@ module WasteCarriersEngine
           transitions from: :construction_demolition_form, to: :your_tier_form,
                       after: :switch_to_upper_tier
 
-          # End smart answers
-
+          # CBD Type
           transitions from: :cbd_type_form, to: :main_people_form,
                       if: :skip_registration_number?
 
           transitions from: :cbd_type_form, to: :registration_number_form
 
+          # Registered company details
           transitions from: :registration_number_form, to: :check_registered_company_name_form
 
           transitions from: :check_registered_company_name_form, to: :incorrect_company_form,
@@ -179,13 +167,21 @@ module WasteCarriersEngine
 
           transitions from: :incorrect_company_form, to: :registration_number_form
 
+          # Trading name
+          transitions from: :use_trading_name_form, to: :company_name_form,
+                      if: :use_trading_name?
+
+          transitions from: :use_trading_name_form, to: :company_address_manual_form,
+                      if: :overseas?
+
+          transitions from: :use_trading_name_form, to: :company_postcode_form
+
           transitions from: :company_name_form, to: :company_address_manual_form,
                       if: :overseas?
 
           transitions from: :company_name_form, to: :company_postcode_form
 
           # Registered address
-
           transitions from: :company_postcode_form, to: :company_address_manual_form,
                       if: :skip_to_manual_address?
 
@@ -204,8 +200,7 @@ module WasteCarriersEngine
 
           transitions from: :company_address_manual_form, to: :declare_convictions_form
 
-          # End registered address
-
+          # Main people & convictions
           transitions from: :main_people_form, to: :use_trading_name_form
 
           transitions from: :declare_convictions_form, to: :conviction_details_form,
@@ -224,7 +219,6 @@ module WasteCarriersEngine
           transitions from: :contact_email_form, to: :contact_postcode_form
 
           # Contact address
-
           transitions from: :contact_address_reuse_form, to: :check_your_answers_form,
                       if: :reuse_registered_address?,
                       after: :set_contact_address_as_registered_address
@@ -248,8 +242,7 @@ module WasteCarriersEngine
 
           transitions from: :contact_address_manual_form, to: :check_your_answers_form
 
-          # End contact address
-
+          # Check answers & declaration
           transitions from: :check_your_answers_form, to: :declaration_form
 
           transitions from: :declaration_form, to: :registration_completed_form,
@@ -260,6 +253,7 @@ module WasteCarriersEngine
 
           transitions from: :declaration_form, to: :cards_form
 
+          # Payment & Completion
           transitions from: :cards_form, to: :payment_summary_form
 
           transitions from: :payment_summary_form, to: :worldpay_form,
@@ -267,20 +261,19 @@ module WasteCarriersEngine
 
           transitions from: :payment_summary_form, to: :confirm_bank_transfer_form
 
-          # Registration completion forms
           transitions from: :confirm_bank_transfer_form, to: :registration_received_pending_payment_form,
                       # TODO: This don't get triggered if in the `success`
                       # callback block, hence we went for `after`
                       after: :set_metadata_route
 
-          transitions from: :worldpay_form,
-                      to: :registration_received_pending_worldpay_payment_form, if: :pending_worldpay_payment?,
+          transitions from: :worldpay_form, to: :registration_received_pending_worldpay_payment_form,
+                      if: :pending_worldpay_payment?,
                       # TODO: This don't get triggered if in the `success`
                       # callback block, hence we went for `after`
                       after: :set_metadata_route
 
-          transitions from: :worldpay_form,
-                      to: :registration_received_pending_conviction_form, if: :conviction_check_required?,
+          transitions from: :worldpay_form, to: :registration_received_pending_conviction_form,
+                      if: :conviction_check_required?,
                       # TODO: This don't get triggered if in the `success`
                       # callback block, hence we went for `after`
                       after: :set_metadata_route

--- a/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
@@ -86,12 +86,13 @@ module WasteCarriersEngine
 
           transitions from: :register_in_wales_form, to: :business_type_form
 
-          # Business type & CBD type
+          # Business type
           transitions from: :business_type_form, to: :cbd_type_form,
                       if: :business_type_change_valid?
 
           transitions from: :business_type_form, to: :cannot_renew_type_change_form
 
+          # CBD type
           transitions from: :cbd_type_form, to: :renewal_information_form
 
           # Renewal information
@@ -147,12 +148,13 @@ module WasteCarriersEngine
 
           transitions from: :company_address_manual_form, to: :declare_convictions_form
 
-          # Main people & convictions
+          # Main people
           transitions from: :main_people_form, to: :company_name_form,
                       if: :company_name_required?
 
           transitions from: :main_people_form, to: :use_trading_name_form
 
+          # Convictions
           transitions from: :declare_convictions_form, to: :conviction_details_form,
                       if: :declared_convictions?
 

--- a/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
@@ -66,7 +66,6 @@ module WasteCarriersEngine
           transitions from: :renewal_start_form, to: :location_form
 
           # Location
-
           transitions from: :location_form, to: :register_in_northern_ireland_form,
                       if: :should_register_in_northern_ireland?
 
@@ -87,8 +86,7 @@ module WasteCarriersEngine
 
           transitions from: :register_in_wales_form, to: :business_type_form
 
-          # End location
-
+          # Business type & CBD type
           transitions from: :business_type_form, to: :cbd_type_form,
                       if: :business_type_change_valid?
 
@@ -96,6 +94,7 @@ module WasteCarriersEngine
 
           transitions from: :cbd_type_form, to: :renewal_information_form
 
+          # Renewal information
           transitions from: :renewal_information_form, to: :check_registered_company_name_form,
                       unless: :skip_registration_number?
 
@@ -107,6 +106,15 @@ module WasteCarriersEngine
 
           transitions from: :renewal_information_form, to: :use_trading_name_form
 
+          # Registered company details
+          transitions from: :check_registered_company_name_form, to: :incorrect_company_form,
+                      if: :incorrect_company_data?
+
+          transitions from: :check_registered_company_name_form, to: :main_people_form
+
+          transitions from: :incorrect_company_form, to: :registration_number_form
+
+          # Trading name
           transitions from: :use_trading_name_form, to: :company_name_form,
                       if: :use_trading_name?
 
@@ -115,20 +123,12 @@ module WasteCarriersEngine
 
           transitions from: :use_trading_name_form, to: :company_postcode_form
 
-          transitions from: :check_registered_company_name_form, to: :incorrect_company_form,
-                      if: :incorrect_company_data?
-
-          transitions from: :check_registered_company_name_form, to: :main_people_form
-
-          transitions from: :incorrect_company_form, to: :registration_number_form
-
           transitions from: :company_name_form, to: :company_address_manual_form,
                       if: :based_overseas?
 
           transitions from: :company_name_form, to: :company_postcode_form
 
           # Registered address
-
           transitions from: :company_postcode_form, to: :company_address_manual_form,
                       if: :skip_to_manual_address?
 
@@ -147,8 +147,7 @@ module WasteCarriersEngine
 
           transitions from: :company_address_manual_form, to: :declare_convictions_form
 
-          # End registered address
-
+          # Main people & convictions
           transitions from: :main_people_form, to: :company_name_form,
                       if: :company_name_required?
 
@@ -171,7 +170,6 @@ module WasteCarriersEngine
           transitions from: :contact_email_form, to: :contact_postcode_form
 
           # Contact address
-
           transitions from: :contact_postcode_form, to: :contact_address_manual_form,
                       if: :skip_to_manual_address?
 
@@ -184,12 +182,13 @@ module WasteCarriersEngine
 
           transitions from: :contact_address_manual_form, to: :check_your_answers_form
 
-          # End contact address
+          # Check answers & declaration
 
           transitions from: :check_your_answers_form, to: :declaration_form
 
           transitions from: :declaration_form, to: :cards_form
 
+          # Payment & completion
           transitions from: :cards_form, to: :payment_summary_form
 
           transitions from: :payment_summary_form, to: :worldpay_form,

--- a/spec/models/waste_carriers_engine/new_registration_workflow/check_your_tier_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/check_your_tier_form_spec.rb
@@ -28,7 +28,7 @@ module WasteCarriersEngine
           context "when the check your tier answer is lower" do
             subject { build(:new_registration, workflow_state: "check_your_tier_form", temp_check_your_tier: "lower") }
 
-            include_examples "has next transition", next_state: "use_trading_name_form"
+            include_examples "has next transition", next_state: "company_name_form"
 
             it "updates the tier of the object to LOWER" do
               expect { subject.next }.to change { subject.tier }.to(WasteCarriersEngine::NewRegistration::LOWER_TIER)

--- a/spec/models/waste_carriers_engine/new_registration_workflow/your_tier_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/your_tier_form_spec.rb
@@ -9,16 +9,62 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":your_tier_form state transitions" do
         context "on next" do
-          context "when the registration is a lower tier registration" do
-            subject { build(:new_registration, :lower, workflow_state: "your_tier_form") }
 
-            include_examples "has next transition", next_state: "use_trading_name_form"
+          let(:business_type) { %i[charity limitedCompany limitedLiabilityPartnership localAuthority partnership soleTrader].sample }
+
+          subject { build(:new_registration, business_type: business_type, tier: tier, location: location, workflow_state: "your_tier_form") }
+
+          context "when the registration is a lower tier registration" do
+            let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
+
+            context "based in England" do
+              let(:location) { "England" }
+
+              include_examples "has next transition", next_state: "company_name_form"
+            end
+
+            context "based overseas" do
+              let(:location) { "overseas" }
+
+              include_examples "has next transition", next_state: "company_name_form"
+            end
           end
 
           context "when the registration is an upper tier registration" do
-            subject { build(:new_registration, :upper, workflow_state: "your_tier_form") }
+            let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
 
-            include_examples "has next transition", next_state: "cbd_type_form"
+            context "for a limited company, limited liability partnership or sole trader" do
+              let(:business_type) { %i[limitedCompany limitedLiabilityPartnership soleTrader].sample }
+
+              context "based in England" do
+                let(:location) { "England" }
+
+                include_examples "has next transition", next_state: "use_trading_name_form"
+              end
+
+              context "based overseas" do
+                let(:location) { "overseas" }
+
+                include_examples "has next transition", next_state: "company_name_form"
+              end
+            end
+
+            context "for a business type other than company or sole trader" do
+              let(:business_type) { %i[charity localAuthority partnership].sample }
+              let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
+
+              context "based in England" do
+                let(:location) { "England" }
+
+                include_examples "has next transition", next_state: "company_name_form"
+              end
+
+              context "based overseas" do
+                let(:location) { "overseas" }
+
+                include_examples "has next transition", next_state: "company_name_form"
+              end
+            end
           end
         end
       end

--- a/spec/support/shared_examples/can_have_registration_attributes.rb
+++ b/spec/support/shared_examples/can_have_registration_attributes.rb
@@ -525,5 +525,15 @@ RSpec.shared_examples "Can have registration attributes" do |factory:|
       let(:business_type) { "soleTrader" }
       it_behaves_like "it is required for lower tier only"
     end
+
+    context "for an overseas business" do
+      let(:business_type) { "soleTrader" }
+      let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
+      before { resource.location = "overseas" }
+
+      it "returns true" do
+        expect(subject).to be true
+      end
+    end
   end
 end


### PR DESCRIPTION
This change fixes an issue with form navigation, bypassing the `use_trading_name` form where company name is mandatory. 
https://eaflood.atlassian.net/browse/RUBY-1942