### PR TITLE
Text change for registration complete sending a letter

### DIFF
--- a/app/views/waste_carriers_engine/registration_completed_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/registration_completed_forms/new.html.erb
@@ -10,7 +10,11 @@
       </div>
     </div>
 
-    <p class="govuk-body"><%= t(".paragraph_1", email: @registration.contact_email) %></p>
+    <% if @registration.contact_email.present? %>
+      <p class="govuk-body"><%= t(".paragraph_1.email", email: @registration.contact_email) %></p>
+    <% else %>
+      <p class="govuk-body"><%= t(".paragraph_1.letter") %></p>
+    <% end %>
 
     <% unless WasteCarriersEngine.configuration.host_is_back_office? %>
       <% if @registration.upper_tier? %>

--- a/config/locales/forms/registration_completed_forms/en.yml
+++ b/config/locales/forms/registration_completed_forms/en.yml
@@ -5,7 +5,9 @@ en:
         title: Registration complete
         heading: Registration complete
         highlight_text: "Your registration number is"
-        paragraph_1: "We’ve sent a registration confirmation and certificate to %{email}."
+        paragraph_1: 
+          email: "We’ve sent a registration confirmation and certificate to %{email}."
+          letter: "We have sent a registration confirmation letter"
         paragraph_2: "A payment confirmation will be sent to %{email}."
         subheading_1: "What happens next"
         list_1:


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-2061

This change is for registrations completed. It changes the text to say they've been sent a letter if they have no email address.