### PR TITLE
deregister link

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
     concurrent-ruby (1.2.0)
     console (1.13.1)
       fiber-local
-    countries (5.3.0)
+    countries (5.3.1)
       unaccent (~> 0.3)
     crack (0.4.5)
       rexml

--- a/app/controllers/waste_carriers_engine/deregisters_controller.rb
+++ b/app/controllers/waste_carriers_engine/deregisters_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class DeregistersController < ApplicationController
+
+    before_action :validate_deregistration_token
+
+    def new
+      redirect_to new_deregistration_confirmation_form_path(registration.deregistration_token)
+    end
+
+    private
+
+    def validate_deregistration_token
+      return render(:invalid_deregistration_link, status: 404) unless registration.present?
+      return render(:already_ceased, status: 422) unless registration.active?
+
+      return if registration.deregistration_token_valid?
+
+      Notify::DeregistrationEmailService.run(registration:)
+      render(:deregistration_link_expired, status: 422)
+    end
+
+    def registration
+      @registration ||= Registration.where(deregistration_token: params[:token]).first
+    end
+  end
+end

--- a/app/controllers/waste_carriers_engine/deregistration_confirmation_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/deregistration_confirmation_forms_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class DeregistrationConfirmationFormsController < WasteCarriersEngine::FormsController
+
+    def new; end
+
+    private
+
+    def validate_token
+      redirect_to(page_path("invalid")) unless Registration.where(deregistration_token: params[:token]).first.present?
+    end
+  end
+end

--- a/app/controllers/waste_carriers_engine/deregistration_confirmation_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/deregistration_confirmation_forms_controller.rb
@@ -3,7 +3,9 @@
 module WasteCarriersEngine
   class DeregistrationConfirmationFormsController < WasteCarriersEngine::FormsController
 
-    def new; end
+    def new
+      # TODO: implement later
+    end
 
     private
 

--- a/app/forms/waste_carriers_engine/deregistration_confirmation_form.rb
+++ b/app/forms/waste_carriers_engine/deregistration_confirmation_form.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  # class DeregistrationConfirmationForm < ::WasteCarriersEngine::BaseForm
+  class DeregistrationConfirmationForm
+    def self.can_navigate_flexibly?
+      false
+    end
+
+    def new
+      render text: "Placeholder deregistration start form"
+      super
+    end
+
+  end
+end

--- a/app/forms/waste_carriers_engine/deregistration_confirmation_form.rb
+++ b/app/forms/waste_carriers_engine/deregistration_confirmation_form.rb
@@ -1,16 +1,14 @@
 # frozen_string_literal: true
 
 module WasteCarriersEngine
-  # class DeregistrationConfirmationForm < ::WasteCarriersEngine::BaseForm
   class DeregistrationConfirmationForm
-    def self.can_navigate_flexibly?
-      false
-    end
 
     def new
       render text: "Placeholder deregistration start form"
-      super
     end
 
+    def submit
+      true
+    end
   end
 end

--- a/app/models/concerns/waste_carriers_engine/can_have_deregistration_token.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_deregistration_token.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  module CanHaveDeregistrationToken
+    extend ActiveSupport::Concern
+    include Mongoid::Document
+
+    included do
+      # This is separate to the CanHaveSecureToken token, which never expires.
+      field :deregistration_token, type: String
+      field :deregistration_token_created_at, type: DateTime
+
+      def generate_deregistration_token
+        self.deregistration_token_created_at = Time.zone.now
+        self.deregistration_token = SecureTokenService.run
+        save!
+
+        deregistration_token
+      end
+
+      def deregistration_token_valid?
+        return false unless active?
+
+        return false unless deregistration_token.present? && deregistration_token_created_at.present?
+
+        deregistration_token_expires_at >= Time.zone.now
+      end
+
+      private
+
+      def deregistration_token_expires_at
+        @deregistration_token_validity_period = ENV.fetch("WCRS_DEREGISTRATION_TOKEN_VALIDITY", 7).to_i
+        deregistration_token_created_at + @deregistration_token_validity_period.days
+      end
+    end
+  end
+end

