### PR TITLE
remove cert date from confirmation emails

### DIFF
--- a/app/services/waste_carriers_engine/notify/registration_confirmation_email_service.rb
+++ b/app/services/waste_carriers_engine/notify/registration_confirmation_email_service.rb
@@ -19,14 +19,13 @@ module WasteCarriersEngine
             phone_number: @registration.phone_number,
             registered_address: registered_address,
             date_registered: date_registered,
-            link_to_file: link_to_certificate,
-            certificate_creation_date: Date.today.strftime("%e %B %Y")
+            link_to_file: link_to_certificate
           }
         }
       end
 
       def template_id
-        @registration.upper_tier? ? "4526496c-1ae0-4dc6-a564-c7007b76c164" : "8d1fb650-93ef-4260-aa08-0b703bbe5609"
+        @registration.upper_tier? ? "fe1e4746-c940-4ace-b111-8be64ee53b35" : "889fa2f2-f70c-4b5a-bbc8-d94a8abd3990"
       end
 
       def registered_address

--- a/app/services/waste_carriers_engine/notify/renewal_confirmation_email_service.rb
+++ b/app/services/waste_carriers_engine/notify/renewal_confirmation_email_service.rb
@@ -10,7 +10,7 @@ module WasteCarriersEngine
       def notify_options
         {
           email_address: @registration.contact_email,
-          template_id: "ce2d9d55-6e16-45fe-83e2-4513a31ea864",
+          template_id: "6d54a9bc-9b62-4d93-a40a-d06d04ed58ca",
           personalisation: {
             reg_identifier: @registration.reg_identifier,
             registration_type: registration_type,
@@ -19,8 +19,7 @@ module WasteCarriersEngine
             phone_number: @registration.phone_number,
             registered_address: registered_address,
             date_activated: date_activated,
-            link_to_file: link_to_certificate,
-            certificate_creation_date: Date.today.strftime("%e %B %Y")
+            link_to_file: link_to_certificate
           }
         }
       end

--- a/spec/cassettes/notify_lower_tier_registration_confirmation_sends_an_email.yml
+++ b/spec/cassettes/notify_lower_tier_registration_confirmation_sends_an_email.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.notifications.service.gov.uk/v2/notifications/email
     body:
       encoding: UTF-8
-      string: '{"email_address":"foo@example.com","template_id":"8d1fb650-93ef-4260-aa08-0b703bbe5609","personalisation":{"reg_identifier":"CBDU2","registration_type":null,"first_name":"Jane","last_name":"Doe","phone_number":"03708
+      string: '{"email_address":"foo@example.com","template_id":"889fa2f2-f70c-4b5a-bbc8-d94a8abd3990","personalisation":{"reg_identifier":"CBDU2","registration_type":null,"first_name":"Jane","last_name":"Doe","phone_number":"03708
         506506","registered_address":"42\r\nFoo Gardens\r\nBaz City\r\nBS1 5AH","date_registered":"
         4 May 2023","link_to_file":"Hello World","certificate_creation_date":" 4 May
         2023"}}'
@@ -76,7 +76,7 @@ http_interactions:
         you have enquiries please email nccc-carrierbroker@environment-agency.gov.uk
         or contact the Environment Agency helpline: 03708 506506\r\n\r\nThis is an
         automated email, please do not reply","from_email":"waste.carriers.registration.service@notifications.service.gov.uk","subject":"Waste
-        Carrier Registration Complete"},"id":"718f0889-df49-4969-acda-78df540cb6b8","reference":null,"scheduled_for":null,"template":{"id":"8d1fb650-93ef-4260-aa08-0b703bbe5609","uri":"https://api.notifications.service.gov.uk/services/25cb6b94-8ce7-485b-918a-559f3b18f69c/templates/8d1fb650-93ef-4260-aa08-0b703bbe5609","version":1},"uri":"https://api.notifications.service.gov.uk/v2/notifications/718f0889-df49-4969-acda-78df540cb6b8"}
+        Carrier Registration Complete"},"id":"718f0889-df49-4969-acda-78df540cb6b8","reference":null,"scheduled_for":null,"template":{"id":"889fa2f2-f70c-4b5a-bbc8-d94a8abd3990","uri":"https://api.notifications.service.gov.uk/services/25cb6b94-8ce7-485b-918a-559f3b18f69c/templates/889fa2f2-f70c-4b5a-bbc8-d94a8abd3990","version":1},"uri":"https://api.notifications.service.gov.uk/v2/notifications/718f0889-df49-4969-acda-78df540cb6b8"}
 
         '
   recorded_at: Thu, 04 May 2023 10:00:08 GMT

