### PR TITLE
Companies house fixes

### DIFF
--- a/app/controllers/waste_carriers_engine/check_registered_company_name_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/check_registered_company_name_forms_controller.rb
@@ -9,8 +9,8 @@ module WasteCarriersEngine
 
       begin
         company_name
-      rescue StandardError
-        Rails.logger.error "Failed to load"
+      rescue StandardError => e
+        Rails.logger.error "Failed to load: #{e}"
         render(:companies_house_down)
       end
     end

--- a/app/controllers/waste_carriers_engine/invalid_company_status_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/invalid_company_status_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class InvalidCompanyStatusFormsController < ::WasteCarriersEngine::FormsController
+    def new
+      super(InvalidCompanyStatusForm, "invalid_company_status_form")
+    end
+
+    def create
+      super(InvalidCompanyStatusForm, "invalid_company_status_form")
+    end
+  end
+end

--- a/app/forms/waste_carriers_engine/invalid_company_status_form.rb
+++ b/app/forms/waste_carriers_engine/invalid_company_status_form.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class InvalidCompanyStatusForm < ::WasteCarriersEngine::BaseForm
+
+  end
+end

--- a/app/forms/waste_carriers_engine/registration_number_form.rb
+++ b/app/forms/waste_carriers_engine/registration_number_form.rb
@@ -11,20 +11,15 @@ module WasteCarriersEngine
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating
       # If param isn't set, use a blank string instead to avoid errors with the validator
-      params[:company_no] = process_company_no(params[:company_no])
+      params[:company_no] = format_company_no(params[:company_no])
 
       super
     end
 
     private
 
-    def process_company_no(company_no)
-      return unless company_no.present?
-
-      number = company_no.to_s
-      # Should be 8 characters, so if it's not, add 0s to the start
-      number = "0#{number}" while number.length < 8
-      number
+    def format_company_no(company_no)
+      company_no&.to_s&.upcase&.rjust(8, "0")
     end
   end
 end

--- a/app/views/waste_carriers_engine/invalid_company_status_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/invalid_company_status_forms/new.html.erb
@@ -1,0 +1,27 @@
+<%= render("waste_carriers_engine/shared/back", token: @invalid_company_status_form.token) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(@invalid_company_status_form) do |f| %>
+      <%= render partial: "waste_carriers_engine/shared/error_summary", locals: { f: f } %>
+
+      <h1 class="govuk-heading-l">
+        <%= t(".heading", ch_number: @transient_registration.company_no) %>
+      </h1>
+      <legend class="govuk-visually-hidden">
+        <%= t(".heading", ch_number: @transient_registration.company_no) %>
+      </legend>
+
+      <p class="govuk-body"><%= t(".description") %></p>
+
+      <div class="govuk-hint">
+        <%= t(".hint_1") %><br>
+        <%= t(".hint_2") %><br>
+        <%= mail_to t(".enquiries_email") %>
+
+      <p>
+      <%= link_to t(".start_a_new_registration_button"), start_forms_path, class: "govuk-button" %>
+    
+    <% end %>
+  </div>
+</div>

--- a/config/locales/forms/invalid_company_status_forms/en.yml
+++ b/config/locales/forms/invalid_company_status_forms/en.yml
@@ -1,0 +1,11 @@
+en:
+  waste_carriers_engine:
+    invalid_company_status_forms:
+      new:
+        title: We could not validate your Companies House number
+        heading: We could not validate your Companies House number %{ch_number}
+        description: There is an issue with your Companies House number against this registration. You must either create a new registration, or speak to our contact centre.
+        hint_1: Environment Agency
+        hint_2: Telephone 03708 506 506, Monday to Friday (8am to 6pm)
+        enquiries_email: enquiries@environment-agency.gov.uk
+        start_a_new_registration_button: Start a new registration

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -266,6 +266,11 @@ WasteCarriersEngine::Engine.routes.draw do
               path: "incorrect-company",
               path_names: { new: "" }
 
+    resources :invalid_company_status_forms,
+              only: %i[new create],
+              path: "invalid-company-status",
+              path_names: { new: "" }
+
     resources :use_trading_name_forms,
               only: %i[new create],
               path: "use-trading-name",

--- a/lib/defra_ruby_companies_house.rb
+++ b/lib/defra_ruby_companies_house.rb
@@ -4,7 +4,7 @@ require "rest-client"
 
 class DefraRubyCompaniesHouse
   def initialize(company_no)
-    @company_url = "#{Rails.configuration.companies_house_host}#{company_no.to_s.rjust(8, '0')}"
+    @company_url = "#{Rails.configuration.companies_house_host}#{format_company_number(company_no)}"
     @api_key = Rails.configuration.companies_house_api_key
 
     raise StandardError "Failed to load company" unless load_company