--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -5,6 +5,7 @@ module WasteCarriersEngine
     include Mongoid::Document
     include CanCheckRegistrationStatus
     include CanFilterConvictionStatus
+    include CanHaveDeregistrationToken
     include CanHaveRegistrationAttributes
     include CanPresentEntityDisplayName
     include CanUseLock

--- a/app/services/waste_carriers_engine/deregistration_magic_link_service.rb
+++ b/app/services/waste_carriers_engine/deregistration_magic_link_service.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class DeregistrationMagicLinkService < BaseService
+    def run(registration:)
+      [
+        Rails.configuration.wcrs_fo_link_domain,
+        "/fo/deregister/",
+        registration.generate_deregistration_token
+      ].join
+    end
+  end
+end

--- a/app/services/waste_carriers_engine/notify/deregistration_email_service.rb
+++ b/app/services/waste_carriers_engine/notify/deregistration_email_service.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  module Notify
+    class DeregistrationEmailService < BaseSendEmailService
+      private
+
+      def notify_options
+        {
+          email_address: @registration.contact_email,
+          template_id: "0001e85a-7a09-4d6d-8988-ffb6fe4e2fd2",
+          personalisation: {
+            company_name: @registration.company_name,
+            first_name: @registration.first_name,
+            last_name: @registration.last_name,
+            deregistration_link: DeregistrationMagicLinkService.run(registration: @registration)
+          }
+        }
+      end
+    end
+  end
+end

--- a/app/views/waste_carriers_engine/deregisters/already_ceased.html.erb
+++ b/app/views/waste_carriers_engine/deregisters/already_ceased.html.erb
@@ -1,0 +1,8 @@
+<% content_for :title, t(".title") %>
+
+<div class="govuk-body">
+  <h1 class="govuk-heading-l">
+    <%= t(".heading") %>
+  </h1>
+
+</div>

--- a/app/views/waste_carriers_engine/deregisters/deregistration_link_expired.erb
+++ b/app/views/waste_carriers_engine/deregisters/deregistration_link_expired.erb
@@ -1,0 +1,12 @@
+<% content_for :title, t(".title") %>
+
+<div class="govuk-body">
+  <h1 class="govuk-heading-l">
+    <%= t(".heading") %>
+  </h1>
+
+  <p>
+    <%= t(".paragraph1", reg_identifier: @registration.reg_identifier) %>
+  </p>
+
+</div>

--- a/app/views/waste_carriers_engine/deregisters/invalid_deregistration_link.html.erb
+++ b/app/views/waste_carriers_engine/deregisters/invalid_deregistration_link.html.erb
@@ -1,0 +1,8 @@
+<% content_for :title, t(".title") %>
+
+<div class="govuk-body">
+  <h1 class="govuk-heading-l">
+    <%= t(".heading") %>
+  </h1>
+
+</div>

--- a/app/views/waste_carriers_engine/deregistration_confirmation_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/deregistration_confirmation_forms/new.html.erb
@@ -1,0 +1,5 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    Development Placeholder: deregistration_confirmation_form
+  </div>
+</div>

--- a/config/locales/forms/renews/en.yml
+++ b/config/locales/forms/renews/en.yml
@@ -2,21 +2,32 @@ en:
   waste_carriers_engine:
     renews:
       already_renewed:
-        title: "That registration has already been renewed"
-        heading: "That registration has already been renewed"
-        paragraph1: "Our records show that registration %{reg_identifier} has already been renewed."
+        title: That registration has already been renewed
+        heading: That registration has already been renewed
+        paragraph1: Our records show that registration %{reg_identifier} has already been renewed.
         paragraph2_html: "If you still need to register as a waste carrier, broker or dealer then <a href=\"%{link_to_new_registration}\">make a new registration.</a>"
