### PR TITLE
Support tracking partial AD registrations

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
@@ -253,10 +253,7 @@ module WasteCarriersEngine
           transitions from: :check_your_answers_form, to: :declaration_form
 
           transitions from: :declaration_form, to: :registration_completed_form,
-                      if: :lower_tier?,
-                      # TODO: This don't get triggered if in the `success`
-                      # callback block, hence we went for `after`
-                      after: :set_metadata_route
+                      if: :lower_tier?
 
           transitions from: :declaration_form, to: :cards_form
 
@@ -271,42 +268,27 @@ module WasteCarriersEngine
 
           transitions from: :payment_summary_form, to: :confirm_bank_transfer_form
 
-          transitions from: :confirm_bank_transfer_form, to: :registration_received_pending_payment_form,
-                      # TODO: This don't get triggered if in the `success`
-                      # callback block, hence we went for `after`
-                      after: :set_metadata_route
+          transitions from: :confirm_bank_transfer_form, to: :registration_received_pending_payment_form
 
           transitions from: :worldpay_form,
                       to: :registration_received_pending_worldpay_payment_form,
-                      if: :pending_online_payment?,
-                      # TODO: This don't get triggered if in the `success`
-                      # callback block, hence we went for `after`
-                      after: :set_metadata_route
+                      if: :pending_online_payment?
 
           transitions from: :worldpay_form,
                       to: :registration_received_pending_conviction_form,
-                      if: :conviction_check_required?,
-                      # TODO: This don't get triggered if in the `success`
-                      # callback block, hence we went for `after`
-                      after: :set_metadata_route
+                      if: :conviction_check_required?
 
-          transitions from: :worldpay_form, to: :registration_completed_form,
-                      # TODO: This don't get triggered if in the `success`
-                      # callback block, hence we went for `after`
-                      after: :set_metadata_route
+          transitions from: :worldpay_form, to: :registration_completed_form
 
           transitions from: :govpay_form,
                       to: :registration_received_pending_govpay_payment_form,
-                      if: :pending_online_payment?,
-                      after: :set_metadata_route
+                      if: :pending_online_payment?
 
           transitions from: :govpay_form,
                       to: :registration_received_pending_conviction_form,
-                      if: :conviction_check_required?,
-                      after: :set_metadata_route
+                      if: :conviction_check_required?
 
-          transitions from: :govpay_form, to: :registration_completed_form,
-                      after: :set_metadata_route
+          transitions from: :govpay_form, to: :registration_completed_form
         end
 
         # Transitions

--- a/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_renewing_registration_workflow.rb
@@ -217,41 +217,26 @@ module WasteCarriersEngine
 
           transitions from: :worldpay_form, to: :renewal_received_pending_worldpay_payment_form,
                       if: :pending_online_payment?,
-                      success: :send_renewal_pending_online_payment_email,
-                      # TODO: This don't get triggered if in the `success`
-                      # callback block, hence we went for `after`
-                      after: :set_metadata_route
+                      success: :send_renewal_pending_online_payment_email
 
           transitions from: :worldpay_form, to: :renewal_received_pending_conviction_form,
                       if: :conviction_check_required?,
-                      success: :send_renewal_pending_checks_email,
-                      # TODO: This don't get triggered if in the `success`
-                      # callback block, hence we went for `after`
-                      after: :set_metadata_route
+                      success: :send_renewal_pending_checks_email
 
-          transitions from: :worldpay_form, to: :renewal_complete_form,
-                      # TODO: This don't get triggered if in the `success`
-                      # callback block, hence we went for `after`
-                      after: :set_metadata_route
+          transitions from: :worldpay_form, to: :renewal_complete_form
 
           transitions from: :govpay_form, to: :renewal_received_pending_govpay_payment_form,
                       if: :pending_online_payment?,
-                      success: :send_renewal_pending_online_payment_email,
-                      after: :set_metadata_route
+                      success: :send_renewal_pending_online_payment_email
 
           transitions from: :govpay_form, to: :renewal_received_pending_conviction_form,
                       if: :conviction_check_required?,
-                      success: :send_renewal_pending_checks_email,
-                      after: :set_metadata_route
+                      success: :send_renewal_pending_checks_email
 
-          transitions from: :govpay_form, to: :renewal_complete_form,
-                      after: :set_metadata_route
+          transitions from: :govpay_form, to: :renewal_complete_form
 
           transitions from: :confirm_bank_transfer_form, to: :renewal_received_pending_payment_form,
-                      success: :send_renewal_pending_payment_email,
-                      # TODO: This don't get triggered if in the `success`
-                      # callback block, hence we went for `after`
-                      after: :set_metadata_route
+                      success: :send_renewal_pending_payment_email
         end
 
         event :skip_to_manual_address do

--- a/app/models/waste_carriers_engine/meta_data.rb
+++ b/app/models/waste_carriers_engine/meta_data.rb
@@ -19,5 +19,11 @@ module WasteCarriersEngine
 
     validates :status,
               presence: true
