### PR TITLE
Main people and conviction details form validation

### DIFF
--- a/app/forms/waste_carriers_engine/conviction_details_form.rb
+++ b/app/forms/waste_carriers_engine/conviction_details_form.rb
@@ -5,6 +5,7 @@ module WasteCarriersEngine
     include CanLimitNumberOfRelevantPeople
 
     validates_with RelevantPersonValidator
+    validates :first_name, :last_name, "waste_carriers_engine/person_name": true
 
     def position?
       true

--- a/app/forms/waste_carriers_engine/main_people_form.rb
+++ b/app/forms/waste_carriers_engine/main_people_form.rb
@@ -9,6 +9,7 @@ module WasteCarriersEngine
     delegate :lower_tier?, to: :transient_registration
 
     validates_with MainPersonValidator
+    validates :first_name, :last_name, "waste_carriers_engine/person_name": true
 
     def initialize(transient_registration)
       super

--- a/app/views/waste_carriers_engine/conviction_details_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/conviction_details_forms/new.html.erb
@@ -5,7 +5,7 @@
     <%= render "waste_carriers_engine/conviction_details_forms/form" %>
   </div>
 
-  <% if @conviction_details_form.number_of_existing_relevant_people > 0 %>
+  <% if @conviction_details_form.number_of_existing_relevant_people > 0 && !@conviction_details_form.errors.any? %>
     <div class="govuk-gridcolumn-one-third">
       <h2 class="govuk-heading-s"><%= t(".list_of_people") %></h2>
       <ul class="govuk-list">

--- a/app/views/waste_carriers_engine/main_people_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/main_people_forms/new.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "waste_carriers_engine/main_people_forms/form" %>
   </div>
-  <% if @main_people_form.number_of_existing_main_people > 0 %>
+  <% if @main_people_form.number_of_existing_main_people > 0 && !@main_people_form.errors.any? %>
     <div class="govuk-grid-column-one-third">
       <h2 class="govuk-heading-s"><%= t(".list_of_people") %></h2>
 

--- a/config/locales/forms/conviction_details_forms/en.yml
+++ b/config/locales/forms/conviction_details_forms/en.yml
@@ -21,9 +21,11 @@ en:
             first_name:
               blank: "Enter a first name"
               too_long: "The first name must be no longer than 35 characters"
+              invalid: "The first name must contain only letters, spaces, commas, full stops, hyphens and apostrophes"
             last_name:
               blank: "Enter a last name"
               too_long: "The last name must be no longer than 35 characters"
+              invalid: "The last name must contain only letters, spaces, commas, full stops, hyphens and apostrophes"
             position:
               blank: "Enter a job title"
               too_long: "The job title must be no longer than 35 characters"

--- a/config/locales/forms/main_people_forms/en.yml
+++ b/config/locales/forms/main_people_forms/en.yml
@@ -31,35 +31,37 @@ en:
       models:
         waste_carriers_engine/main_people_form:
           not_enough_main_people:
-            one: "Add the details of at least one person"
-            other: "Add the details of at least %{count} people"
+            one: Add the details of at least one person
+            other: Add the details of at least %{count} people
           attributes:
             first_name:
-              blank: "Enter a first name"
-              too_long: "The first name must be no longer than 35 characters"
+              blank: Enter a first name
+              too_long: The first name must be no longer than 35 characters
+              invalid: The first name must contain only letters, spaces, commas, full stops, hyphens and apostrophes
             last_name:
-              blank: "Enter a last name"
-              too_long: "The last name must be no longer than 35 characters"
+              blank: Enter a last name
+              too_long: The last name must be no longer than 35 characters
+              invalid: The last name must contain only letters, spaces, commas, full stops, hyphens and apostrophes
             dob:
