### PR TITLE
transient registration addresses

### DIFF
--- a/app/controllers/waste_carriers_engine/application_controller.rb
+++ b/app/controllers/waste_carriers_engine/application_controller.rb
@@ -16,7 +16,7 @@ module WasteCarriersEngine
     rescue_from StandardError do |e|
       Airbrake.notify e
       Rails.logger.error "Unhandled exception: #{e}"
-      log_transient_registration_details("Uncaught system error", @transient_registration)
+      log_transient_registration_details("Uncaught system error", e, @transient_registration)
       redirect_to "/bo/pages/system_error"
     end
 

--- a/app/controllers/waste_carriers_engine/govpay_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/govpay_forms_controller.rb
@@ -31,8 +31,8 @@ module WasteCarriersEngine
           respond_to_unsuccessful_payment(govpay_payment_status)
         end
       end
-    rescue ArgumentError
-      log_transient_registration_details("Invalid payment uuid in payment callback", @transient_registration)
+    rescue ArgumentError => e
+      log_transient_registration_details("Invalid payment uuid in payment callback", e, @transient_registration)
       Rails.logger.warn "Govpay payment callback error: invalid payment uuid \"#{params[:uuid]}\""
       Airbrake.notify("Govpay callback error: Invalid payment uuid", payment_uuid: params[:uuid])
       flash[:error] = I18n.t(".waste_carriers_engine.govpay_forms.new.internal_error")

--- a/app/models/concerns/waste_carriers_engine/can_strip_whitespace.rb
+++ b/app/models/concerns/waste_carriers_engine/can_strip_whitespace.rb
@@ -34,6 +34,8 @@ module WasteCarriersEngine
 
     def strip_array(array)
       array.each do |nested_object|
+        return nested_object if nested_object.is_a? BSON::Document
+
         strip_whitespace(nested_object.attributes)
       end
     end

--- a/app/models/waste_carriers_engine/renewing_registration.rb
+++ b/app/models/waste_carriers_engine/renewing_registration.rb
@@ -19,7 +19,6 @@ module WasteCarriersEngine
                                isMainService
                                constructionWaste
                                onlyAMF
-                               addresses
                                key_people
                                financeDetails
                                declaredConvictions

--- a/app/services/concerns/waste_carriers_engine/can_add_debug_logging.rb
+++ b/app/services/concerns/waste_carriers_engine/can_add_debug_logging.rb
@@ -5,13 +5,14 @@ module WasteCarriersEngine
     extend ActiveSupport::Concern
 
     # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
-    def log_transient_registration_details(description, transient_registration)
+    def log_transient_registration_details(description, exception, transient_registration)
       return unless FeatureToggle.active?(:additional_debug_logging)
 
-      details = if transient_registration.nil?
-                  { transient_registration: nil }
+      details = { backtrace: exception.backtrace }
+      if transient_registration.nil?
+                  details.merge!({ transient_registration: nil })
                 else
-                  { type: transient_registration.class.to_s,
+                details.merge!({ type: transient_registration.class.to_s,
                     reg_identifier: transient_registration.reg_identifier,
                     from_magic_link: from_magic_link(transient_registration),
                     workflow_state: transient_registration.workflow_state,
@@ -23,7 +24,7 @@ module WasteCarriersEngine
                     "metaData.route": transient_registration.metaData.route,
                     created_at: transient_registration.created_at,
                     orders: transient_registration.finance_details&.orders.to_s,
-                    payments: transient_registration.finance_details&.payments.to_s }
+                    payments: transient_registration.finance_details&.payments.to_s })
                 end
       Airbrake.notify(StandardError.new(description), details)
       Rails.logger.warn "#{description}: #{details}"

--- a/app/services/concerns/waste_carriers_engine/can_add_debug_logging.rb
+++ b/app/services/concerns/waste_carriers_engine/can_add_debug_logging.rb
@@ -8,7 +8,7 @@ module WasteCarriersEngine
     def log_transient_registration_details(description, exception, transient_registration)
       return unless FeatureToggle.active?(:additional_debug_logging)
 
-      details = { backtrace: exception.backtrace }
+      details = { backtrace: exception&.backtrace }
       if transient_registration.nil?
         details.merge!({ transient_registration: nil })
       else

--- a/app/services/concerns/waste_carriers_engine/can_add_debug_logging.rb
+++ b/app/services/concerns/waste_carriers_engine/can_add_debug_logging.rb
@@ -10,22 +10,22 @@ module WasteCarriersEngine
 
       details = { backtrace: exception.backtrace }
       if transient_registration.nil?
