### PR TITLE
Add support for govpay refund statuses

### DIFF
--- a/app/models/waste_carriers_engine/govpay/refund.rb
+++ b/app/models/waste_carriers_engine/govpay/refund.rb
@@ -6,6 +6,10 @@ module WasteCarriersEngine
       def success?
         status == "success"
       end
+
+      def submitted?
+        status == "submitted"
+      end
     end
   end
 end

--- a/spec/factories/payment.rb
+++ b/spec/factories/payment.rb
@@ -13,5 +13,10 @@ FactoryBot.define do
     trait :bank_transfer do
       payment_type { "BANKTRANSFER" }
     end
+
+    trait :govpay_refund do
+      payment_type { WasteCarriersEngine::Payment::REFUND }
+      govpay_id { SecureRandom.hex(22) }
+    end
   end
 end

--- a/spec/fixtures/files/govpay/get_refund_response_success.json
+++ b/spec/fixtures/files/govpay/get_refund_response_success.json
@@ -2,5 +2,5 @@
   "amount": 2000,
   "created_date": "2019-09-19T16:53:03.213Z",
   "refund_id": "j6se0f2o427g28g8yg3u3i",
-  "status": "success"
+  "status": "submitted"
 }

--- a/spec/services/waste_carriers_engine/govpay/objects/refund_spec.rb
+++ b/spec/services/waste_carriers_engine/govpay/objects/refund_spec.rb
@@ -9,13 +9,15 @@ module WasteCarriersEngine
     let(:params) { JSON.parse(file_fixture("govpay/get_refund_response_success.json").read) }
 
     describe "#status" do
-      it { expect(refund.status).to eq "success" }
-      it { expect(refund.success?).to be true }
+      it { expect(refund.status).to eq "submitted" }
+      it { expect(refund.success?).to be false }
+      it { expect(refund.submitted?).to be true }
 
       context "with non-successful refund" do
-        let(:params) { super().merge(status: "submitted") }
+        let(:params) { super().merge(status: "error") }
 
         it { expect(refund.success?).to be false }
+        it { expect(refund.submitted?).to be false }
       end
     end
   end


### PR DESCRIPTION
This change adds support for govpay refunds `submitted` status and fixes an issue with finance_details balance computation.
https://eaflood.atlassian.net/browse/RUBY-2433