### PR TITLE
Payment confirmation content fixes

### DIFF
--- a/app/views/waste_carriers_engine/confirm_bank_transfer_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/confirm_bank_transfer_forms/new.html.erb
@@ -18,11 +18,6 @@
         </p>
       <% end %>
 
-      <p class="govuk-body">
-        <%= link_to(t(".link_text"),
-                    go_back_forms_path(@confirm_bank_transfer_form.token)) %>
-      </p>
-
       <%= f.govuk_submit t(".next_button") %>
     <% end %>
   </div>

--- a/config/locales/forms/confirm_bank_transfer_forms/en.yml
+++ b/config/locales/forms/confirm_bank_transfer_forms/en.yml
@@ -8,5 +8,4 @@ en:
           instructions: "In order to pay by bank transfer, you will need to follow the instructions on the next screen and email us to confirm payment. This will take approximately 5 working days."
           instant_confirmation: "We do not send a payment confirmation if you pay by bank transfer."
           payment_confirmation: "In most cases we can provide instant confirmation if you pay by card."
-        link_text: "Go back to pay by credit or debit card instead"
         next_button: "Confirm you’ll pay by bank transfer"

--- a/config/locales/forms/other_businesses_forms/en.yml
+++ b/config/locales/forms/other_businesses_forms/en.yml
@@ -1,13 +1,9 @@
 en:
   waste_carriers_engine:
-    payment_method_confirmation_forms:
+    other_businesses_forms:
       new:
-        title: Confirm payment method
-        heading: Are you sure you want to pay by %{payment_method}?
-        paragraph: If you don't have your payment details to hand you can return to this page later. Your answers are saved for 30 days.
-        payment_method:
-          card: credit or debit card
-          bank_transfer: bank transfer
+        title: Do you ever deal with waste from other businesses or households?
+        heading: Do you ever deal with waste from other businesses or households?
         options:
           "yes": "Yes"
           "no": "No"
@@ -16,10 +12,11 @@ en:
   activemodel:
     errors:
       models:
-        waste_carriers_engine/payment_method_confirmation_form:
+        waste_carriers_engine/other_businesses_form:
           attributes:
-            temp_confirm_payment_method:
-              inclusion: Select yes or no
+            other_businesses:
+              inclusion: "Select yes or no"
             reg_identifier:
-              invalid_format: The registration ID is not in a valid format
-              no_registration: There is no registration matching this ID
+              invalid_format: "The registration ID is not in a valid format"
+              no_registration: "There is no registration matching this ID"
+              renewal_in_progress: "This renewal is already in progress"

--- a/config/locales/forms/payment_method_confirmation_forms/en.yml
+++ b/config/locales/forms/payment_method_confirmation_forms/en.yml
@@ -1,9 +1,13 @@
 en:
   waste_carriers_engine:
-    other_businesses_forms:
+    payment_method_confirmation_forms:
       new:
-        title: Do you ever deal with waste from other businesses or households?
-        heading: Do you ever deal with waste from other businesses or households?
+        title: Confirm payment method
+        heading: Are you sure you want to pay by %{payment_method}?
+        paragraph: If you don't have your payment details to hand you can return to this page later. Your answers are saved for 30 days.
+        payment_method:
+          card: credit or debit card
+          bank_transfer: bank transfer
         options:
           "yes": "Yes"
           "no": "No"
@@ -12,11 +16,10 @@ en:
   activemodel:
     errors:
       models:
-        waste_carriers_engine/other_businesses_form:
+        waste_carriers_engine/payment_method_confirmation_form:
           attributes:
-            other_businesses:
-              inclusion: "Select yes or no"
+            temp_confirm_payment_method:
+              inclusion: Select yes or no
             reg_identifier:
-              invalid_format: "The registration ID is not in a valid format"
-              no_registration: "There is no registration matching this ID"
-              renewal_in_progress: "This renewal is already in progress"
+              invalid_format: The registration ID is not in a valid format
+              no_registration: There is no registration matching this ID

--- a/config/locales/forms/payment_summary_forms/en.yml
+++ b/config/locales/forms/payment_summary_forms/en.yml
@@ -24,7 +24,7 @@ en:
           subheading: Where should the card payment confirmation be sent?
           paragraph_1: WorldPay will send a card payment confirmation to this address, once the payment has been processed.
           label: Email address
-        next_button: Proceed to payment
+        next_button: Continue
   activemodel:
     errors:
       models:


### PR DESCRIPTION
Fix payment-summary Continue button text and remove link from confirm-bank-transfer page.
https://eaflood.atlassian.net/browse/RUBY-2463