-                  details.merge!({ transient_registration: nil })
-                else
-                details.merge!({ type: transient_registration.class.to_s,
-                    reg_identifier: transient_registration.reg_identifier,
-                    from_magic_link: from_magic_link(transient_registration),
-                    workflow_state: transient_registration.workflow_state,
-                    workflow_history: transient_registration.workflow_history.to_s,
-                    tier: transient_registration.tier,
-                    account_email: transient_registration.account_email,
-                    expires_on: transient_registration.expires_on,
-                    renew_token: renew_token(transient_registration),
-                    "metaData.route": transient_registration.metaData.route,
-                    created_at: transient_registration.created_at,
-                    orders: transient_registration.finance_details&.orders.to_s,
-                    payments: transient_registration.finance_details&.payments.to_s })
-                end
+        details.merge!({ transient_registration: nil })
+      else
+        details.merge!({ type: transient_registration.class.to_s,
+                         reg_identifier: transient_registration.reg_identifier,
+                         from_magic_link: from_magic_link(transient_registration),
+                         workflow_state: transient_registration.workflow_state,
+                         workflow_history: transient_registration.workflow_history.to_s,
+                         tier: transient_registration.tier,
+                         account_email: transient_registration.account_email,
+                         expires_on: transient_registration.expires_on,
+                         renew_token: renew_token(transient_registration),
+                         "metaData.route": transient_registration.metaData.route,
+                         created_at: transient_registration.created_at,
+                         orders: transient_registration.finance_details&.orders.to_s,
+                         payments: transient_registration.finance_details&.payments.to_s })
+      end
       Airbrake.notify(StandardError.new(description), details)
       Rails.logger.warn "#{description}: #{details}"
 

--- a/app/services/waste_carriers_engine/base_registration_permission_checks_service.rb
+++ b/app/services/waste_carriers_engine/base_registration_permission_checks_service.rb
@@ -24,6 +24,7 @@ module WasteCarriersEngine
       unless user.present?
         log_transient_registration_details(
           "Permissions check requested for nil user, action: #{action}",
+          nil,
           @transient_registration
         )
       end

--- a/app/services/waste_carriers_engine/registration_completion_service.rb
+++ b/app/services/waste_carriers_engine/registration_completion_service.rb
@@ -31,7 +31,7 @@ module WasteCarriersEngine
         begin
           RegistrationActivationService.run(registration: registration)
         rescue StandardError => e
-          log_transient_registration_details("Exception running RegistrationCompletionService", @transient_registration)
+          log_transient_registration_details("Exception running RegistrationCompletionService", e, @transient_registration)
           Airbrake.notify(e, reg_identifier: @transient_registration.reg_identifier)
           Rails.logger.error e
         end

--- a/app/services/waste_carriers_engine/registration_completion_service.rb
+++ b/app/services/waste_carriers_engine/registration_completion_service.rb
@@ -31,7 +31,8 @@ module WasteCarriersEngine
         begin
           RegistrationActivationService.run(registration: registration)
         rescue StandardError => e
-          log_transient_registration_details("Exception running RegistrationCompletionService", e, @transient_registration)
+          log_transient_registration_details("Exception running RegistrationCompletionService",
+                                             e, @transient_registration)
           Airbrake.notify(e, reg_identifier: @transient_registration.reg_identifier)
           Rails.logger.error e
         end

--- a/spec/requests/waste_carriers_engine/company_address_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/company_address_forms_spec.rb
@@ -111,9 +111,11 @@ module WasteCarriersEngine
           end
 
           it "does not update the transient registration, returns a 302 response and redirects to the correct form for the state" do
+            old_company_address = transient_registration.company_address
+
             post company_address_forms_path(transient_registration.token), params: { company_address_form: valid_params }
 
-            expect(transient_registration.reload.addresses.count).to eq(0)
+            expect(transient_registration.reload.company_address).to eq old_company_address
             expect(response).to have_http_status(:found)
             expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
           end

--- a/spec/requests/waste_carriers_engine/company_address_manual_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/company_address_manual_forms_spec.rb
@@ -106,9 +106,11 @@ module WasteCarriersEngine
           end
 
           it "does not update the transient registration, returns a 302 response and redirects to the correct form for the state" do
+            old_registered_address = transient_registration.registered_address
+
             post company_address_forms_path(transient_registration.token), params: { company_address_form: valid_params }
 
-            expect(transient_registration.reload.addresses.count).to eq(0)
+            expect(transient_registration.reload.registered_address).to eq old_registered_address
             expect(response).to have_http_status(:found)
             expect(response).to redirect_to(new_renewal_start_form_path(transient_registration.token))
           end