--- a/spec/cassettes/notify_upper_tier_registration_confirmation_sends_an_email.yml
+++ b/spec/cassettes/notify_upper_tier_registration_confirmation_sends_an_email.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.notifications.service.gov.uk/v2/notifications/email
     body:
       encoding: UTF-8
-      string: '{"email_address":"foo@example.com","template_id":"4526496c-1ae0-4dc6-a564-c7007b76c164","personalisation":{"reg_identifier":"CBDU2","registration_type":"carrier,
+      string: '{"email_address":"foo@example.com","template_id":"fe1e4746-c940-4ace-b111-8be64ee53b35","personalisation":{"reg_identifier":"CBDU2","registration_type":"carrier,
         broker and dealer","first_name":"Jane","last_name":"Doe","phone_number":"03708
         506506","registered_address":"42\r\nFoo Gardens\r\nBaz City\r\nBS1 5AH","date_registered":"
         4 May 2023","link_to_file":"Hello World","certificate_creation_date":" 4 May
@@ -87,7 +87,7 @@ http_interactions:
         generation.\r\n\r\nIf you have enquiries please email nccc-carrierbroker@environment-agency.gov.uk
         or contact the Environment Agency helpline: 03708 506506\r\n\r\nThis is an
         automated email, please do not reply","from_email":"waste.carriers.registration.service@notifications.service.gov.uk","subject":"Waste
-        Carrier Registration Complete"},"id":"f21ee201-8e9f-4dd4-93ee-bcde38d6df26","reference":null,"scheduled_for":null,"template":{"id":"4526496c-1ae0-4dc6-a564-c7007b76c164","uri":"https://api.notifications.service.gov.uk/services/25cb6b94-8ce7-485b-918a-559f3b18f69c/templates/4526496c-1ae0-4dc6-a564-c7007b76c164","version":1},"uri":"https://api.notifications.service.gov.uk/v2/notifications/f21ee201-8e9f-4dd4-93ee-bcde38d6df26"}
+        Carrier Registration Complete"},"id":"f21ee201-8e9f-4dd4-93ee-bcde38d6df26","reference":null,"scheduled_for":null,"template":{"id":"fe1e4746-c940-4ace-b111-8be64ee53b35","uri":"https://api.notifications.service.gov.uk/services/25cb6b94-8ce7-485b-918a-559f3b18f69c/templates/fe1e4746-c940-4ace-b111-8be64ee53b35","version":1},"uri":"https://api.notifications.service.gov.uk/v2/notifications/f21ee201-8e9f-4dd4-93ee-bcde38d6df26"}
 
         '
   recorded_at: Thu, 04 May 2023 10:03:09 GMT

--- a/spec/cassettes/notify_upper_tier_renewal_confirmation_sends_an_email.yml
+++ b/spec/cassettes/notify_upper_tier_renewal_confirmation_sends_an_email.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.notifications.service.gov.uk/v2/notifications/email
     body:
       encoding: UTF-8
-      string: '{"email_address":"foo@example.com","template_id":"ce2d9d55-6e16-45fe-83e2-4513a31ea864","personalisation":{"reg_identifier":"CBDU29","registration_type":"carrier,
+      string: '{"email_address":"foo@example.com","template_id":"6d54a9bc-9b62-4d93-a40a-d06d04ed58ca","personalisation":{"reg_identifier":"CBDU29","registration_type":"carrier,
         broker and dealer","first_name":"Jane","last_name":"Doe","phone_number":"03708
         506506","registered_address":"42\r\nFoo Gardens\r\nBaz City\r\nBS1 5AH","date_activated":"
         4 May 2023","link_to_file":"My certificate","certificate_creation_date":"
@@ -83,7 +83,7 @@ http_interactions:
         you have enquiries please email nccc-carrierbroker@environment-agency.gov.uk
         or contact the Environment Agency helpline: 03708 506506\r\n\r\nThis is an
         automated email, please do not reply","from_email":"waste.carriers.registration.service@notifications.service.gov.uk","subject":"Your
