### PR TITLE
add cert generation date to PDF certificate

### DIFF
--- a/app/presenters/waste_carriers_engine/certificate_presenter.rb
+++ b/app/presenters/waste_carriers_engine/certificate_presenter.rb
@@ -57,6 +57,10 @@ module WasteCarriersEngine
       displayable_address(registered_address)
     end
 
+    def certificate_creation_date
+      Date.today.strftime("%e %B %Y")
+    end
+
     private
 
     def expires_after_pluralized

--- a/app/views/waste_carriers_engine/pdfs/certificate.html.erb
+++ b/app/views/waste_carriers_engine/pdfs/certificate.html.erb
@@ -138,6 +138,8 @@
               </tbody>
             </table>
 
+            <p class="certificate_text"><%= t(".cert_created_date", date: @presenter.certificate_creation_date) %></p>
+
             <h2 class="certificate_title"><%=t ".heading2" %></h2>
 
             <!-- Renewal details section -->

--- a/config/locales/pdfs/certificate.en.yml
+++ b/config/locales/pdfs/certificate.en.yml
@@ -23,6 +23,7 @@ en:
         carrier_telephone_number: "Telephone number"
         registration_date: "Date of registration"
         expiry_date: "Expiry date of registration (unless revoked)"
+        cert_created_date: "This certificate was created on %{date}. These details are correct at the time of certificate generation."
         heading2: "Making changes to your registration"
         lower_renewal: "Your registration will last indefinitely so does not need to be renewed but you must update your registration details if they change, within 28 days of the change."
         upper_renewal: "Your registration will last %{expires_after_pluralized} and will need to be renewed after this period. If any of your details change, you must notify us within 28 days of the change."

--- a/spec/presenters/waste_carriers_engine/certificate_presenter_spec.rb
+++ b/spec/presenters/waste_carriers_engine/certificate_presenter_spec.rb
@@ -148,6 +148,12 @@ module WasteCarriersEngine
       end
     end
 
+    describe "#certificate_creation_date" do
+      it "returns today's date in the expected format" do
+        expect(presenter.certificate_creation_date).to eq Date.today.strftime("%e %B %Y")
+      end
+    end
+
     describe "#renewal_message" do
       context "when the registration is lower tier" do
         let(:tier) { "LOWER" }


### PR DESCRIPTION
This fix adds the certificate generation date to the PDF certificate.
https://eaflood.atlassian.net/browse/RUBY-2457