--- a/spec/requests/waste_carriers_engine/contact_address_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/contact_address_forms_spec.rb
@@ -77,9 +77,11 @@ module WasteCarriersEngine
           end
 
           it "does not update the transient registration, returns a 302 response and redirects to the correct form for the state" do
+            old_contact_address = transient_registration.contact_address
+
             post contact_address_forms_path(transient_registration.token)
 
-            expect(transient_registration.reload.addresses.count).to eq(0)
+            expect(transient_registration.reload.contact_address).to eq old_contact_address
             expect(response).to have_http_status(:found)
             expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
           end

--- a/spec/requests/waste_carriers_engine/contact_address_manual_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/contact_address_manual_forms_spec.rb
@@ -87,9 +87,11 @@ module WasteCarriersEngine
           end
 
           it "does not update the transient registration, returns a 302 response and redirects to the correct form for the state" do
+            old_contact_address = transient_registration.contact_address
+
             post contact_address_forms_path(transient_registration.token), params: { contact_address_form: valid_params }
 
-            expect(transient_registration.reload.addresses.count).to eq(0)
+            expect(transient_registration.reload.contact_address).to eq(old_contact_address)
             expect(response).to have_http_status(:found)
             expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:token]))
           end

--- a/spec/services/concerns/waste_carriers_engine/can_add_debug_logging_spec.rb
+++ b/spec/services/concerns/waste_carriers_engine/can_add_debug_logging_spec.rb
@@ -13,7 +13,7 @@ module WasteCarriersEngine
 
       let(:transient_registration) { create(:new_registration, :has_required_data) }
 
-      subject(:log_details) { DebugClass.new.log_transient_registration_details("foo", transient_registration) }
+      subject(:log_details) { DebugClass.new.log_transient_registration_details("foo", nil, transient_registration) }
 
       before do
         allow(Airbrake).to receive(:notify)

--- a/spec/services/concerns/waste_carriers_engine/can_add_debug_logging_spec.rb
+++ b/spec/services/concerns/waste_carriers_engine/can_add_debug_logging_spec.rb
@@ -12,8 +12,9 @@ module WasteCarriersEngine
     describe "#log_transient_registration_details" do
 
       let(:transient_registration) { create(:new_registration, :has_required_data) }
+      let(:standard_error) { StandardError.new }
 
-      subject(:log_details) { DebugClass.new.log_transient_registration_details("foo", nil, transient_registration) }
+      subject(:log_details) { DebugClass.new.log_transient_registration_details("foo", standard_error, transient_registration) }
 
       before do
         allow(Airbrake).to receive(:notify)
@@ -31,6 +32,24 @@ module WasteCarriersEngine
         it "logs an error" do
           log_details
           expect(Airbrake).to have_received(:notify)
+        end
+      end
+
+      context "with an exception" do
+        it "sends the exception backtrace to Airbrake" do
+          raise standard_error
+        rescue StandardError
+          log_details
+          # The parameters array should include a backtrace entry which includes the name of this spec file
+          expect(Airbrake).to have_received(:notify)
+            .with(
+              instance_of(StandardError),
+              hash_including(
+                backtrace: array_including(
+                  match(/#{File.basename(__FILE__)}/)
+                )
+              )
+            )
         end
       end
 

--- a/spec/services/waste_carriers_engine/registration_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/registration_completion_service_spec.rb
@@ -52,6 +52,23 @@ module WasteCarriersEngine
         expect(new_registration_scope.to_a).to be_empty
       end
 
+      context "when the activation service raises an exception" do
+        let(:registration_completion_service) { described_class.new }
+        let(:activation_service_instance) { instance_double(RegistrationActivationService) }
+
+        before do
+          allow(registration_completion_service).to receive(:log_transient_registration_details)
+          allow(RegistrationActivationService).to receive(:new).and_return(activation_service_instance)
+          allow(activation_service_instance).to receive(:run).and_raise(StandardError)
+        end
+
+        it "logs the transient registration details" do
+          registration_completion_service.run(transient_registration)
+
+          expect(registration_completion_service).to have_received(:log_transient_registration_details)
+        end
+      end
+
       context "when the registration is a lower tier registration" do
         let(:transient_registration) do
           create(


### PR DESCRIPTION
This change includes addresses when creating a transient registration. This is necessary so that a renewing registration can be included in the EPR export.
https://eaflood.atlassian.net/browse/RUBY-2249