### PR TITLE
Prevent changing from partnership to LLP

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_check_business_type_changes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_check_business_type_changes.rb
@@ -25,8 +25,6 @@ module WasteCarriersEngine
           changing_to?("localAuthority")
         when "limitedCompany"
           changing_to?("limitedLiabilityPartnership")
-        when "partnership"
-          changing_to?("limitedLiabilityPartnership")
         when "publicBody"
           changing_to?("localAuthority")
         # There are no valid changes for charity or soleTrader

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/business_type_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/business_type_form_spec.rb
@@ -24,7 +24,7 @@ module WasteCarriersEngine
             %w[charity limitedCompany] => :cannot_renew_type_change_form,
             %w[limitedCompany limitedLiabilityPartnership] => :cbd_type_form,
             %w[limitedCompany soleTrader] => :cannot_renew_type_change_form,
-            %w[partnership limitedLiabilityPartnership] => :cbd_type_form,
+            %w[partnership limitedLiabilityPartnership] => :cannot_renew_type_change_form,
             %w[partnership soleTrader] => :cannot_renew_type_change_form,
             %w[publicBody localAuthority] => :cbd_type_form,
             %w[publicBody soleTrader] => :cannot_renew_type_change_form,


### PR DESCRIPTION
This change prevents a user changing the business type for a registration from partnership to LLP during renewal.
https://eaflood.atlassian.net/browse/RUBY-1957