+
+    def initialize(params = nil)
+      super(params)
+
+      self.route = Rails.configuration.metadata_route
+    end
   end
 end

--- a/spec/models/waste_carriers_engine/new_registration_workflow/confirm_bank_transfer_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/confirm_bank_transfer_form_spec.rb
@@ -10,12 +10,6 @@ module WasteCarriersEngine
       context "with :confirm_bank_transfer_form state transitions" do
         context "with :next transition" do
           include_examples "has next transition", next_state: "registration_received_pending_payment_form"
-
-          it "set a metadata route" do
-            allow(Rails.configuration).to receive(:metadata_route).and_return("test_route")
-
-            expect { new_registration.next! }.to change { new_registration.metaData.route }.to("test_route")
-          end
         end
       end
     end

--- a/spec/models/waste_carriers_engine/renewing_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_spec.rb
@@ -14,44 +14,9 @@ module WasteCarriersEngine
 
     describe "workflow_state" do
 
-      before { allow(renewing_registration).to receive(:set_metadata_route) }
-
       context "when a RenewingRegistration is created" do
         it "has the state :renewal_start_form" do
           expect(renewing_registration).to have_state(:renewal_start_form)
-        end
-      end
-
-      context "when transitioning from confirm_bank_transfer_form to renewal_received_pending_payment_form successfully" do
-        it "set the transient registration metadata route" do
-          renewing_registration.update_attributes(workflow_state: :confirm_bank_transfer_form)
-          renewing_registration.next
-
-          expect(renewing_registration).to have_received(:set_metadata_route).once
-        end
-      end
-
-      context "when transitioning from worldpay_form to renewal_complete_form successfully" do
-        it "set the transient registration metadata route" do
-          allow(renewing_registration).to receive(:pending_online_payment?).and_return(false)
-          allow(renewing_registration).to receive(:conviction_check_required?).and_return(false)
-
-          renewing_registration.update_attributes(workflow_state: :worldpay_form)
-          renewing_registration.next
-
-          expect(renewing_registration).to have_received(:set_metadata_route).once
-        end
-      end
-
-      context "when transitioning from worldpay_form to renewal_received_pending_conviction_form succesfully" do
-        it "set the transient registration metadata route" do
-          allow(renewing_registration).to receive(:pending_online_payment?).and_return(false)
-          allow(renewing_registration).to receive(:conviction_check_required?).and_return(true)
-
-          renewing_registration.update_attributes(workflow_state: :worldpay_form)
-          renewing_registration.next
-
-          expect(renewing_registration).to have_received(:set_metadata_route).once
         end
       end
     end

--- a/spec/models/waste_carriers_engine/transient_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/transient_registration_spec.rb
@@ -4,35 +4,38 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe TransientRegistration, type: :model do
-    let(:transient_registration) { build(:transient_registration, :has_required_data) }
+    let(:transient_registration) { create(:transient_registration, :has_required_data, metaData: build(:metaData, :has_required_data)) }
 
-    describe "#set_metadata_route" do
-      let(:metadata_route) { instance_double(described_class, :metadata_route) }
+    describe "#initialize" do
+      context "when the metadata_route config value is set" do
+        before do
+          allow(Rails.configuration).to receive(:metadata_route).and_return("foo")
+        end
 
-      before do
-        allow_message_expectations_on_nil
-        allow(Rails.configuration).to receive(:metadata_route).and_return(metadata_route)
-        allow(transient_registration.metaData).to receive(:route=)
-        allow(transient_registration).to receive(:save)
+        it "sets a new TransientRegistration's metaData.route to the correct value" do
+          expect(transient_registration.metaData.route).to eq("foo")
+        end
       end
 
-      it "updates the transient registration's metadata route" do
-        transient_registration.set_metadata_route
+      context "when the metadata_route config value is not set" do
+        before do
+          allow(Rails.configuration).to receive(:metadata_route).and_return(nil)
+        end
 
-        expect(transient_registration.metaData).to have_received(:route=).with(metadata_route)
+        it "sets a new TransientRegistration's metaData.route to nil" do
+          expect(transient_registration.metaData.route).to be_nil
+        end
       end
     end
 
     describe "#update_created_at" do
       context "when a new transient registration is created" do
-        it "updates the transient registration's created_at" do
-          time = instance_double(described_class, :time)
-          allow(Time).to receive(:current).and_return(time)
-          allow(transient_registration).to receive(:created_at=)
+        let(:time) { Time.new(2019, 1, 1) }
 
-          transient_registration.save
+        before { allow(Time).to receive(:current).and_return(time) }
 
-          expect(transient_registration).to have_received(:created_at=).with(time)
+        it "sets the transient registration's created_at" do
+          expect(transient_registration.created_at).to eq(time.to_datetime)
         end
       end
     end