@@ -28,6 +28,10 @@ class DefraRubyCompaniesHouse
   end
 
   private
+
+  def format_company_number(company_number)
+    company_number&.to_s&.upcase&.rjust(8, "0")
+  end
 
   def load_company
     @company =

--- a/lib/defra_ruby_companies_house.rb
+++ b/lib/defra_ruby_companies_house.rb
@@ -27,6 +27,10 @@ class DefraRubyCompaniesHouse
     ].compact
   end
 
+  def company_status
+    @company[:company_status] if @company
+  end
+
   private
 
   def format_company_number(company_number)

--- a/spec/factories/forms/invalid_company_status_form.rb
+++ b/spec/factories/forms/invalid_company_status_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :invalid_company_status_form, class: "WasteCarriersEngine::InvalidCompanyStatusForm" do
+    trait :has_required_data do
+      initialize_with { new(create(:renewing_registration, :has_required_data, workflow_state: "invalid_company_status_form")) }
+    end
+  end
+end

--- a/spec/forms/waste_carriers_engine/invalid_company_status_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/invalid_company_status_forms_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe InvalidCompanyStatusForm, type: :model do
+    describe "#submit" do
+      let(:form) { build(:invalid_company_status_form, :has_required_data) }
+
+      context "when the form is valid" do
+        let(:valid_params) { { token: form.token } }
+
+        it "submits" do
+          expect(form.submit(valid_params)).to be_truthy
+        end
+      end
+
+      context "when the form is not valid" do
+        before do
+          allow(form).to receive(:valid?).and_return(false)
+        end
+
+        it "does not submit" do
+          expect(form.submit({})).to be_falsey
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/waste_carriers_engine/registration_number_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/registration_number_forms_spec.rb
@@ -20,10 +20,23 @@ module WasteCarriersEngine
           expect(registration_number_form.submit(valid_params)).to be true
         end
 
-        context "when the token is less than 8 characters" do
+        context "when the company number contains lower case characters" do
+          before { valid_params[:company_no] = "az016107" }
+
+          it "saves as upper case" do
+            registration_number_form.submit(valid_params)
+            expect(registration_number_form.company_no).to eq("AZ016107")
+          end
+
+          it "submits" do
+            expect(registration_number_form.submit(valid_params)).to be true
+          end
+        end
+
+        context "when the company number is less than 8 characters" do
           before { valid_params[:company_no] = "946107" }
 
-          it "increases the length" do
+          it "increases the length before saving" do
             registration_number_form.submit(valid_params)
             expect(registration_number_form.company_no).to eq("00946107")
           end

--- a/spec/lib/defra_ruby_companies_house_spec.rb
+++ b/spec/lib/defra_ruby_companies_house_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe DefraRubyCompaniesHouse do
       end
     end
 
-    context "when the requests time out" do
+    context "when the request times out" do
       it "raises a standard error" do
         expect { company_name_for_number }.to raise_error(StandardError)
       end
@@ -95,6 +95,40 @@ RSpec.describe DefraRubyCompaniesHouse do
 
       it "returns the address lines" do
         expect(address_for_company_number).to eq ["R House", "Middle Street", "Thereabouts", "HD1 2BN"]
