### PR TITLE
Fixing the partial telephone match

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -114,7 +114,6 @@ module WasteCarriersEngine
         # e.g. search "CBDU01" reduces to "01" matching all phone numbers with a "01"
         # Also, searching with an empty value would match all model instances
         exact_term = "\\b#{term}\\b"
-        # escaped_exact_term = Regexp.escape(exact_term)
         return exact_term if telephone_number.length < 10
 
         # Regex can search for a number with spaces and dashes anywhere and for UK numbers either starting in 0 or +44

--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -113,7 +113,9 @@ module WasteCarriersEngine
         # Avoid trivial matches with search terms intended for other attributes
         # e.g. search "CBDU01" reduces to "01" matching all phone numbers with a "01"
         # Also, searching with an empty value would match all model instances
-        return Regexp.escape(term) if telephone_number.length < 10
+        exact_term = "\\b#{term}\\b"
+        # escaped_exact_term = Regexp.escape(exact_term)
+        return exact_term if telephone_number.length < 10
 
         # Regex can search for a number with spaces and dashes anywhere and for UK numbers either starting in 0 or +44
         "(\\+44|0|\\+)?[\\s-]*" + telephone_number.scan(/\d/).map { |c| "#{c}[\\s-]*" }.join

--- a/spec/support/shared_examples/searching_phone_number.rb
+++ b/spec/support/shared_examples/searching_phone_number.rb
@@ -29,6 +29,8 @@ RSpec.shared_examples "searching phone number attribute" do |factory:|
   let(:number_starting_with_44) { "+441234567890" }
   let(:interntational_number) { "+78121234567" }
   let(:number_with_text) { "Landline 01234567890" }
+  # The partial number matches the non matching record as it shouldn't display this
+  let(:partial_number) { "111" }
 
   context "when the number in the database has not got any spaces or dashes and doesn't start in +44" do
     context "and the search term has not got any spaces or dashes and doesn't start in +44" do
@@ -106,5 +108,15 @@ RSpec.shared_examples "searching phone number attribute" do |factory:|
 
       it_behaves_like "matching and non matching registrations"
     end
+  end
+
+  context "when the search term is a partial number" do
+    let(:term) { partial_number }
+
+    let(:matching_record) do
+      create(factory, :has_required_data, phone_number: partial_number)
+    end
+
+    it_behaves_like "matching and non matching registrations"
   end
 end

--- a/spec/support/shared_examples/searching_phone_number.rb
+++ b/spec/support/shared_examples/searching_phone_number.rb
@@ -29,7 +29,7 @@ RSpec.shared_examples "searching phone number attribute" do |factory:|
   let(:number_starting_with_44) { "+441234567890" }
   let(:interntational_number) { "+78121234567" }
   let(:number_with_text) { "Landline 01234567890" }
-  # The partial number matches the non matching record as it shouldn't display this
+  # The partial number matches *part* of the non matching record as it shouldn't display this
   let(:partial_number) { "111" }
 
   context "when the number in the database has not got any spaces or dashes and doesn't start in +44" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-2074

Here we have the fix for the BO telephone search mechanism. Previously it was returning partial matches, but the issue with this is if you typed in just 1 digit i.e '6' it would return any phone number that included a 6 in it resulting in a lot of matches. This partial match has been removed for telephone numbers less than 10 digits. 
Anything less than 10 digits requires a full match (meaning if a number has been entered wrongly and only contains 9 digits for example, it will still match. Anything over 10 digits will get turned into the regex string where it can be match with spaces, dashes and the +44 at the beginning as well. 