### PR TITLE
Adding letter text to renewal confirmation page

### DIFF
--- a/app/views/waste_carriers_engine/renewal_complete_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/renewal_complete_forms/new.html.erb
@@ -21,7 +21,11 @@
         </div>
 
         <p class="govuk-body"><%= t(".paragraph_1", date: @renewal_complete_form.projected_renewal_end_date) %></p>
-        <p class="govuk-body"><%= t(".paragraph_2", email: @renewal_complete_form.contact_email) %></p>
+        <% if @renewal_complete_form.contact_email.present?%>
+          <p class="govuk-body"><%= t(".paragraph_2.email", email: @renewal_complete_form.contact_email) %></p>
+        <% else%>
+          <p class="govuk-body"><%= t(".paragraph_2.letter") %></p>
+        <% end %>
 
         <% unless WasteCarriersEngine.configuration.host_is_back_office? %>
           <p class="govuk-body"><%= t(".paragraph_3", email: @renewal_complete_form.transient_registration.email_to_send_receipt) %></p>

--- a/config/locales/forms/renewal_complete_forms/en.yml
+++ b/config/locales/forms/renewal_complete_forms/en.yml
@@ -6,7 +6,9 @@ en:
         heading: Renewal complete
         highlight_text: "Your registration number is still"
         paragraph_1: "Your registration has been renewed until %{date}."
-        paragraph_2: "We have sent a confirmation email to %{email}."
+        paragraph_2: 
+          email: "We have sent a confirmation email to %{email}."
+          letter: "We have sent a confirmation letter"
         paragraph_3: "A payment confirmation will be sent to %{email}."
         subheading_2: What happens next
         paragraph_4:


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-2062

These changes are for adding text when a letter is sent instead of an email