-        paragraph3: "If you want to discuss this registration, contact the Environment Agency. You will need your registration number."
+        paragraph3: If you want to discuss this registration, contact the Environment Agency. You will need your registration number.
         paragraph4_html: "Environment Agency helpline: 03708 506 506 (Monday to Friday, 8am to 6pm) <a href=\"mailto:nccc-carrierbroker@environment-agency.gov.uk\">nccc-carrierbroker@environment-agency.gov.uk</a>"
       past_renewal_window:
-        title: "This registration has expired"
-        heading: "This registration has expired"
-        paragraph1: "Your registration has expired so you cannot renew."
-        register_again: "Register again"
+        title: This registration has expired
+        heading: This registration has expired
+        paragraph1: Your registration has expired so you cannot renew.
+        register_again: Register again
       invalid_magic_link:
-        title: "We cannot find that renewal"
-        heading: "We cannot find that renewal"
+        title: We cannot find that renewal
+        heading: We cannot find that renewal
         paragraph1: "Things to try:"
-        point1: "Go back to your email and follow the link again."
-        point2: "Copy the whole link from the email and paste it into your web browser. Make sure that you include all of the characters at the end of the link."
+        point1: Go back to your email and follow the link again.
+        point2: Copy the whole link from the email and paste it into your web browser. Make sure that you include all of the characters at the end of the link.
         point3_html: "If that does not work, <a href=\"%{link_to_new_registration}\">start a new registration</a>."
+    deregisters:
+      deregistration_link_expired:
+        title: This link has expired. We will send a new link to your contact email address.
+        heading: This link has expired. We will send a new link to your contact email address.
+        paragraph1: You can close this window.
+      already_ceased:
+        title: This link has already been cancelled
+        heading: This link has already been cancelled
+      invalid_deregistration_link:
+        title: Invalid Deregistration Link
+        heading: Development Placeholder Heading

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -191,6 +191,13 @@ WasteCarriersEngine::Engine.routes.draw do
               path_names: { new: "" }
     # End of edit flow
 
+    # Deregistration flow
+    resources :deregistration_confirmation_forms,
+              only: %i[new create],
+              path: "deregistration-confirmation",
+              path_names: { new: "" }
+    # End of deregistration flow
+
     resources :renewal_start_forms,
               only: %i[new create],
               path: "renew",
@@ -487,6 +494,11 @@ WasteCarriersEngine::Engine.routes.draw do
   get "/renew/:token",
       to: "renews#new",
       as: "renew"
+
+  # Deregister via magic link token
+  get "/deregister/:token",
+      to: "deregisters#new",
+      as: "deregister"
 
   # Static pages with HighVoltage
   resources :pages, only: [:show], controller: "pages"

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -57,11 +57,13 @@ module Dummy
     config.companies_house_api_key = ENV["WCRS_COMPANIES_HOUSE_API_KEY"]
 
     # Paths
-    config.wcrs_renewals_url = ENV["WCRS_RENEWALS_DOMAIN"] || "http://localhost:3002"
+    # This is the domain to use on URLs for FO services such as renewal and deregistration
+    config.wcrs_fo_link_domain = ENV["WCRS_RENEWALS_DOMAIN"] || "http://localhost:3002"
+
     config.wcrs_frontend_url = ENV["WCRS_FRONTEND_DOMAIN"] || "http://localhost:3000"
     config.wcrs_services_url = ENV["WCRS_SERVICES_DOMAIN"] || "http://localhost:8003"
     config.os_places_service_url = ENV["WCRS_OS_PLACES_DOMAIN"] || "http://localhost:8005"
-    config.host = config.wcrs_renewals_url
+    config.host = config.wcrs_fo_link_domain
 
     # Fees
     config.renewal_charge = ENV["WCRS_RENEWAL_CHARGE"].to_i

