### PR TITLE
Feature/dereg conf email

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -259,7 +259,7 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.5.8)
-    nokogiri (1.14.1)
+    nokogiri (1.14.2)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     notifications-ruby-client (5.4.0)

--- a/app/services/waste_carriers_engine/notify/deregistration_confirmation_email_service.rb
+++ b/app/services/waste_carriers_engine/notify/deregistration_confirmation_email_service.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  module Notify
+    class DeregistrationConfirmationEmailService < BaseSendEmailService
+      private
+
+      def notify_options
+        {
+          email_address: @registration.contact_email,
+          template_id: "012a872c-2e79-4efb-a84e-5ce2bf26d0bf",
+          personalisation: {
+            reg_identifier: @registration.reg_identifier
+          }
+        }
+      end
+    end
+  end
+end

--- a/app/services/waste_carriers_engine/registration_deactivation_service.rb
+++ b/app/services/waste_carriers_engine/registration_deactivation_service.rb
@@ -19,6 +19,8 @@ module WasteCarriersEngine
       @status = status
 
       set_metadata
+
+      send_confirmation_email unless WasteCarriersEngine.configuration.host_is_back_office?
     end
 
     private
@@ -40,6 +42,10 @@ module WasteCarriersEngine
       registration.metaData.dateDeactivated = Time.zone.now
 
       registration.save!
+    end
+
+    def send_confirmation_email
+      Notify::DeregistrationConfirmationEmailService.run(registration: registration)
     end
   end
 end

--- a/spec/forms/waste_carriers_engine/edit_complete_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/edit_complete_forms_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe EditCompleteForm do
-    pending "No examples currently defined"
+    it_behaves_like "a fixed final state",
+                    current_state: :edit_complete_form,
+                    factory: :edit_registration
   end
 end

--- a/spec/requests/waste_carriers_engine/deregistration_confirmation_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/deregistration_confirmation_forms_spec.rb
@@ -7,6 +7,7 @@ module WasteCarriersEngine
 
     let(:transient_registration) { create(:deregistering_registration, workflow_state: "deregistration_confirmation_form") }
     let(:original_registration) { transient_registration.registration }
+    let(:email_service) { instance_double(Notify::DeregistrationConfirmationEmailService) }
 
     describe "GET new_deregister_confirmation_form_path" do
       it "loads the form" do
@@ -17,6 +18,11 @@ module WasteCarriersEngine
     end
 
     describe "POST deregister_confirmation_forms_path" do
+
+      before do
+        allow(Notify::DeregistrationConfirmationEmailService).to receive(:new).and_return(email_service)
+        allow(email_service).to receive(:run)
+      end
 
       subject(:submit_form) do
         post_form_with_params(:deregistration_confirmation_form,

--- a/spec/services/waste_carriers_engine/notify/deregistration_confirmation_email_service_spec.rb
+++ b/spec/services/waste_carriers_engine/notify/deregistration_confirmation_email_service_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  module Notify
+
+    RSpec.describe DeregistrationConfirmationEmailService do
+      describe ".run" do
+        let(:expected_notify_options) do
+          {
+            email_address: registration.contact_email,
+            template_id: "012a872c-2e79-4efb-a84e-5ce2bf26d0bf",
+            personalisation: {
+              reg_identifier: registration.reg_identifier
+            }
+          }
+        end
+        let(:notifications_client) { instance_double(Notifications::Client) }
+
+        before do
+          allow(Notifications::Client).to receive(:new).and_return(notifications_client)
+          allow(notifications_client).to receive(:send_email)
+
+          described_class.run(registration: registration)
+        end
+
+        context "with a contact_email" do
+          let(:registration) { create(:registration, :has_required_data, :lower_tier) }
+
+          it "sends an email" do
+            expect(notifications_client).to have_received(:send_email).with(expected_notify_options)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/waste_carriers_engine/registration_deactivation_service_spec.rb
+++ b/spec/services/waste_carriers_engine/registration_deactivation_service_spec.rb
@@ -11,10 +11,17 @@ module WasteCarriersEngine
         create(:registration, :has_required_data, (registration_status == "ACTIVE" ? :is_active : :is_inactive))
       end
       let(:metadata) { registration.metaData }
+      let(:email_service) { instance_double(Notify::DeregistrationConfirmationEmailService) }
 
-      subject(:run_service) { described_class.run(registration: registration) }
+      before do
+        allow(Notify::DeregistrationConfirmationEmailService).to receive(:new).and_return(email_service)
+        allow(email_service).to receive(:run)
+      end
 
       context "when run in the front office" do
+
+        subject(:run_service) { described_class.run(registration: registration) }
+
         before { allow(WasteCarriersEngine.configuration).to receive(:host_is_back_office?).and_return(false) }
 
         it "saves the contact_email" do
@@ -40,6 +47,12 @@ module WasteCarriersEngine
           expect(metadata.dateDeactivated.to_time).to be_within(2.seconds).of(Time.zone.now)
         end
 
+        it "sends a confirmation email" do
+          run_service
+
+          expect(email_service).to have_received(:run).with(registration: registration)
+        end
+
         context "when the registration is already inactive" do
           let(:registration_status) { "INACTIVE" }
 
@@ -49,6 +62,28 @@ module WasteCarriersEngine
             expect { run_service }.not_to change(metadata, :revoked_reason)
             expect { run_service }.not_to change(metadata, :deactivated_by)
           end
+        end
+      end
+
+      context "when run in the back office" do
+        subject(:run_service) do
+          described_class.run(registration: registration, email: user_email, reason: reason, status: status)
+        end
+
+        let(:user_email) { Faker::Internet.email }
+        let(:reason) { Faker::Lorem.sentence }
+        let(:status) { "REVOKED" }
+
+        before { allow(WasteCarriersEngine.configuration).to receive(:host_is_back_office?).and_return(true) }
+
+        it "sets deactivation_route to BACK OFFICE" do
+          expect { run_service }.to change(metadata, :deactivation_route).to("BACK OFFICE")
+        end
+
+        it "does not send an email" do
+          run_service
+
+          expect(email_service).not_to have_received(:run)
         end
       end
     end


### PR DESCRIPTION
This change sends a confirmation email when a self-serve deregistration has been completed.
https://eaflood.atlassian.net/browse/RUBY-2318