-              age_limit_localAuthority: "Chief executives must be 17 or older"
-              age_limit_limitedCompany: "Directors must be 16 or older to be a director of a private limited company in the UK"
-              age_limit_limitedLiabilityPartnership: "Partners must be 17 or older"
-              age_limit_overseas: "Business owners must be 17 or older"
-              age_limit_partnership: "Partners must be 17 or older"
-              age_limit_soleTrader: "Business owners must be 17 or older"
-              age_limit_authority: "Chief executives must be 17 or older"
-              age_limit_publicBody: "Chief executives must be 17 or older"
-              not_a_date: "Enter a valid date"
-              day_blank: "Enter a day"
-              day_integer: "The day must be a number"
-              day_range: "The day must be between 1 and 31"
-              month_blank: "Enter a month"
-              month_integer: "The month must be a number"
-              month_range: "The month must be between 1 and 12"
-              year_blank: "Enter a year"
-              year_integer: "The year must be a number"
-              year_range: "The year must be between 1900 and now"
+              age_limit_localAuthority: Chief executives must be 17 or older
+              age_limit_limitedCompany: Directors must be 16 or older to be a director of a private limited company in the UK
+              age_limit_limitedLiabilityPartnership: Partners must be 17 or older
+              age_limit_overseas: Business owners must be 17 or older
+              age_limit_partnership: Partners must be 17 or older
+              age_limit_soleTrader: Business owners must be 17 or older
+              age_limit_authority: Chief executives must be 17 or older
+              age_limit_publicBody: Chief executives must be 17 or older
+              not_a_date: Enter a valid date
+              day_blank: Enter a day
+              day_integer: The day must be a number
+              day_range: The day must be between 1 and 31
+              month_blank: Enter a month
+              month_integer: The month must be a number
+              month_range: The month must be between 1 and 12
+              year_blank: Enter a year
+              year_integer: The year must be a number
+              year_range: The year must be between 1900 and now
             reg_identifier:
-              invalid_format: "The registration ID is not in a valid format"
-              no_registration: "There is no registration matching this ID"
-              renewal_in_progress: "This renewal is already in progress"
+              invalid_format: The registration ID is not in a valid format
+              no_registration: There is no registration matching this ID
+              renewal_in_progress: This renewal is already in progress

--- a/spec/forms/waste_carriers_engine/conviction_details_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/conviction_details_forms_spec.rb
@@ -52,8 +52,8 @@ module WasteCarriersEngine
             conviction_details_form.transient_registration.update_attributes(key_people: [build(:key_person, :has_required_data, :relevant)])
           end
 
-          it "should submit" do
-            expect(conviction_details_form.submit(blank_params)).to eq(true)
+          it "should not submit" do
+            expect(conviction_details_form.submit(blank_params)).to eq(false)
           end
         end
 

--- a/spec/forms/waste_carriers_engine/main_people_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/main_people_forms_spec.rb
@@ -117,9 +117,7 @@ module WasteCarriersEngine
         end
 
         context "when a first_name is blank" do
-          before(:each) do
-            main_people_form.first_name = ""
-          end
+          before { main_people_form.first_name = "" }
 
           it "is not valid" do
             expect(main_people_form).to_not be_valid
@@ -127,12 +125,19 @@ module WasteCarriersEngine
         end
 
         context "when a first_name is too long" do
-          before(:each) do
-            main_people_form.first_name = "gsm2lgu3q7cg5pcs02ftc1wtpx4lt5ghmyaclhe9qg9li7ibs5ldi3w3n1pt24pbfo0666bq"
-          end
+          before { main_people_form.first_name = "gsm2lgu3q7cg5pcs02ftc1wtpx4lt5ghmyaclhe9qg9li7ibs5ldi3w3n1pt24pbfo0666bq" }
 
           it "is not valid" do
             expect(main_people_form).to_not be_valid
+          end
+        end
+
+        context "when a first name contains a special character" do
+          it "is not valid" do
+            "!@€\#£$%^&*()[]{}?\":;~<>/\\+=".each_char do |c|
+              main_people_form.first_name = "ab#{c}123"
+              expect(main_people_form).to_not be_valid
+            end
           end
         end
       end
@@ -145,9 +150,7 @@ module WasteCarriersEngine
         end
 
         context "when a last_name is blank" do
-          before(:each) do
-            main_people_form.last_name = ""
-          end
+          before { main_people_form.last_name = "" }
 
           it "is not valid" do
             expect(main_people_form).to_not be_valid