--- a/spec/factories/forms/deregistration_confirmation_form.rb
+++ b/spec/factories/forms/deregistration_confirmation_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :deregistration_confirmation_form, class: "WasteCarriersEngine::DeregistrationConfirmationForm" do
+    trait :has_required_data do
+      initialize_with { new(create(:registration)) }
+    end
+  end
+end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -126,6 +126,10 @@ FactoryBot.define do
       metaData { build(:metaData, :has_required_data, status: :ACTIVE) }
     end
 
+    trait :is_inactive do
+      metaData { build(:metaData, :has_required_data, status: :INACTIVE) }
+    end
+
     trait :is_revoked do
       metaData { build(:metaData, :has_required_data, status: :REVOKED) }
     end

--- a/spec/forms/waste_carriers_engine/deregistration_confirmation_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/deregistration_confirmation_forms_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe DeregistrationConfirmationForm do
+    describe "#submit" do
+      let(:deregistration_confirmation_form) { build(:deregistration_confirmation_form) }
+
+      it "submits" do
+        expect(deregistration_confirmation_form.submit).to be true
+      end
+    end
+  end
+end

--- a/spec/models/waste_carriers_engine/concerns/can_have_deregistration_token_spec.rb
+++ b/spec/models/waste_carriers_engine/concerns/can_have_deregistration_token_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+class RegistrableTest
+  include WasteCarriersEngine::CanHaveDeregistrationToken
+  def active?; end
+end
+
+module WasteCarriersEngine
+  RSpec.describe "CanHaveDeregistrationToken" do
+
+    before { allow(registrable).to receive(:active?).and_return(true) }
+
+    subject(:registrable) { RegistrableTest.new }
+
+    describe "#generate_deregistration_token" do
+
+      context "with no existing deregistration token" do
+        it "creates a token" do
+          expect { registrable.generate_deregistration_token }.to change(registrable, :deregistration_token).from(nil)
+        end
+
+        it "sets the token timestamp" do
+          expect { registrable.generate_deregistration_token }.to change(registrable, :deregistration_token_created_at).from(nil)
+        end
+
+        it "returns the token" do
+          expect(registrable.generate_deregistration_token).to eq registrable.deregistration_token
+        end
+      end
+
+      context "with an existing deregistration token" do
+        before { Timecop.freeze(1.day.ago { registrable.generate_deregistration_token }) }
+
+        it "updates the token" do
+          expect { registrable.generate_deregistration_token }.to change(registrable, :deregistration_token)
+        end
+
+        it "updates the token timestamp" do
+          expect { registrable.generate_deregistration_token }.to change(registrable, :deregistration_token_created_at)
+        end
+      end
+    end
+
+    describe "#deregistration_token_valid?" do
+      let(:token_expiry_days) { 7 }
+
+      before do
+        allow(ENV).to receive(:fetch).with("WCRS_DEREGISTRATION_TOKEN_VALIDITY", any_args).and_return(token_expiry_days.to_s)
+      end
+
+      context "with no deregistration token" do
+        it "returns false" do
+          expect(registrable.deregistration_token_valid?).to be false
+        end
+      end
+
+      context "with a deregistration token" do
+        let(:token_created_at) { 1.day.ago }
+
+        before { Timecop.freeze(token_created_at) { registrable.generate_deregistration_token } }
+
+        context "with an expired deregistration token" do
+          let(:token_created_at) { 6.months.ago }
+
+          it "returns false" do
+            expect(registrable.deregistration_token_valid?).to be false
+          end
+        end
+
+        context "with a deregistration token expiring earlier today" do
+          let(:token_created_at) { token_expiry_days.days.ago - 1.hour }
+
+          it "returns false" do
+            expect(registrable.deregistration_token_valid?).to be false
+          end
+        end
+
+        context "with a deregistration token expiring later today" do
+          let(:token_created_at) { token_expiry_days.days.ago + 1.hour }
+
+          it "returns true" do
+            expect(registrable.deregistration_token_valid?).to be true
+          end
+        end
+
+        context "with a valid unexpired deregistration token" do
+          it "returns true" do
+            expect(registrable.deregistration_token_valid?).to be true
+          end
+        end
+
+        context "when the registration is not active" do
+          before { allow(registrable).to receive(:active?).and_return false }
+
+          it "returns false" do
+            expect(registrable.deregistration_token_valid?).to be false
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/waste_carriers_engine/deregisters_spec.rb
+++ b/spec/requests/waste_carriers_engine/deregisters_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "Deregisters" do
+    describe "GET deregister_path" do
+      context "when the deregistration token is valid" do
+        let(:active) { true }
+        let(:token_created_at) { 2.days.ago }
+        let(:registration) do
+          create(:registration, :has_required_data,
+                 (active ? :is_active : :is_inactive),
+                 deregistration_token: "X123",
+                 deregistration_token_created_at: token_created_at)
+        end
+
+        let(:magic_link_service) { instance_double(DeregistrationMagicLinkService) }
+        let(:email_service) { instance_double(Notify::DeregistrationEmailService) }
+
+        before do
+          allow(DeregistrationMagicLinkService).to receive(:new).and_return(magic_link_service)
+          allow(magic_link_service).to receive(:run)
+          allow(Notify::DeregistrationEmailService).to receive(:new).and_return(email_service)
+          allow(email_service).to receive(:run)
+
+          get deregister_path(token: registration.deregistration_token)
+        end
+
+        it "returns a 302 response" do
+          expect(response).to have_http_status(:found)
+        end
+
+        it "redirects to the deregistration start form" do
+          expect(response).to redirect_to(new_deregistration_confirmation_form_path(registration.deregistration_token))
+        end
+
+        context "when the token has expired" do
+          let(:token_created_at) { 3.months.ago }
+
+          it "returns a 422 response code" do
+            expect(response).to have_http_status(:unprocessable_entity)
+          end
+
+          it "renders the correct template" do
+            expect(response).to render_template(:deregistration_link_expired)
+          end
+
+          it "re-sends the deregistration email" do
+            expect(email_service).to have_received(:run)
+          end
+        end
+
+        context "when the registration has already been deactivated" do
+          let(:active) { false }
+
+          it "returns a 422 response code" do
+            expect(response).to have_http_status(:unprocessable_entity)
+          end
+
+          it "renders the correct template" do
+            expect(response).to render_template(:already_ceased)
+          end
+        end
+      end
+
+      context "when the deregistration token is invalid" do
+        before { get deregister_path(token: "FooBarBaz") }
+
+        it "returns a 404 response code" do
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it "renders the correct template" do
+          expect(response).to render_template(:invalid_deregistration_link)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/waste_carriers_engine/deregistration_completion_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/deregistration_completion_forms_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "DeregisterCompletionForms" do
+    let(:token) { "X123" }
+
+    before do
+      create(:registration, :has_required_data,
+             deregistration_token: token, deregistration_token_created_at: 3.days.ago)
+    end
+
+    it "loads the requested page" do
+      get new_deregistration_confirmation_form_path(token)
+
+      expect(response).to render_template("waste_carriers_engine/deregistration_confirmation_forms/new")
+    end
+  end
+end