--- a/spec/presenters/waste_carriers_engine/certificate_presenter_spec.rb
+++ b/spec/presenters/waste_carriers_engine/certificate_presenter_spec.rb
@@ -8,7 +8,6 @@ module WasteCarriersEngine
 
     include_context "with a sample registration with defaults", :registration do
       let(:registration_type) { "carrier_broker_dealer" }
-      let(:route) { "DIGITAL" }
     end
     let(:registration) { resource }
 
@@ -135,7 +134,7 @@ module WasteCarriersEngine
 
     describe "#assisted_digital?" do
       context "when the registration is assisted digital" do
-        let(:route) { "ASSISTED_DIGITAL" }
+        before { allow(Rails.configuration).to receive(:metadata_route).and_return("ASSISTED_DIGITAL") }
 
         it "returns 'true'" do
           expect(presenter.assisted_digital?).to be true

--- a/spec/requests/waste_carriers_engine/confirm_bank_transfer_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/confirm_bank_transfer_forms_spec.rb
@@ -64,44 +64,5 @@ module WasteCarriersEngine
     end
 
     include_examples "POST without params form", "confirm_bank_transfer_form"
-
-    describe "POST new_confirm_bank_transfer_form" do
-      context "when a valid user is signed in" do
-        let(:user) { create(:user) }
-
-        before do
-          sign_in(user)
-        end
-
-        context "when a renewal is in progress" do
-          let(:transient_registration) do
-            create(:renewing_registration,
-                   :has_required_data,
-                   :has_addresses,
-                   :has_key_people,
-                   :has_unpaid_balance,
-                   account_email: user.email)
-          end
-
-          context "when the workflow_state matches the requested form" do
-            before do
-              transient_registration.update_attributes(workflow_state: :confirm_bank_transfer_form)
-            end
-
-            context "when the request is successful" do
-              it "updates the transient registration metadata attributes from application configuration" do
-                allow(Rails.configuration).to receive(:metadata_route).and_return("ASSISTED_DIGITAL")
-
-                expect(transient_registration.reload.metaData.route).to be_nil
-
-                post_form_with_params(:confirm_bank_transfer_form, transient_registration.token)
-
-                expect(transient_registration.reload.metaData.route).to eq("ASSISTED_DIGITAL")
-              end
-            end
-          end
-        end
-      end
-    end
   end
 end

--- a/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
@@ -121,8 +121,7 @@ module WasteCarriersEngine
               }
             end
 
-            it "add a new payment to the registration, redirects to renewal_complete_form, updates the metadata route and is idempotent." do
-              allow(Rails.configuration).to receive(:metadata_route).and_return("ASSISTED_DIGITAL")
+            it "adds a new payment to the registration, redirects to renewal_complete_form and is idempotent." do
               expected_payments_count = transient_registration.finance_details.payments.count + 1
 
               get success_worldpay_forms_path(token), params: params
@@ -131,7 +130,6 @@ module WasteCarriersEngine
               transient_registration.reload
 
               expect(response).to redirect_to(new_renewal_complete_form_path(token))
-              expect(transient_registration.metaData.route).to eq("ASSISTED_DIGITAL")
               expect(transient_registration.finance_details.payments.count).to eq(expected_payments_count)
             end
 
@@ -140,14 +138,9 @@ module WasteCarriersEngine
                 transient_registration.conviction_sign_offs = [build(:conviction_sign_off)]
               end
 
-              it "updates the transient registration metadata attributes from application configuration and redirects to renewal_received_pending_conviction_form" do
-                allow(Rails.configuration).to receive(:metadata_route).and_return("ASSISTED_DIGITAL")
-
-                expect(transient_registration.reload.metaData.route).to be_nil
-
+              it "redirects to renewal_received_pending_conviction_form" do
                 get success_worldpay_forms_path(token), params: params
 
-                expect(transient_registration.reload.metaData.route).to eq("ASSISTED_DIGITAL")
                 expect(response).to redirect_to(new_renewal_received_pending_conviction_form_path(token))
               end
 

--- a/spec/services/waste_carriers_engine/renewal_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/renewal_completion_service_spec.rb
@@ -93,12 +93,12 @@ module WasteCarriersEngine
         end
 
         it "copies the registration's route from the transient_registration to the registration" do
-          transient_registration.metaData.route = "ASSISTED_DIGITAL_FROM_TRANSIENT_REGISTRATION"
+          transient_registration.metaData.route = "ASSISTED_DIGITAL"
           transient_registration.save
 
           renewal_completion_service.complete_renewal
 
-          expect(registration.reload.metaData.route).to eq("ASSISTED_DIGITAL_FROM_TRANSIENT_REGISTRATION")
+          expect(registration.reload.metaData.route).to eq("ASSISTED_DIGITAL")
         end
 
         it "keeps existing orders" do


### PR DESCRIPTION
This change initialises metaData.route at transient registration creation time, instead of at the end of the registration/renewal workflows. This is to support tracking of partial assisted digital registrations.
https://eaflood.atlassian.net/browse/RUBY-2001