### PR TITLE
Add restore attributes to metaData

### DIFF
--- a/app/models/waste_carriers_engine/meta_data.rb
+++ b/app/models/waste_carriers_engine/meta_data.rb
@@ -18,6 +18,8 @@ module WasteCarriersEngine
     field :revokedReason, as: :revoked_reason,         type: String
     field :deactivatedBy, as: :deactivated_by,         type: String
     field :deactivationRoute, as: :deactivation_route, type: String
+    field :restoredReason, as: :restored_reason,       type: String
+    field :restoredBy, as: :restored_by,               type: String
     field :distance,                                   type: String
 
     validates :status, presence: true


### PR DESCRIPTION
This change adds `restored_reason` and `restored_by` attributes to the meta_data model. This is to support the back-office changes for restoring revoked/ceased registrations.
https://eaflood.atlassian.net/browse/RUBY-2410