+      end
+    end
+  end
+
+  describe "#company_status" do
+    subject(:company_status) { described_class.new(company_no).company_status }
+
+    context "with an invalid company number" do
+      let(:company_no) { invalid_company_no }
+
+      it "raises a standard error" do
+        expect { company_status }.to raise_error(StandardError)
+      end
+    end
+
+    context "when the request times out" do
+      it "raises a standard error" do
+        expect { company_status }.to raise_error(StandardError)
+      end
+    end
+
+    context "when the request returns an error" do
+      before { stub_request(:get, /#{Rails.configuration.companies_house_host}*/).to_raise(SocketError) }
+
+      it "raises a standard error" do
+        expect { company_status }.to raise_error(StandardError)
+      end
+    end
+
+    context "with a valid company number" do
+      let(:company_no) { valid_company_no }
+
+      it "returns the expected status" do
+        expect(company_status).to eq "active"
       end
     end
   end

--- a/spec/lib/defra_ruby_companies_house_spec.rb
+++ b/spec/lib/defra_ruby_companies_house_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe DefraRubyCompaniesHouse do
       status: 404
     )
     # ... then add a stub to cover valid company_no values
-    stub_request(:get, /#{Rails.configuration.companies_house_host}[a-zA-Z\d]{8}/).to_return(
+    stub_request(:get, /#{Rails.configuration.companies_house_host}[A-Z\d]{8}/).to_return(
       status: 200,
       body: File.read("./spec/fixtures/files/companies_house_response.json")
     )
@@ -42,6 +42,14 @@ RSpec.describe DefraRubyCompaniesHouse do
 
     context "with a short company number" do
       let(:company_no) { short_company_no }
+
+      it "returns the company name" do
+        expect(company_name_for_number).to eq "BOGUS LIMITED"
+      end
+    end
+
+    context "with a lower case company number" do
+      let(:company_no) { "xy12345z" }
 
       it "returns the company name" do
         expect(company_name_for_number).to eq "BOGUS LIMITED"

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/invalid_company_status_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/invalid_company_status_form_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe RenewingRegistration, type: :model do
+    subject do
+      build(:renewing_registration,
+            :has_required_data,
+            workflow_state: "invalid_company_status_form")
+    end
+
+    describe "#workflow_state" do
+      context "with :next transition" do
+        include_examples "has next transition", next_state: :start_form
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/renewing_registration_workflow/renewal_information_form_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_workflow/renewal_information_form_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "defra_ruby_companies_house"
 
 module WasteCarriersEngine
   RSpec.describe RenewingRegistration, type: :model do
@@ -15,6 +16,13 @@ module WasteCarriersEngine
     let(:tier) { WasteCarriersEngine::Registration::UPPER_TIER }
     let(:business_type) { nil }
     let(:location) { "england" }
+    let(:defra_ruby_companies_house) { instance_double(DefraRubyCompaniesHouse) }
+    let(:company_status) { "active" }
+
+    before do
+      allow(DefraRubyCompaniesHouse).to receive(:new).and_return(defra_ruby_companies_house)
+      allow(defra_ruby_companies_house).to receive(:company_status).and_return(company_status)
+    end
 
     describe "#workflow_state" do
       context "with :renewal_information_form state transitions" do
@@ -58,16 +66,45 @@ module WasteCarriersEngine
             it_behaves_like "main_people_form or company_name_form based on tier"
           end
 
+          shared_examples "check_registered_company_name_form or invalid_company_status_form" do
+
+            %w[active
+               voluntary-arrangement].each do |status|
+              context "with a company status of #{status}" do
+                let(:company_status) { status }
+
+                include_examples "has next transition", next_state: "check_registered_company_name_form"
+              end
+            end
+
+            %w[dissolved
+               liquidation
+               receivership
+               administration
+               converted-closed
+               insolvency-proceedings
+               registered
+               removed
+               closed
+               open].each do |status|
+              context "with a company status of #{status}" do
+                let(:company_status) { status }
+
+                include_examples "has next transition", next_state: "invalid_company_status_form"
+              end
+            end
+          end
+
           context "when the business type is limitedCompany" do
             let(:business_type) { "limitedCompany" }
 
-            include_examples "has next transition", next_state: "check_registered_company_name_form"
+            include_examples "check_registered_company_name_form or invalid_company_status_form"
           end
 
           context "when the business type is limitedLiabilityPartnership" do
             let(:business_type) { "limitedLiabilityPartnership" }
 
-            include_examples "has next transition", next_state: "check_registered_company_name_form"
+            include_examples "check_registered_company_name_form or invalid_company_status_form"
           end
         end
       end

--- a/spec/requests/waste_carriers_engine/invalid_company_status_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/invalid_company_status_forms_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "InvalidCompanyStatusForms", type: :request do
+    include_examples "GET flexible form", "invalid_company_status_form"
+
+    describe "POST invalid_company_status_form_path" do
+      let(:transient_registration) do
+        create(:renewing_registration,
+               :has_required_data,
+               account_email: user.email,
+               workflow_state: "invalid_company_status_form")
+      end
+      let(:user) { create(:user) }
+
+      before do
+        sign_in(user)
+      end
+
+      it "redirects to new registration start form" do
+        post_form_with_params(:invalid_company_status_form, transient_registration.token)
+
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to(new_start_form_path(token: transient_registration.token))
+      end
+    end
+  end
+end

--- a/spec/requests/waste_carriers_engine/renewal_information_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/renewal_information_forms_spec.rb
@@ -1,9 +1,17 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "defra_ruby_companies_house"
 
 module WasteCarriersEngine
   RSpec.describe "RenewalInformationForms", type: :request do
+    let(:defra_ruby_companies_house) { instance_double(DefraRubyCompaniesHouse) }
+
+    before do
+      allow(DefraRubyCompaniesHouse).to receive(:new).and_return(defra_ruby_companies_house)
+      allow(defra_ruby_companies_house).to receive(:company_status).and_return("active")
+    end
+
     include_examples "GET flexible form", "renewal_information_form"
 
     include_examples "POST without params form", "renewal_information_form"


### PR DESCRIPTION
This change implements two changes to companies house handling:
1. Upper-cases company registration "numbers" before sending them to the Companies House API: https://eaflood.atlassian.net/browse/RUBY-2258
2. Checks company registration status before allowing a company to renew a registration: https://eaflood.atlassian.net/browse/RUBY-2014