### PR TITLE
edit registration copy error

### DIFF
--- a/app/models/waste_carriers_engine/edit_registration.rb
+++ b/app/models/waste_carriers_engine/edit_registration.rb
@@ -24,7 +24,8 @@ module WasteCarriersEngine
                                conviction_sign_offs
                                declaration
                                past_registrations
-                               copy_cards],
+                               copy_cards
+                               deregistration_token],
       copy_addresses: true,
       copy_people: true
     }.freeze

--- a/app/models/waste_carriers_engine/renewing_registration.rb
+++ b/app/models/waste_carriers_engine/renewing_registration.rb
@@ -31,7 +31,8 @@ module WasteCarriersEngine
                                firstName
                                lastName
                                phoneNumber
-                               contactEmail],
+                               contactEmail
+                               deregistration_token],
       remove_revoked_reason: true
     }.freeze
 


### PR DESCRIPTION
Exclude deregistration_token when copying transient registration attributes
https://eaflood.atlassian.net/browse/RUBY-2411