### PR TITLE
Drop minimum people validation

### DIFF
--- a/app/forms/waste_carriers_engine/conviction_details_form.rb
+++ b/app/forms/waste_carriers_engine/conviction_details_form.rb
@@ -4,8 +4,7 @@ module WasteCarriersEngine
   class ConvictionDetailsForm < PersonForm
     include CanLimitNumberOfRelevantPeople
 
-    validates_with RelevantPersonValidator
-    validates :first_name, :last_name, "waste_carriers_engine/person_name": true
+    validates_with RelevantPersonFormValidator
 
     def position?
       true

--- a/app/forms/waste_carriers_engine/main_people_form.rb
+++ b/app/forms/waste_carriers_engine/main_people_form.rb
@@ -8,7 +8,7 @@ module WasteCarriersEngine
 
     delegate :lower_tier?, to: :transient_registration
 
-    validates_with MainPersonValidator, validate_fields: false
+    validates_with MainPersonFormValidator
 
     def initialize(transient_registration)
       super

--- a/app/validators/waste_carriers_engine/main_person_form_validator.rb
+++ b/app/validators/waste_carriers_engine/main_person_form_validator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class MainPersonFormValidator < MainPersonValidator
+
+    def validate(record)
+      # Allow blank form submission if sufficient people already added
+      return true if !record.fields_have_content? && record.enough_main_people?
+
+      validate_individual_fields(record)
+    end
+  end
+end

--- a/app/validators/waste_carriers_engine/relevant_person_form_validator.rb
+++ b/app/validators/waste_carriers_engine/relevant_person_form_validator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class RelevantPersonFormValidator < RelevantPersonValidator
+
+    def validate(record)
+      # Allow blank form submission if sufficient people already added
+      return true if !record.fields_have_content? && record.enough_relevant_people?
+
+      validate_individual_fields(record)
+    end
+  end
+end

--- a/spec/forms/waste_carriers_engine/conviction_details_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/conviction_details_forms_spec.rb
@@ -52,7 +52,7 @@ module WasteCarriersEngine
             conviction_details_form.transient_registration.update_attributes(key_people: [build(:key_person, :has_required_data, :relevant)])
           end
 
-          it "should not submit" do
+          it "should submit" do
             expect(conviction_details_form.submit(blank_params)).to eq(false)
           end
         end
@@ -64,6 +64,11 @@ module WasteCarriersEngine
 
           it "should not submit" do
             expect(conviction_details_form.submit(blank_params)).to eq(false)
+          end
+
+          it "should raise individual errors for each blank field" do
+            conviction_details_form.submit(blank_params)
+            expect(conviction_details_form.errors.attribute_names).to include(:first_name, :last_name, :position, :dob)
           end
         end
       end

--- a/spec/forms/waste_carriers_engine/conviction_details_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/conviction_details_forms_spec.rb
@@ -53,7 +53,7 @@ module WasteCarriersEngine
           end
 
           it "should submit" do
-            expect(conviction_details_form.submit(blank_params)).to eq(false)
+            expect(conviction_details_form.submit(blank_params)).to eq(true)
           end
         end
 

--- a/spec/forms/waste_carriers_engine/main_people_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/main_people_forms_spec.rb
@@ -65,6 +65,11 @@ module WasteCarriersEngine
           it "should not submit" do
             expect(main_people_form.submit(blank_params)).to eq(false)
           end
+
+          it "should raise individual errors for each blank field" do
+            main_people_form.submit(blank_params)
+            expect(main_people_form.errors.attribute_names).to include(:first_name, :last_name, :dob)
+          end
         end
       end
     end


### PR DESCRIPTION
This change drops the "Add at least N people" error when validating a blank main-people or conviction-details form. It shows individual field-level validations instead.
It also allows a blank main-people or conviction-details form to be submitted provided sufficient people have already been added.
https://eaflood.atlassian.net/browse/RUBY-108
https://eaflood.atlassian.net/browse/RUBY-912