--- a/spec/services/waste_carriers_engine/deregistration_magic_link_service_spec.rb
+++ b/spec/services/waste_carriers_engine/deregistration_magic_link_service_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe DeregistrationMagicLinkService do
+
+    subject(:run_service) { described_class.run(registration: registration) }
+
+    before { allow(Rails.configuration).to receive(:wcrs_fo_link_domain).and_return("http://example.com") }
+
+    RSpec.shared_examples "magic link with token" do
+      it "returns the magic link with the token" do
+        expect(run_service).to eq("http://example.com/fo/deregister/#{registration.deregistration_token}")
+      end
+    end
+
+    context "when the registration does not already have a deregistration token" do
+      let(:registration) { create(:registration, :has_required_data) }
+
+      it "generates a token" do
+        expect { run_service }.to change(registration, :deregistration_token).from(nil)
+      end
+
+      it_behaves_like "magic link with token"
+    end
+
+    context "when the registration already has a deregistration token" do
+      let(:registration) { create(:registration, :has_required_data, deregistration_token: "X123", deregistration_token_created_at: 1.month.ago) }
+
+      it "updates the token" do
+        expect { run_service }.to change(registration, :deregistration_token)
+      end
+
+      it_behaves_like "magic link with token"
+    end
+  end
+end

--- a/spec/services/waste_carriers_engine/govpay_payment_service_spec.rb
+++ b/spec/services/waste_carriers_engine/govpay_payment_service_spec.rb
@@ -32,7 +32,7 @@ module WasteCarriersEngine
 
     describe "prepare_for_payment" do
       context "when the request is valid" do
