### PR TITLE
EPR pending convictions check

### DIFF
--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -35,12 +35,12 @@ module WasteCarriersEngine
 
     field :renew_token, type: String
 
-    def self.lower_tier_or_unexpired_or_in_covid_grace_window
+    def self.registrations_for_epr_export
       beginning_of_today = Time.now.in_time_zone("London").beginning_of_day
       normal_expiry_date = beginning_of_today + 1.day
       earliest_day_of_covid_grace_window = beginning_of_today - Rails.configuration.covid_grace_window.days + 1.day
 
-      any_of(
+      unscoped.any_of(
         # Registration is lower tier
         { tier: LOWER_TIER },
         # Registration expires on or after the current date
@@ -49,7 +49,9 @@ module WasteCarriersEngine
         { expires_on: {
           "$lt" => Rails.configuration.end_of_covid_extension,
           "$gte" => earliest_day_of_covid_grace_window
-        } }
+        } },
+        # Registration is inactive because it has declared convictions
+        { "$and": ["metaData.status": "PENDING", declared_convictions: "yes"] }
       )
     end
 

--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -50,8 +50,17 @@ module WasteCarriersEngine
           "$lt" => Rails.configuration.end_of_covid_extension,
           "$gte" => earliest_day_of_covid_grace_window
         } },
-        # Registration is inactive because it has declared convictions
-        { "$and": ["metaData.status": "PENDING", declared_convictions: "yes"] }
+        # Registration is a renewal pending a convictions check, without a pending payment
+        { "$and": [
+          # ... has declared convictions
+          declared_convictions: "yes",
+          # .... is a renewal
+          "past_registrations.0": { "$exists": true },
+          # ... is pending
+          "metaData.status": "PENDING",
+          # ... does not have a pending payment
+          "financeDetails.balance": { "$lte": 0 }
+        ] }
       )
     end
 

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -174,26 +174,48 @@ module WasteCarriersEngine
         end
       end
 
-      describe ".lower_tier_or_unexpired_or_in_covid_grace_window" do
-        it "returns registrations who are lower tier, unexpired or in the COVID grace window" do
+      describe ".registrations_for_epr_export" do
+
+        before do
           allow(Rails.configuration).to receive(:end_of_covid_extension).and_return(10.days.ago.to_date)
           allow(Rails.configuration).to receive(:covid_grace_window).and_return(30)
+        end
 
+        subject(:result) { described_class.registrations_for_epr_export }
+
+        it "returns registrations which are unexpired" do
           future_expire_date = create(:registration, :has_required_data, expires_on: 2.days.from_now)
-          past_covid_extension_in_grace_window = create(:registration, :has_required_data, expires_on: 20.days.ago)
-          past_covid_extension_edge_grace_window = create(:registration, :has_required_data, expires_on: 30.days.ago.beginning_of_day)
-          past_covid_extension_not_in_grace_window = create(:registration, :has_required_data, expires_on: 40.days.ago)
-          past_not_covid = create(:registration, :has_required_data, expires_on: 2.days.ago)
-          lower_tier = create(:registration, :has_required_data, :lower_tier, expires_on: nil)
-
-          result = described_class.lower_tier_or_unexpired_or_in_covid_grace_window
-
           expect(result).to include(future_expire_date)
-          expect(result).to include(past_covid_extension_in_grace_window)
+        end
+
+        it "does not return registrations which are expired" do
+          expired = create(:registration, :has_required_data, expires_on: 2.days.ago)
+          expect(result).not_to include(expired)
+        end
+
+        it "does not return registrations without an expiry date" do
+          not_activated = create(:registration, :has_required_data, expires_on: nil)
+          expect(result).not_to include(not_activated)
+        end
+
+        it "returns registrations which are lower tier" do
+          lower_tier = create(:registration, :has_required_data, :lower_tier, expires_on: nil)
           expect(result).to include(lower_tier)
+        end
+
+        it "returns registrations which are in the COVID grace window" do
+          past_covid_extension_in_grace_window = create(:registration, :has_required_data, expires_on: 20.days.ago)
+          expect(result).to include(past_covid_extension_in_grace_window)
+        end
+
+        it "does not return registrations which are not in the COVID grace window" do
+          past_covid_extension_not_in_grace_window = create(:registration, :has_required_data, expires_on: 40.days.ago)
           expect(result).not_to include(past_covid_extension_not_in_grace_window)
-          expect(result).not_to include(past_covid_extension_edge_grace_window)
-          expect(result).not_to include(past_not_covid)
+        end
+
+        it "returns registrations which are pending a conviction check" do
+          pending_check_registration = create(:registration, :has_required_data, :is_pending, declared_convictions: "yes")
+          expect(result).to include(pending_check_registration)
         end
       end
 

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -213,9 +213,39 @@ module WasteCarriersEngine
           expect(result).not_to include(past_covid_extension_not_in_grace_window)
         end
 
-        it "returns registrations which are pending a conviction check" do
-          pending_check_registration = create(:registration, :has_required_data, :is_pending, declared_convictions: "yes")
-          expect(result).to include(pending_check_registration)
+        context "when a registration is pending a conviction check" do
+          let(:pending_check_registration) do
+            create(:registration,
+                   :has_required_data,
+                   :is_pending,
+                   past_registrations: past_registrations,
+                   declared_convictions: "yes",
+                   finance_details: build(:finance_details, balance: balance))
+          end
+          let(:past_registrations) { [create(:registration, :has_required_data)] }
+          let(:balance) { 0 }
+
+          before { pending_check_registration }
+
+          it "returns registrations which are pending a conviction check" do
+            expect(result).to include(pending_check_registration)
+          end
+
+          context "with an unpaid balance" do
+            let(:balance) { 1 }
+
+            it "does not include the registration" do
+              expect(result).not_to include(pending_check_registration)
+            end
+          end
+
+          context "when not a renewal" do
+            let(:past_registrations) { [] }
+
+            it "does not include the registration" do
+              expect(result).not_to include(pending_check_registration)
+            end
+          end
         end
       end
 


### PR DESCRIPTION
This change updates the scoping method for the EPR export to include registrations pending conviction checks.
https://eaflood.atlassian.net/browse/RUBY-2113