### PR TITLE
Renewals: Ruse business address as contact address

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
@@ -224,8 +224,6 @@ module WasteCarriersEngine
 
           transitions from: :contact_email_form, to: :contact_address_reuse_form
 
-          transitions from: :contact_email_form, to: :contact_postcode_form
-
           # Contact address
           transitions from: :contact_address_reuse_form, to: :check_your_answers_form,
                       if: :reuse_registered_address?,

--- a/spec/factories/renewing_registration.rb
+++ b/spec/factories/renewing_registration.rb
@@ -21,6 +21,10 @@ FactoryBot.define do
       addresses { [build(:address, :has_required_data, :registered, :from_os_places), build(:address, :has_required_data, :contact, :from_os_places)] }
     end
 
+    trait :has_registered_address do
+      addresses { [build(:address, :has_required_data, :registered, :from_os_places)] }
+    end
+
     trait :expires_today do
       initialize_with { new(reg_identifier: create(:registration, :has_required_data, :expires_today).reg_identifier) }
     end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/contact_address_reuse_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/contact_address_reuse_form_spec.rb
@@ -4,44 +4,6 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe NewRegistration do
-    subject(:new_registration) do
-      build(
-        :new_registration,
-        :has_registered_address,
-        temp_reuse_registered_address: temp_reuse_registered_address,
-        workflow_state: "contact_address_reuse_form"
-      )
-    end
-
-    context ":contact_address_reuse_form state transitions" do
-      context "on next" do
-        context "when the temp_reuse_registered_address is `yes`" do
-          let(:temp_reuse_registered_address) { "yes" }
-
-          include_examples "has next transition", next_state: "check_your_answers_form"
-
-          it "invokes the ContactAddressAsRegisteredAddressService" do
-            expect(WasteCarriersEngine::ContactAddressAsRegisteredAddressService)
-              .to receive(:run)
-              .with(subject)
-
-            subject.next
-          end
-        end
-
-        context "when the temp_reuse_registered_address is `no`" do
-          let(:temp_reuse_registered_address) { "no" }
-
-          include_examples "has next transition", next_state: "contact_postcode_form"
-
-          it "does not invoke the ContactAddressAsRegisteredAddressService" do
-            expect(WasteCarriersEngine::ContactAddressAsRegisteredAddressService)
-              .not_to receive(:run)
-
-            subject.next
-          end
-        end
-      end
-    end
+    it_behaves_like "company_address_reuse_form workflow", factory: :new_registration
   end
 end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/contact_address_reuse_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/contact_address_reuse_form_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe RenewingRegistration do
+    it_behaves_like "company_address_reuse_form workflow", factory: :renewing_registration
+  end
+end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/contact_email_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/contact_email_form_spec.rb
@@ -13,7 +13,7 @@ module WasteCarriersEngine
     describe "#workflow_state" do
       context ":contact_email_form state transitions" do
         context "on next" do
-          include_examples "has next transition", next_state: "contact_postcode_form"
+          include_examples "has next transition", next_state: "contact_address_reuse_form"
         end
       end
     end

--- a/spec/requests/waste_carriers_engine/contact_address_reuse_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/contact_address_reuse_forms_spec.rb
@@ -12,48 +12,63 @@ module WasteCarriersEngine
       sign_in(user)
     end
 
+    RSpec.shared_examples "new or renewing registration" do
+
+      include_examples "POST form",
+                       "contact_address_reuse_form",
+                       valid_params: { temp_reuse_registered_address: "yes" },
+                       invalid_params: { temp_reuse_registered_address: "" }
+
+      context "when the contact address will be reused" do
+        it "redirects to check_your_answers form" do
+          post_form_with_params(
+            :contact_address_reuse_form,
+            transient_registration.token,
+            { temp_reuse_registered_address: "yes" }
+          )
+
+          expect(response).to have_http_status(302)
+
+          expect(response).to redirect_to(
+            new_check_your_answers_form_path(transient_registration.token)
+          )
+        end
+      end
+
+      context "when the contact address will not be reused" do
+        it "redirects to contact_address form" do
+          post_form_with_params(
+            :contact_address_reuse_form,
+            transient_registration.token,
+            { temp_reuse_registered_address: "no" }
+          )
+
+          expect(response).to have_http_status(302)
+
+          expect(response).to redirect_to(
+            new_contact_postcode_form_path(transient_registration.token)
+          )
+        end
+      end
+
+    end
+
     describe "POST contact_address_reuse_form_path" do
+
       context "When the transient_registration is a new registration" do
         let(:transient_registration) do
           create(:new_registration, workflow_state: "contact_address_reuse_form")
         end
 
-        include_examples "POST form",
-                         "contact_address_reuse_form",
-                         valid_params: { temp_reuse_registered_address: "yes" },
-                         invalid_params: { temp_reuse_registered_address: "" }
+        it_behaves_like "new or renewing registration", factory: :new_registration
+      end
 
-        context "when the contact address will be reused" do
-          it "redirects to check_your_answers form" do
-            post_form_with_params(
-              :contact_address_reuse_form,
-              transient_registration.token,
-              { temp_reuse_registered_address: "yes" }
-            )
-
-            expect(response).to have_http_status(302)
-
-            expect(response).to redirect_to(
-              new_check_your_answers_form_path(transient_registration.token)
-            )
-          end
+      context "When the transient_registration is a renewing registration" do
+        let(:transient_registration) do
+          create(:renewing_registration, workflow_state: "contact_address_reuse_form", from_magic_link: true)
         end
 
-        context "when the contact address will not be reused" do
-          it "redirects to contact_address form" do
-            post_form_with_params(
-              :contact_address_reuse_form,
-              transient_registration.token,
-              { temp_reuse_registered_address: "no" }
-            )
-
-            expect(response).to have_http_status(302)
-
-            expect(response).to redirect_to(
-              new_contact_postcode_form_path(transient_registration.token)
-            )
-          end
-        end
+        it_behaves_like "new or renewing registration", factory: :renewing_registration
       end
     end
   end

--- a/spec/support/shared_examples/form_workflows/contact_address_reuse_form_workflow.rb
+++ b/spec/support/shared_examples/form_workflows/contact_address_reuse_form_workflow.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "company_address_reuse_form workflow" do |factory:|
+  describe "#workflow_state" do
+
+    subject(:transient_registration) do
+      build(
+        factory,
+        :has_registered_address,
+        temp_reuse_registered_address: temp_reuse_registered_address,
+        workflow_state: "contact_address_reuse_form"
+      )
+    end
+
+    context ":contact_address_reuse_form state transitions" do
+      context "on next" do
+        context "when the temp_reuse_registered_address is `yes`" do
+          let(:temp_reuse_registered_address) { "yes" }
+
+          include_examples "has next transition", next_state: "check_your_answers_form"
+
+          it "invokes the ContactAddressAsRegisteredAddressService" do
+            expect(WasteCarriersEngine::ContactAddressAsRegisteredAddressService)
+              .to receive(:run)
+              .with(subject)
+
+            subject.next
+          end
+        end
+
+        context "when the temp_reuse_registered_address is `no`" do
+          let(:temp_reuse_registered_address) { "no" }
+
+          include_examples "has next transition", next_state: "contact_postcode_form"
+
+          it "does not invoke the ContactAddressAsRegisteredAddressService" do
+            expect(WasteCarriersEngine::ContactAddressAsRegisteredAddressService)
+              .not_to receive(:run)
+
+            subject.next
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change aligns the renewal journey with the new registration journey, allowing the user to reuse the business address as the contact address.
https://eaflood.atlassian.net/browse/RUBY-1866