### PR TITLE
Main people form validation fixes

### DIFF
--- a/app/forms/waste_carriers_engine/main_people_form.rb
+++ b/app/forms/waste_carriers_engine/main_people_form.rb
@@ -8,7 +8,7 @@ module WasteCarriersEngine
 
     delegate :lower_tier?, to: :transient_registration
 
-    validates_with MainPersonValidator
+    validates_with MainPersonValidator, validate_fields: true
     validates :first_name, :last_name, "waste_carriers_engine/person_name": true
 
     def initialize(transient_registration)

--- a/app/validators/waste_carriers_engine/person_validator.rb
+++ b/app/validators/waste_carriers_engine/person_validator.rb
@@ -16,7 +16,7 @@ module WasteCarriersEngine
       validate_first_name(record)
       validate_last_name(record)
       validate_position(record) if record.position?
-      DateOfBirthValidator.new.validate(record)
+      DateOfBirthValidator.new(validate_fields: false).validate(record)
     end
 
     def validate_number_of_people(_record)


### PR DESCRIPTION
This change validates all individual fields on the main people form, as opposed to validating whether sufficient people have been added, but validates date of birth as a single virtual field, as opposed to separate validation errors for day, month and year.