### PR TITLE
Fix/use trading name mandatory

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
@@ -143,10 +143,7 @@ module WasteCarriersEngine
                       after: :switch_to_upper_tier
 
           transitions from: :your_tier_form, to: :company_name_form,
-                      if: :company_name_required?
-
-          transitions from: :your_tier_form, to: :use_trading_name_form,
-                      if: :upper_tier?
+                      if: :lower_tier?
 
           transitions from: :your_tier_form, to: :cbd_type_form
 

--- a/app/validators/waste_carriers_engine/company_name_validator.rb
+++ b/app/validators/waste_carriers_engine/company_name_validator.rb
@@ -31,7 +31,7 @@ module WasteCarriersEngine
     end
 
     def valid_company_name?(record, attribute, value)
-      return true unless record.company_name_required? || record.temp_use_trading_name
+      return true unless record.company_name_required? || record.temp_use_trading_name == "yes"
 
       value_is_present?(record, attribute, value)
     end

--- a/spec/forms/waste_carriers_engine/check_your_answers_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/check_your_answers_forms_spec.rb
@@ -331,6 +331,43 @@ module WasteCarriersEngine
         end
       end
 
+      describe "#company_name" do
+        context "without a company name" do
+          before do
+            check_your_answers_form.transient_registration.company_name = nil
+            check_your_answers_form.transient_registration.temp_use_trading_name = "no"
+          end
+
+          context "for an upper tier registration" do
+            before { check_your_answers_form.transient_registration.tier = "UPPER" }
+
+            context "based in England" do
+              before { check_your_answers_form.transient_registration.location = "england" }
+
+              it "is valid" do
+                expect(check_your_answers_form).to be_valid
+              end
+            end
+
+            context "based overseas" do
+              before { check_your_answers_form.transient_registration.location = "overseas" }
+
+              it "is not valid" do
+                expect(check_your_answers_form).to_not be_valid
+              end
+            end
+          end
+
+          context "for a lower tier registration" do
+            before { check_your_answers_form.transient_registration.tier = "LOWER" }
+
+            it "is not valid" do
+              expect(check_your_answers_form).to_not be_valid
+            end
+          end
+        end
+      end
+
       context "when the business type has an invalid change" do
         before(:each) do
           check_your_answers_form.transient_registration.business_type = "limitedCompany"

--- a/spec/models/waste_carriers_engine/new_registration_workflow/your_tier_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/your_tier_form_spec.rb
@@ -4,27 +4,22 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe NewRegistration do
+
+    all_business_types = %i[charity limitedCompany limitedLiabilityPartnership localAuthority partnership soleTrader].freeze
+
     subject { build(:new_registration, workflow_state: "your_tier_form", temp_check_your_tier: "unknown") }
 
     describe "#workflow_state" do
       context ":your_tier_form state transitions" do
         context "on next" do
 
-          let(:business_type) { %i[charity limitedCompany limitedLiabilityPartnership localAuthority partnership soleTrader].sample }
-
-          subject { build(:new_registration, business_type: business_type, tier: tier, location: location, workflow_state: "your_tier_form") }
+          subject { build(:new_registration, business_type: business_type, tier: tier, workflow_state: "your_tier_form") }
 
           context "when the registration is a lower tier registration" do
             let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
 
-            context "based in England" do
-              let(:location) { "England" }
-
-              include_examples "has next transition", next_state: "company_name_form"
-            end
-
-            context "based overseas" do
-              let(:location) { "overseas" }
+            all_business_types.each do |business_type|
+              let(:business_type) { business_type }
 
               include_examples "has next transition", next_state: "company_name_form"
             end
@@ -33,37 +28,10 @@ module WasteCarriersEngine
           context "when the registration is an upper tier registration" do
             let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
 
-            context "for a limited company, limited liability partnership or sole trader" do
-              let(:business_type) { %i[limitedCompany limitedLiabilityPartnership soleTrader].sample }
+            all_business_types.each do |business_type|
+              let(:business_type) { business_type }
 