@@ -155,12 +158,19 @@ module WasteCarriersEngine
         end
 
         context "when a last_name is too long" do
-          before(:each) do
-            main_people_form.last_name = "gsm2lgu3q7cg5pcs02ftc1wtpx4lt5ghmyaclhe9qg9li7ibs5ldi3w3n1pt24pbfo0666bq"
-          end
+          before { main_people_form.last_name = "gsm2lgu3q7cg5pcs02ftc1wtpx4lt5ghmyaclhe9qg9li7ibs5ldi3w3n1pt24pbfo0666bq" }
 
           it "is not valid" do
             expect(main_people_form).to_not be_valid
+          end
+        end
+
+        context "when a last name contains a special character" do
+          it "is not valid" do
+            "!@€\#£$%^&*()[]{}?\":;~<>/\\+=".each_char do |c|
+              main_people_form.last_name = "ab#{c}123"
+              expect(main_people_form).to_not be_valid
+            end
           end
         end
       end

--- a/spec/forms/waste_carriers_engine/main_people_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/main_people_forms_spec.rb
@@ -51,8 +51,8 @@ module WasteCarriersEngine
             main_people_form.business_type = "overseas"
           end
 
-          it "should submit" do
-            expect(main_people_form.submit(blank_params)).to eq(true)
+          it "should not submit" do
+            expect(main_people_form.submit(blank_params)).to eq(false)
           end
         end
 

--- a/spec/requests/waste_carriers_engine/conviction_details_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/conviction_details_forms_spec.rb
@@ -85,6 +85,14 @@ module WasteCarriersEngine
 
                 expect(response).to redirect_to(new_conviction_details_form_path(transient_registration[:token]))
               end
+
+              it "reloads the form listing the people already added" do
+                post conviction_details_forms_path(transient_registration.token), params: { conviction_details_form: valid_params, commit: "Add another person" }
+                follow_redirect!
+
+                expect(response.body).to include "You have added the following people"
+                expect(response.body).to include "Foo Bar"
+              end
             end
           end
 
@@ -105,6 +113,12 @@ module WasteCarriersEngine
               post conviction_details_forms_path(transient_registration.token), params: { conviction_details_form: invalid_params }
 
               expect(transient_registration.reload.key_people.count).to eq(total_people_count)
+            end
+
+            it "does not display the 'You have added' content" do
+              post conviction_details_forms_path(transient_registration.token), params: { conviction_details_form: invalid_params }
+
+              expect(response.body).not_to include "You have added the following people"
             end
 
             context "when there is already a main person" do

--- a/spec/requests/waste_carriers_engine/main_people_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/main_people_forms_spec.rb
@@ -114,6 +114,14 @@ module WasteCarriersEngine
                 post main_people_forms_path(transient_registration.token), params: { main_people_form: valid_params, commit: "Add another person" }
                 expect(response).to redirect_to(new_main_people_form_path(transient_registration[:token]))
               end
+
+              it "reloads the form listing the people already added" do
+                post main_people_forms_path(transient_registration.token), params: { main_people_form: valid_params, commit: "Add another person" }
+                follow_redirect!
+
+                expect(response.body).to include "You have added the following people"
+                expect(response.body).to include "Foo Bar"
+              end
             end
           end
 
@@ -132,6 +140,12 @@ module WasteCarriersEngine
               key_people_count = transient_registration.key_people.count
               post main_people_forms_path(transient_registration.token), params: { main_people_form: invalid_params }
               expect(transient_registration.reload.key_people.count).to eq(key_people_count)
+            end
+
+            it "does not display the 'You have added' content" do
+              post main_people_forms_path(transient_registration.token), params: { main_people_form: invalid_params }
+
+              expect(response.body).not_to include "You have added the following people"
             end
 
             context "when there is already a main person" do


### PR DESCRIPTION
This change applies existing person-name validation to the main people and conviction forms, and prevents display of unsaved added names in the event of form validation errors.
https://eaflood.atlassian.net/browse/RUBY-914
https://eaflood.atlassian.net/browse/RUBY-1558
https://eaflood.atlassian.net/browse/RUBY-913
https://eaflood.atlassian.net/browse/RUBY-912
