### PR TITLE
Adding in CH API down error handling

### DIFF
--- a/app/controllers/waste_carriers_engine/check_registered_company_name_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/check_registered_company_name_forms_controller.rb
@@ -6,6 +6,13 @@ module WasteCarriersEngine
   class CheckRegisteredCompanyNameFormsController < ::WasteCarriersEngine::FormsController
     def new
       super(CheckRegisteredCompanyNameForm, "check_registered_company_name_form")
+
+      begin
+        company_name
+      rescue StandardError
+        Rails.logger.error "Failed to load"
+        render(:companies_house_down)
+      end
     end
 
     def create
@@ -16,6 +23,10 @@ module WasteCarriersEngine
 
     def transient_registration_attributes
       params.fetch(:check_registered_company_name_form, {}).permit(:temp_use_registered_company_details, :token)
+    end
+
+    def company_name
+      DefraRubyCompaniesHouse.new(@transient_registration.company_no).company_name
     end
   end
 end

--- a/app/views/waste_carriers_engine/check_registered_company_name_forms/companies_house_down.html.erb
+++ b/app/views/waste_carriers_engine/check_registered_company_name_forms/companies_house_down.html.erb
@@ -1,0 +1,7 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+    <p class="govuk-body"><%= t(".paragraph_1") %></p>
+    <p class="govuk-body"><%= t(".paragraph_2") %></p>
+  </div>
+</div>

--- a/config/locales/forms/check_registered_company_name_forms/en.yml
+++ b/config/locales/forms/check_registered_company_name_forms/en.yml
@@ -11,7 +11,11 @@ en:
         next_button: Continue
         enter_a_different_number: "Enter a different number"
         must_create_new_registration: If you have a new companies house number you need to create a new registration
-
+      companies_house_down:
+        title: There is a problem with Companies House
+        heading: There is a problem with Companies House
+        paragraph_1: We are unable to verify your Companies House details at the moment
+        paragraph_2: Please try again later.
   activemodel:
     errors:
       models:

--- a/lib/defra_ruby_companies_house.rb
+++ b/lib/defra_ruby_companies_house.rb
@@ -7,7 +7,7 @@ class DefraRubyCompaniesHouse
     @company_url = "#{Rails.configuration.companies_house_host}#{company_no.to_s.rjust(8, '0')}"
     @api_key = Rails.configuration.companies_house_api_key
 
-    load_company
+    raise StandardError "Failed to load company" unless load_company
   end
 
   def company_name
@@ -39,7 +39,7 @@ class DefraRubyCompaniesHouse
           password: ""
         )
       ).deep_symbolize_keys
-  rescue RestClient::ResourceNotFound
-    :not_found
+  rescue RestClient::ResourceNotFound, RestClient::NotFound
+    false
   end
 end

--- a/spec/forms/waste_carriers_engine/check_registered_company_name_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/check_registered_company_name_forms_spec.rb
@@ -9,7 +9,7 @@ module WasteCarriersEngine
     let(:company_address) { ["10 Downing St", "Horizon House", "Bristol", "BS1 5AH"] }
 
     before do
-      allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:load_company)
+      allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:load_company).and_return(true)
       allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:company_name).and_return(registered_company_name)
       allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:registered_office_address_lines).and_return(company_address)
     end

--- a/spec/lib/defra_ruby_companies_house_spec.rb
+++ b/spec/lib/defra_ruby_companies_house_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe DefraRubyCompaniesHouse do
 
     context "with an invalid company number" do
       let(:company_no) { invalid_company_no }
-      it "returns nil" do
-        expect(subject).to be_nil
+      it "raises a standard error" do
+        expect { subject }.to raise_error(StandardError)
       end
     end
 
@@ -44,6 +44,22 @@ RSpec.describe DefraRubyCompaniesHouse do
         expect(subject).to eq "BOGUS LIMITED"
       end
     end
+
+    context "when there is a problem with the companies house API" do
+      context "and the requests time out" do
+        it "raises a standard error" do
+          expect { subject }.to raise_error(StandardError)
+        end
+      end
+
+      context "and requests return an error" do
+        before { stub_request(:get, /#{Rails.configuration.companies_house_host}*/).to_raise(SocketError) }
+
+        it "raises an exception" do
+          expect { subject.status }.to raise_error(StandardError)
+        end
+      end
+    end
   end
 
   describe "#registered_office_address_lines" do
@@ -51,8 +67,8 @@ RSpec.describe DefraRubyCompaniesHouse do
 
     context "with an invalid company number" do
       let(:company_no) { invalid_company_no }
-      it "returns an empty array" do
-        expect(subject).to eq []
+      it "raises a standard error" do
+        expect { subject }.to raise_error(StandardError)
       end
     end
 

--- a/spec/requests/waste_carriers_engine/check_registered_company_name_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/check_registered_company_name_forms_spec.rb
@@ -10,7 +10,7 @@ module WasteCarriersEngine
     let(:company_address) { ["10 Downing St", "Horizon House", "Bristol", "BS1 5AH"] }
 
     before do
-      allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:load_company)
+      allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:load_company).and_return(true)
       allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:company_name).and_return(company_name)
       allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:registered_office_address_lines).and_return(company_address)
     end
@@ -42,6 +42,18 @@ module WasteCarriersEngine
 
             company_address.each do |line|
               expect(response.body).to include(line)
+            end
+          end
+
+          context "when the company house API is down" do
+            before do
+              allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:load_company).and_raise(StandardError)
+            end
+
+            it "raises an error" do
+              get check_registered_company_name_forms_path(transient_registration[:token])
+
+              expect(response).to render_template("waste_carriers_engine/check_registered_company_name_forms/companies_house_down")
             end
           end
         end

--- a/spec/services/waste_carriers_engine/refresh_companies_house_name_service_spec.rb
+++ b/spec/services/waste_carriers_engine/refresh_companies_house_name_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe WasteCarriersEngine::RefreshCompaniesHouseNameService do
   let(:companies_house_name) { new_registered_name }
 
   before do
-    allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:load_company)
+    allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:load_company).and_return(true)
     allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:company_name).and_return(companies_house_name)
   end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1933

Here we have the changes for how to handle the CH API being down. When it is down for whatever reason we show a specific page detailing the customer to try again later. 

I've left this available for both the front office and renewals as during a registration if CH is down they won't get passed the 'Enter your company number' page and if they did successfully get past that page and then the API goes down at least there is a sufficient error message in place for registrations as well 