### PR TITLE
No error on continue for blank people page

### DIFF
--- a/app/forms/waste_carriers_engine/main_people_form.rb
+++ b/app/forms/waste_carriers_engine/main_people_form.rb
@@ -8,8 +8,7 @@ module WasteCarriersEngine
 
     delegate :lower_tier?, to: :transient_registration
 
-    validates_with MainPersonValidator, validate_fields: true
-    validates :first_name, :last_name, "waste_carriers_engine/person_name": true
+    validates_with MainPersonValidator, validate_fields: false
 
     def initialize(transient_registration)
       super

--- a/app/validators/waste_carriers_engine/person_validator.rb
+++ b/app/validators/waste_carriers_engine/person_validator.rb
@@ -26,19 +26,19 @@ module WasteCarriersEngine
     def validate_first_name(record)
       return unless field_is_present?(record, :first_name)
 
-      field_is_not_too_long?(record, :first_name, 35)
+      field_content_is_valid?(record, :first_name, 35)
     end
 
     def validate_last_name(record)
       return unless field_is_present?(record, :last_name)
 
-      field_is_not_too_long?(record, :last_name, 35)
+      field_content_is_valid?(record, :last_name, 35)
     end
 
     def validate_position(record)
       return unless field_is_present?(record, :position)
 
-      field_is_not_too_long?(record, :position, 35)
+      field_content_is_valid?(record, :position, 35)
     end
 
     def field_is_present?(record, field)
@@ -48,10 +48,23 @@ module WasteCarriersEngine
       false
     end
 
+    def field_content_is_valid?(record, field, length)
+      field_is_not_too_long?(record, field, length)
+      field_has_no_invalid_characters?(record, field)
+    end
+
     def field_is_not_too_long?(record, field, length)
       return true if record.send(field).length < length
 
       record.errors.add(field, :too_long)
+      false
+    end
+
+    def field_has_no_invalid_characters?(record, field)
+      # Name fields must contain only letters, spaces, commas, full stops, hyphens and apostrophes
+      return true if record.send(field).match?(/\A[-a-z\s,.']+\z/i)
+
+      record.errors.add(field, :invalid)
       false
     end
 

--- a/spec/forms/waste_carriers_engine/main_people_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/main_people_forms_spec.rb
@@ -51,8 +51,8 @@ module WasteCarriersEngine
             main_people_form.business_type = "overseas"
           end
 
-          it "should not submit" do
-            expect(main_people_form.submit(blank_params)).to eq(false)
+          it "should submit" do
+            expect(main_people_form.submit(blank_params)).to eq(true)
           end
         end
 


### PR DESCRIPTION
This change allows the submission of a blank main people page without errors if sufficient people have already been added.
https://eaflood.atlassian.net/browse/RUBY-912