-              context "based in England" do
-                let(:location) { "England" }
-
-                include_examples "has next transition", next_state: "use_trading_name_form"
-              end
-
-              context "based overseas" do
-                let(:location) { "overseas" }
-
-                include_examples "has next transition", next_state: "company_name_form"
-              end
-            end
-
-            context "for a business type other than company or sole trader" do
-              let(:business_type) { %i[charity localAuthority partnership].sample }
-              let(:tier) { WasteCarriersEngine::Registration::LOWER_TIER }
-
-              context "based in England" do
-                let(:location) { "England" }
-
-                include_examples "has next transition", next_state: "company_name_form"
-              end
-
-              context "based overseas" do
-                let(:location) { "overseas" }
-
-                include_examples "has next transition", next_state: "company_name_form"
-              end
+              include_examples "has next transition", next_state: "cbd_type_form"
             end
           end
         end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/main_people_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/main_people_form_spec.rb
@@ -7,12 +7,8 @@ module WasteCarriersEngine
     subject do
       build(:renewing_registration,
             :has_required_data,
-            addresses: addresses,
-            business_type: business_type,
             workflow_state: "main_people_form")
     end
-    let(:business_type) { "soleTrader" }
-    let(:addresses) { [] }
 
     describe "#workflow_state" do
       context ":main_people_form state transitions" do

--- a/spec/requests/waste_carriers_engine/your_tier_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/your_tier_forms_spec.rb
@@ -18,7 +18,7 @@ module WasteCarriersEngine
     describe "POST your_tier_form_path" do
       let(:params) { { token: new_registration.token } }
 
-      RSpec.shared_examples "updates workflow state and redirects" do |next_form|
+      RSpec.shared_examples "updates workflow state and redirects" do |business_type, next_form|
         let(:new_registration) { create(:new_registration, tier, business_type: business_type, workflow_state: "your_tier_form") }
 
         it "updates the transient registration workflow" do
@@ -40,48 +40,17 @@ module WasteCarriersEngine
 
       context "when the new registration is a lower tier registration" do
         let(:tier) { :lower }
-        let(:business_type) { "soleTrader" }
 
-        it_behaves_like "updates workflow state and redirects", "company_name_form"
+        %i[charity limitedCompany limitedLiabilityPartnership localAuthority partnership soleTrader].each do |business_type|
+          it_behaves_like "updates workflow state and redirects", business_type, "company_name_form"
+        end
       end
 
       context "when the new registration is an upper tier registration" do
         let(:tier) { :upper }
 
-        context "and the business type does not require a company name" do
-
-          context "with business type limitedCompany" do
-            let(:business_type) { "limitedCompany" }
-            it_behaves_like "updates workflow state and redirects", "use_trading_name_form"
-          end
-
-          context "with business type limitedLiabilityPartnership" do
-            let(:business_type) { "limitedLiabilityPartnership" }
-            it_behaves_like "updates workflow state and redirects", "use_trading_name_form"
-          end
-
-          context "with business type soleTrader" do
-            let(:business_type) { "soleTrader" }
-            it_behaves_like "updates workflow state and redirects", "use_trading_name_form"
-          end
-        end
-
-        context "and the business type requires a company name" do
-
-          context "with business type partnership" do
-            let(:business_type) { "partnership" }
-            it_behaves_like "updates workflow state and redirects", "company_name_form"
-          end
-
-          context "with business type localAuthority" do
-            let(:business_type) { "localAuthority" }
-            it_behaves_like "updates workflow state and redirects", "company_name_form"
-          end
-
-          context "with business type charity" do
-            let(:business_type) { "charity" }
-            it_behaves_like "updates workflow state and redirects", "company_name_form"
-          end
+        %i[charity limitedCompany limitedLiabilityPartnership localAuthority partnership soleTrader].each do |business_type|
+          it_behaves_like "updates workflow state and redirects", business_type, "cbd_type_form"
         end
       end
     end


### PR DESCRIPTION
This change fixes the navigation to the cbd_type form and also fixes the checking of the `temp_use_trading_name` value in the check answers form.
https://eaflood.atlassian.net/browse/RUBY-1942