### PR TITLE
Use reg_identifier instead of token when redirecting

### DIFF
--- a/app/controllers/waste_carriers_engine/deregistration_confirmation_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/deregistration_confirmation_forms_controller.rb
@@ -21,13 +21,13 @@ module WasteCarriersEngine
 
     private
 
-    def find_or_initialize_transient_registration(token)
-      @transient_registration = DeregisteringRegistration.where(token: token).first
+    def find_or_initialize_transient_registration(reg_identifier)
+      @transient_registration = DeregisteringRegistration.where(reg_identifier: reg_identifier).first
       if @transient_registration.present?
         # If a DeregisteringRegistration already exists, reset its workflow state to the beginning
         @transient_registration.update_attributes(workflow_state: "deregistration_confirmation_form")
       else
-        @transient_registration = DeregisteringRegistration.new(token: token)
+        @transient_registration = DeregisteringRegistration.new(reg_identifier: reg_identifier)
       end
     end
 

--- a/app/models/waste_carriers_engine/deregistering_registration.rb
+++ b/app/models/waste_carriers_engine/deregistering_registration.rb
@@ -11,6 +11,8 @@ module WasteCarriersEngine
     field :temp_confirm_deregistration, type: String
 
     def registration
+      Rails.logger.warn "\n>>>>> getting registration, reg_identifier: \"#{reg_identifier}\""
+      Rails.logger.warn ">>>>> called from #{caller}\n"
       @_registration ||= Registration.find_by(reg_identifier: reg_identifier)
     end
 

--- a/spec/requests/waste_carriers_engine/deregistration_confirmation_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/deregistration_confirmation_forms_spec.rb
@@ -20,7 +20,7 @@ module WasteCarriersEngine
 
       subject(:submit_form) do
         post_form_with_params(:deregistration_confirmation_form,
-                              transient_registration.token,
+                              transient_registration.reg_identifier,
                               { temp_confirm_deregistration: selected_option })
       end
 


### PR DESCRIPTION
This fixes an issue where token was being used instead of reg_identifier when redirecting to the deregistration_confirmation form.
https://eaflood.atlassian.net/browse/RUBY-2297