### PR TITLE
strip contact email whitespace

### DIFF
--- a/app/forms/waste_carriers_engine/contact_email_form.rb
+++ b/app/forms/waste_carriers_engine/contact_email_form.rb
@@ -2,15 +2,18 @@
 
 module WasteCarriersEngine
   class ContactEmailForm < ::WasteCarriersEngine::BaseForm
+    include CanStripWhitespace
+
     delegate :contact_email, to: :transient_registration
     attr_accessor :confirmed_email, :no_contact_email
 
     validates_with ContactEmailValidator, attributes: [:contact_email]
 
-    after_initialize :populate_confirmed_email
-
     def submit(params)
-      # Blank email address vluaes should be processed as nil
+      # Strip whitespace here because confirmed_email does not get passed to the base form
+      params = strip_whitespace(params)
+
+      # Blank email address values should be processed as nil
       params[:contact_email] = nil if params[:contact_email].blank?
       params[:confirmed_email] = nil if params[:confirmed_email].blank?
 
@@ -19,12 +22,6 @@ module WasteCarriersEngine
       self.no_contact_email = params[:no_contact_email]
 
       super(params.permit(:contact_email))
-    end
-
-    private
-
-    def populate_confirmed_email
-      self.confirmed_email = contact_email
     end
   end
 end

--- a/app/validators/waste_carriers_engine/contact_email_validator.rb
+++ b/app/validators/waste_carriers_engine/contact_email_validator.rb
@@ -14,7 +14,7 @@ module WasteCarriersEngine
         return true
       end
 
-      if record.confirmed_email != record.contact_email
+      if record.confirmed_email&.downcase != record.contact_email&.downcase
         add_validation_error(record, :confirmed_email, :does_not_match)
         return false
       end

--- a/spec/forms/waste_carriers_engine/cannot_renew_type_change_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/cannot_renew_type_change_forms_spec.rb
@@ -4,6 +4,10 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe CannotRenewTypeChangeForm, type: :model do
-    pending "No examples currently defined"
+    describe "#workflow_state" do
+      it_behaves_like "a fixed final state",
+                      current_state: :cannot_renew_type_change_form,
+                      factory: :renewing_registration
+    end
   end
 end

--- a/spec/forms/waste_carriers_engine/contact_email_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/contact_email_forms_spec.rb
@@ -12,14 +12,26 @@ module WasteCarriersEngine
         {
           token: contact_email_form.token,
           contact_email: contact_email,
-          confirmed_email: contact_email,
+          confirmed_email: confirmed_email,
           no_contact_email: defined?(no_contact_email) ? no_contact_email : nil
         }
       end
+      let(:confirmed_email) { contact_email }
 
       shared_examples "should submit" do
         it "submits the form successfully" do
           expect(contact_email_form.submit(ActionController::Parameters.new(params))).to be true
+        end
+      end
+
+      shared_examples "should submit and populate the contact_email" do
+        it "submits the form successfully" do
+          expect(contact_email_form.submit(ActionController::Parameters.new(params))).to be true
+        end
+
+        it "populates the contact_email" do
+          expect { contact_email_form.submit(ActionController::Parameters.new(params)) }
+            .to change { contact_email_form.transient_registration.contact_email }.to(contact_email.strip)
         end
       end
 
@@ -38,7 +50,22 @@ module WasteCarriersEngine
           context "with an email address" do
             let(:contact_email) { Faker::Internet.email }
 
-            it_behaves_like "should submit"
+            it_behaves_like "should submit and populate the contact_email"
+          end
+
+          context "with whitespace around the email address" do
+            let(:actual_email) { Faker::Internet.email }
+            let(:contact_email) { "  #{actual_email} " }
+            let(:confirmed_email) { actual_email }
+
+            it_behaves_like "should submit and populate the contact_email"
+          end
+
+          context "with whitespace around the confirmed email address" do
+            let(:contact_email) { Faker::Internet.email }
+            let(:confirmed_email) { "#{contact_email} " }
+
+            it_behaves_like "should submit and populate the contact_email"
           end
         end
 
@@ -48,12 +75,7 @@ module WasteCarriersEngine
           context "with an email address" do
             let(:contact_email) { Faker::Internet.email }
 
-            it_behaves_like "should submit"
-
-            it "populates contact_email" do
-              expect { contact_email_form.submit(ActionController::Parameters.new(params)) }
-                .to change { contact_email_form.transient_registration.contact_email }.to(contact_email)
-            end
+            it_behaves_like "should submit and populate the contact_email"
           end
 
           context "with a blank email address" do

--- a/spec/forms/waste_carriers_engine/renewal_complete_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/renewal_complete_forms_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe RenewalCompleteForm, type: :model do
-    pending "No examples currently defined"
+    it_behaves_like "a fixed final state",
+                    current_state: :renewal_complete_form,
+                    factory: :renewing_registration
   end
 end

--- a/spec/requests/waste_carriers_engine/registration_received_pending_payment_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/registration_received_pending_payment_forms_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 module WasteCarriersEngine
-  RSpec.describe "RenewalCompleteForms", type: :request do
+  RSpec.describe "RegistrationReceivedPendingPaymentForm", type: :request do
     describe "GET new_registration_received_pending_payment_form_path" do
       context "when no new registration exists" do
         it "redirects to the invalid page" do

--- a/spec/validators/waste_carriers_engine/contact_email_validator_spec.rb
+++ b/spec/validators/waste_carriers_engine/contact_email_validator_spec.rb
@@ -59,6 +59,18 @@ module WasteCarriersEngine
         it_behaves_like "is valid"
       end
 
+      context "with a matching confirmed email address in a different case" do
+        let(:confirmed_email) { contact_email.upcase }
+
+        it_behaves_like "is valid"
+      end
+
+      context "with a matching confirmed email address in mixed case" do
+        let(:confirmed_email) { "#{contact_email[0..5].upcase}#{contact_email[6..-1]}" }
+
+        it_behaves_like "is valid"
+      end
+
       context "with a mismatched confirmed email address" do
         let(:confirmed_email) { "not@chance.com" }
 

--- a/spec/validators/waste_carriers_engine/contact_email_validator_spec.rb
+++ b/spec/validators/waste_carriers_engine/contact_email_validator_spec.rb
@@ -66,7 +66,7 @@ module WasteCarriersEngine
       end
 
       context "with a matching confirmed email address in mixed case" do
-        let(:confirmed_email) { "#{contact_email[0..5].upcase}#{contact_email[6..-1]}" }
+        let(:confirmed_email) { "#{contact_email[0..5].upcase}#{contact_email[6..]}" }
 
         it_behaves_like "is valid"
       end


### PR DESCRIPTION
This change strips whitespace from confirmation email and contact email before comparison. Previously this was done only for contact_email, and after comparison.
https://eaflood.atlassian.net/browse/RUBY-2143