### PR TITLE
Production debug logging

### DIFF
--- a/app/services/concerns/waste_carriers_engine/can_add_debug_logging.rb
+++ b/app/services/concerns/waste_carriers_engine/can_add_debug_logging.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  module CanAddDebugLogging
+    extend ActiveSupport::Concern
+
+    # rubocop:disable Metrics/MethodLength
+    def log_transient_registration_details(description, transient_registration)
+      return unless FeatureToggle.active?(:additional_debug_logging)
+
+      error = if transient_registration.nil?
+                StandardError.new("#{description}: transient_registration is nil")
+              else
+                StandardError.new(
+                  "#{description}: " \
+                  "type: #{transient_registration.class}, " \
+                  "reg_identifier #{transient_registration.reg_identifier}, " \
+                  "from_magic_link: #{from_magic_link(transient_registration)}, " \
+                  "workflow_state: #{transient_registration.workflow_state}, " \
+                  "workflow_history: #{transient_registration.workflow_history}, " \
+                  "tier: #{transient_registration.tier}, " \
+                  "account_email: #{transient_registration.account_email}, " \
+                  "expires_on: #{transient_registration.expires_on}, " \
+                  "renew_token: #{renew_token(transient_registration)}, " \
+                  "metaData.route: #{transient_registration.metaData.route}, " \
+                  "created_at: #{transient_registration.created_at}"
+                )
+              end
+      Airbrake.notify(error, reg_identifier: transient_registration.reg_identifier) if defined?(Airbrake)
+      Rails.logger.warn error
+
+    # Handle any exceptions which arise while logging
+    rescue StandardError => e
+      Airbrake.notify(e, reg_identifier: transient_registration.reg_identifier) if defined?(Airbrake)
+      Rails.logger.warn "Error writing transient registration details to the log: #{e}"
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    private
+
+    def from_magic_link(transient_registration)
+      return "N/A" unless transient_registration.is_a?(RenewingRegistration)
+
+      transient_registration.from_magic_link ? "true" : "false"
+    end
+
+    def renew_token(transient_registration)
+      return "N/A" unless transient_registration.registration.present?
+
+      transient_registration.registration.renew_token
+    rescue NotImplementedError
+      "N/A"
+    end
+  end
+end

--- a/app/services/waste_carriers_engine/base_registration_permission_checks_service.rb
+++ b/app/services/waste_carriers_engine/base_registration_permission_checks_service.rb
@@ -2,6 +2,8 @@
 
 module WasteCarriersEngine
   class BaseRegistrationPermissionChecksService < BaseService
+    include CanAddDebugLogging
+
     delegate :registration, to: :transient_registration
 
     attr_reader :transient_registration, :user, :permission_check_result
@@ -19,6 +21,13 @@ module WasteCarriersEngine
     private
 
     def can?(action, object)
+      unless user.present?
+        log_transient_registration_details(
+          "Permissions check requested for nil user, action: #{action}",
+          @transient_registration
+        )
+      end
+
       ability = Ability.new(user)
 
       ability.can?(action, object)

--- a/app/services/waste_carriers_engine/registration_completion_service.rb
+++ b/app/services/waste_carriers_engine/registration_completion_service.rb
@@ -3,8 +3,11 @@
 module WasteCarriersEngine
   # rubocop:disable Metrics/ClassLength
   class RegistrationCompletionService < BaseService
+    include CanAddDebugLogging
+
     attr_reader :transient_registration
 
+    # rubocop:disable Metrics/MethodLength
     def run(transient_registration)
       @transient_registration = transient_registration
 
@@ -28,6 +31,7 @@ module WasteCarriersEngine
         begin
           RegistrationActivationService.run(registration: registration)
         rescue StandardError => e
+          log_transient_registration_details("Exception running RegistrationCompletionService", @transient_registration)
           Airbrake.notify(e, reg_identifier: @transient_registration.reg_identifier)
           Rails.logger.error e
         end
@@ -35,6 +39,7 @@ module WasteCarriersEngine
 
       registration
     end
+    # rubocop:enable Metrics/MethodLength
 
     private
 

--- a/spec/services/waste_carriers_engine/renewing_registration_permission_checks_service_spec.rb
+++ b/spec/services/waste_carriers_engine/renewing_registration_permission_checks_service_spec.rb
@@ -4,16 +4,17 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe RenewingRegistrationPermissionChecksService do
-    let(:transient_registration) { double(:transient_registration, from_magic_link: false) }
-    let(:user) { double(:user) }
-    let(:result) { double(:result) }
-    let(:params) { { transient_registration: transient_registration, user: user } }
+
+    before do
+      expect(transient_registration).to receive(:valid?).and_return(valid)
+      expect(PermissionChecksResult).to receive(:new).and_return(result)
+    end
 
     describe ".run" do
-      before do
-        expect(transient_registration).to receive(:valid?).and_return(valid)
-        expect(PermissionChecksResult).to receive(:new).and_return(result)
-      end
+      let(:transient_registration) { double(:transient_registration, from_magic_link: false) }
+      let(:user) { double(:user) }
+      let(:result) { double(:result) }
+      let(:params) { { transient_registration: transient_registration, user: user } }
 
       context "when the transient registration is not valid" do
         let(:valid) { false }
@@ -86,6 +87,26 @@ module WasteCarriersEngine
               expect(described_class.run(params)).to eq(result)
             end
           end
+        end
+      end
+
+      describe "temporary additional debugging" do
+        let(:valid) { true }
+        let(:registration) { create(:registration, :has_required_data) }
+        let(:transient_registration) do
+          create(:renewing_registration, reg_identifier: registration.reg_identifier, from_magic_link: false)
+        end
+        let(:user) { nil }
+
+        before do
+          allow(FeatureToggle).to receive(:active?).with(:use_extended_grace_window).and_return true
+          allow(FeatureToggle).to receive(:active?).with(:additional_debug_logging).and_return true
+        end
+
+        it "logs an error and raises a NoMethodError" do
+          expect(Airbrake).to receive(:notify)
+
+          expect { described_class.run(params) }.to raise_error(NoMethodError)
         end
       end
     end


### PR DESCRIPTION
This change adds a general-purpose concern for writing transient registration details to the Rails log and Errbit. It is intended to help debug some intermittent errors which occur in production but with insufficient details in the logs to resolve them.
Note that this PR replaces an earlier version.
https://eaflood.atlassian.net/browse/RUBY-1921