-        let(:root) { Rails.configuration.wcrs_renewals_url }
+        let(:root) { Rails.configuration.wcrs_fo_link_domain }
         let(:reg_id) { transient_registration.reg_identifier }
 
         it "returns a link" do

--- a/spec/services/waste_carriers_engine/notify/deregistration_email_service_spec.rb
+++ b/spec/services/waste_carriers_engine/notify/deregistration_email_service_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  module Notify
+
+    RSpec.describe DeregistrationEmailService do
+      describe ".run" do
+        let(:deregistration_link) { "https://a.deregistration.link" }
+        let(:expected_notify_options) do
+          {
+            email_address: registration.contact_email,
+            template_id: "0001e85a-7a09-4d6d-8988-ffb6fe4e2fd2",
+            personalisation: {
+              company_name: registration.company_name,
+              first_name: registration.first_name,
+              last_name: registration.last_name,
+              deregistration_link: deregistration_link
+            }
+          }
+        end
+        let(:magic_link_service) { instance_double(DeregistrationMagicLinkService) }
+        let(:notifications_client) { instance_double(Notifications::Client) }
+
+        before do
+          allow(DeregistrationMagicLinkService).to receive(:new).and_return(magic_link_service)
+          allow(magic_link_service).to receive(:run).with(registration:).and_return(deregistration_link)
+          allow(Notifications::Client).to receive(:new).and_return(notifications_client)
+          allow(notifications_client).to receive(:send_email)
+
+          described_class.run(registration: registration)
+        end
+
+        context "with a contact_email" do
+          let(:registration) { create(:registration, :has_required_data, :lower_tier) }
+
+          it "generates a link" do
+            expect(magic_link_service).to have_received(:run)
+          end
+
+          it "sends an email" do
+            expect(notifications_client).to have_received(:send_email).with(expected_notify_options)
+          end
+        end
+
+        context "with no contact_email" do
+          let(:registration) { create(:registration, :has_required_data, contact_email: nil) }
+
+          it "does not generate a link" do
+            expect(magic_link_service).not_to have_received(:run)
+          end
+
+          it "does not send an email" do
+            expect(notifications_client).not_to have_received(:send_email)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/waste_carriers_engine/worldpay_service_spec.rb
+++ b/spec/services/waste_carriers_engine/worldpay_service_spec.rb
@@ -91,7 +91,7 @@ module WasteCarriersEngine
 
     describe "prepare_for_payment" do
       context "when the request is valid" do
-        let(:root) { Rails.configuration.wcrs_renewals_url }
+        let(:root) { Rails.configuration.wcrs_fo_link_domain }
         let(:reg_id) { transient_registration.reg_identifier }
         let(:worldpay_url_service) { instance_double(WorldpayUrlService) }
 


### PR DESCRIPTION
This change adds:
- A model concern for deregistration links including expiry and validation logic
- A service to generate deregistration magic links
- A service to send the deregistration email including a fresh magic link
- A new route for processing a deregistration magic link and handling expired and invalid links
- A new route for the deregistration confirmation page for a valid magic link
- A placeholder page for the deregistration confirmation ("are you sure") page (https://eaflood.atlassian.net/browse/RUBY-2297)
- Link invalid, expired and already cancelled pages
https://eaflood.atlassian.net/browse/RUBY-2294