### PR TITLE
Update card payment text

### DIFF
--- a/app/forms/waste_carriers_engine/payment_summary_form.rb
+++ b/app/forms/waste_carriers_engine/payment_summary_form.rb
@@ -58,6 +58,8 @@ module WasteCarriersEngine
     end
 
     def ignore_card_confirmation_email?
+      return true if WasteCarriersEngine::FeatureToggle.active?(:govpay_payments)
+
       return true if WasteCarriersEngine.configuration.host_is_back_office?
 
       temp_payment_method != "card"

--- a/app/views/waste_carriers_engine/payment_summary_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/payment_summary_forms/new.html.erb
@@ -74,13 +74,15 @@
                   text: t(".options.card.hint")
                 } do %>
 
-              <% unless WasteCarriersEngine.configuration.host_is_back_office? %>
-                <%= f.govuk_text_field :card_confirmation_email,
-                    label:  {
-                      text: t(".payment_confirmation.label")
-                    },
-                    value: @payment_summary_form.card_confirmation_email,
-                    width: "one-half" %>
+              <% unless WasteCarriersEngine::FeatureToggle.active?(:govpay_payments) %>
+                <% unless WasteCarriersEngine.configuration.host_is_back_office? %>
+                  <%= f.govuk_text_field :card_confirmation_email,
+                      label:  {
+                        text: t(".payment_confirmation.label")
+                      },
+                      value: @payment_summary_form.card_confirmation_email,
+                      width: "one-half" %>
+                <% end %>
               <% end %>
             <% end %>
 

--- a/config/locales/forms/payment_summary_forms/en.yml
+++ b/config/locales/forms/payment_summary_forms/en.yml
@@ -16,7 +16,7 @@ en:
         options:
           card:
             label: Pay by credit or debit card
-            hint: You will be transferred to the secure WorldPay site. We accept MasterCard, Maestro and Visa.
+            hint: We accept MasterCard, Maestro and Visa.
           bank_transfer:
             label: Pay by bank transfer and then email us to confirm payment
             hint: We cannot register you until your payment clears.


### PR DESCRIPTION
This change updates the hint text for card payments and removes the email address field for Govpay payments.
https://eaflood.atlassian.net/browse/RUBY-1891
https://eaflood.atlassian.net/browse/RUBY-1893