-        waste carriers registration CBDU29 has been renewed"},"id":"c5280e54-c0b5-4c58-b5ea-22b111544613","reference":null,"scheduled_for":null,"template":{"id":"ce2d9d55-6e16-45fe-83e2-4513a31ea864","uri":"https://api.notifications.service.gov.uk/services/25cb6b94-8ce7-485b-918a-559f3b18f69c/templates/ce2d9d55-6e16-45fe-83e2-4513a31ea864","version":1},"uri":"https://api.notifications.service.gov.uk/v2/notifications/c5280e54-c0b5-4c58-b5ea-22b111544613"}
+        waste carriers registration CBDU29 has been renewed"},"id":"c5280e54-c0b5-4c58-b5ea-22b111544613","reference":null,"scheduled_for":null,"template":{"id":"6d54a9bc-9b62-4d93-a40a-d06d04ed58ca","uri":"https://api.notifications.service.gov.uk/services/25cb6b94-8ce7-485b-918a-559f3b18f69c/templates/6d54a9bc-9b62-4d93-a40a-d06d04ed58ca","version":1},"uri":"https://api.notifications.service.gov.uk/v2/notifications/c5280e54-c0b5-4c58-b5ea-22b111544613"}
 
         '
   recorded_at: Thu, 04 May 2023 10:38:47 GMT

--- a/spec/services/waste_carriers_engine/notify/registration_confirmation_email_service_spec.rb
+++ b/spec/services/waste_carriers_engine/notify/registration_confirmation_email_service_spec.rb
@@ -21,8 +21,7 @@ module WasteCarriersEngine
               phone_number: "03708 506506",
               registered_address: "42\r\nFoo Gardens\r\nBaz City\r\nBS1 5AH",
               date_registered: registration.metaData.date_registered.strftime("%e %B %Y"),
-              link_to_file: "Hello World",
-              certificate_creation_date: Date.today.strftime("%e %B %Y")
+              link_to_file: "Hello World"
             }
           }
         end
@@ -40,7 +39,7 @@ module WasteCarriersEngine
           end
 
           context "with a lower tier registration" do
-            let(:template_id) { "8d1fb650-93ef-4260-aa08-0b703bbe5609" }
+            let(:template_id) { "889fa2f2-f70c-4b5a-bbc8-d94a8abd3990" }
             let(:registration) { create(:registration, :has_required_data, :lower_tier) }
             let(:registration_type) { nil }
 
@@ -58,7 +57,7 @@ module WasteCarriersEngine
           end
 
           context "with an upper tier registration" do
-            let(:template_id) { "4526496c-1ae0-4dc6-a564-c7007b76c164" }
+            let(:template_id) { "fe1e4746-c940-4ace-b111-8be64ee53b35" }
             let(:registration) { create(:registration, :has_required_data, :already_renewed) }
             let(:registration_type) { "carrier, broker and dealer" }
 

--- a/spec/services/waste_carriers_engine/notify/renewal_confirmation_email_service_spec.rb
+++ b/spec/services/waste_carriers_engine/notify/renewal_confirmation_email_service_spec.rb
@@ -21,8 +21,7 @@ module WasteCarriersEngine
               phone_number: "03708 506506",
               registered_address: "42\r\nFoo Gardens\r\nBaz City\r\nBS1 5AH",
               date_activated: registration.metaData.date_activated.strftime("%e %B %Y"),
-              link_to_file: "My certificate",
-              certificate_creation_date: Date.today.strftime("%e %B %Y")
+              link_to_file: "My certificate"
             }
           }
         end
@@ -40,7 +39,7 @@ module WasteCarriersEngine
           end
 
           context "with an upper tier registration" do
-            let(:template_id) { "ce2d9d55-6e16-45fe-83e2-4513a31ea864" }
+            let(:template_id) { "6d54a9bc-9b62-4d93-a40a-d06d04ed58ca" }
             let(:registration) { create(:registration, :has_required_data, :already_renewed) }
             let(:registration_type) { "carrier, broker and dealer" }
 


### PR DESCRIPTION
This change reverts registration and renewal confirmation emails to not include the certificate creation date.
https://eaflood.atlassian.net/browse/RUBY-2457