### PR TITLE
Do not log valid but unsuccessful payments unless there is an error

### DIFF
--- a/app/controllers/waste_carriers_engine/govpay_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/govpay_forms_controller.rb
@@ -87,11 +87,12 @@ module WasteCarriersEngine
     end
 
     def log_and_send_govpay_response(is_valid, action)
+      return if is_valid && action != "error"
+
       valid_text = is_valid ? "Valid" : "Invalid"
       title = "#{valid_text} Govpay response: #{action}"
-
-      Rails.logger.debug [title, "Params:", params.to_json].join("\n") unless is_valid
-      Airbrake.notify(title, error_message: params) unless is_valid && action == "success"
+      Rails.logger.debug [title, "Params:", params.to_json].join("\n")
+      Airbrake.notify(title, error_message: params)
     end
 
     def form_error_message(action, type = :message)

--- a/spec/requests/waste_carriers_engine/govpay_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/govpay_forms_spec.rb
@@ -232,50 +232,49 @@ module WasteCarriersEngine
 
           context "for unsuccessful govpay statuses" do
 
-            RSpec.shared_examples "payment is unsuccessful" do
+            RSpec.shared_examples "payment is unsuccessful but no error" do
 
-              context "when the payment uuid is valid" do
-                it "redirects to payment_summary_form" do
-                  get payment_callback_govpay_forms_path(token, order.payment_uuid)
+              it "redirects to payment_summary_form" do
+                get payment_callback_govpay_forms_path(token, order.payment_uuid)
 
-                  expect(response).to redirect_to(new_payment_summary_form_path(token))
-                end
-
-                it "logs an error" do
-                  expect(Airbrake).to receive(:notify)
-
-                  get payment_callback_govpay_forms_path(token, order.payment_uuid)
-                end
+                expect(response).to redirect_to(new_payment_summary_form_path(token))
               end
 
-              context "when the payment uuid is invalid" do
-                it "redirects to payment_summary_form" do
-                  get payment_callback_govpay_forms_path(token, order.payment_uuid)
+              it "does not log an error" do
+                expect(Airbrake).not_to receive(:notify)
 
-                  expect(response).to redirect_to(new_payment_summary_form_path(token))
-                end
+                get payment_callback_govpay_forms_path(token, order.payment_uuid)
+              end
+            end
 
-                it "logs an error" do
-                  expect(Airbrake).to receive(:notify)
+            RSpec.shared_examples "payment is unsuccessful with an error" do
 
-                  get payment_callback_govpay_forms_path(token, order.payment_uuid)
-                end
+              it "redirects to payment_summary_form" do
+                get payment_callback_govpay_forms_path(token, order.payment_uuid)
+
+                expect(response).to redirect_to(new_payment_summary_form_path(token))
+              end
+
+              it "logs an error" do
+                expect(Airbrake).to receive(:notify)
+
+                get payment_callback_govpay_forms_path(token, order.payment_uuid)
               end
             end
 
             context "when govpay status is cancel" do
               let(:govpay_status) { "cancelled" }
-              it_behaves_like "payment is unsuccessful"
+              it_behaves_like "payment is unsuccessful but no error"
             end
 
             context "failure" do
               let(:govpay_status) { "failure" }
-              it_behaves_like "payment is unsuccessful"
+              it_behaves_like "payment is unsuccessful but no error"
             end
 
             context "error" do
               let(:govpay_status) { "not_found" }
-              it_behaves_like "payment is unsuccessful"
+              it_behaves_like "payment is unsuccessful with an error"
             end
           end
 
@@ -283,14 +282,14 @@ module WasteCarriersEngine
             before { allow(GovpayValidatorService).to receive(:valid_govpay_status?).and_return(false) }
 
             let(:govpay_status) { "success" }
-            it_behaves_like "payment is unsuccessful"
+            it_behaves_like "payment is unsuccessful with an error"
           end
 
           context "for an invalid failure status" do
             before { allow(GovpayValidatorService).to receive(:valid_govpay_status?).and_return(false) }
 
             let(:govpay_status) { "cancelled" }
-            it_behaves_like "payment is unsuccessful"
+            it_behaves_like "payment is unsuccessful with an error"
           end
         end
       end


### PR DESCRIPTION
This change prevents logging of valid, non-error Govpay payments in Errbit.
https://eaflood.atlassian.net/browse/RUBY-2119