### PR TITLE
DO NOT MERGE - Fix/area service

### DIFF
--- a/app/services/waste_carriers_engine/assign_site_details_service.rb
+++ b/app/services/waste_carriers_engine/assign_site_details_service.rb
@@ -2,12 +2,13 @@
 
 module WasteCarriersEngine
   class AssignSiteDetailsService < BaseService
-    attr_reader :address
+    attr_reader :address, :registration
 
     delegate :postcode, :area, to: :address
 
-    def run(address:)
-      @address = address
+    def run(registration_id:)
+      @registration = Registration.find(registration_id)
+      @address = @registration.company_address
 
       assign_area_from_postcode
     end
@@ -18,14 +19,14 @@ module WasteCarriersEngine
       return if area.present?
       return unless postcode.present?
 
-      if address.registration.overseas?
-        address.area = "Outside England"
+      if registration.overseas?
+        address.update(area: "Outside England")
         return
       end
 
       x, y = DetermineEastingAndNorthingService.run(postcode: postcode).values
 
-      address.area = DetermineAreaService.run(easting: x, northing: y)
+      address.update(area: DetermineAreaService.run(easting: x, northing: y))
     end
   end
 end

--- a/app/services/waste_carriers_engine/determine_area_service.rb
+++ b/app/services/waste_carriers_engine/determine_area_service.rb
@@ -11,7 +11,7 @@ module WasteCarriersEngine
       return "Not found" if response.error.instance_of?(DefraRuby::Area::NoMatchError)
 
       handle_error(response.error, easting, northing)
-      "Not found"
+      nil
     end
 
     private

--- a/spec/services/waste_carriers_engine/assign_site_details_service_spec.rb
+++ b/spec/services/waste_carriers_engine/assign_site_details_service_spec.rb
@@ -25,11 +25,22 @@ module WasteCarriersEngine
         before do
           create(:address, :has_required_data, address_type: "REGISTERED", registration: registration)
           allow(DetermineEastingAndNorthingService).to receive(:run).and_return(easting: x, northing: y)
-          allow(DetermineAreaService).to receive(:run).and_return(area)
         end
 
-        it "assigns area" do
-          expect { run_service }.to change { registration.reload.company_address.area }.to(area)
+        context "when the service returns an area" do
+          before { allow(DetermineAreaService).to receive(:run).and_return(area) }
+
+          it "assigns area" do
+            expect { run_service }.to change { registration.reload.company_address.area }.to(area)
+          end
+        end
+
+        context "when the service does not return an area" do
+          before { allow(DetermineAreaService).to receive(:run).and_return(nil) }
+
+          it "does not assign area" do
+            expect { run_service }.not_to change { registration.reload.company_address.area }
+          end
         end
       end
 

--- a/spec/services/waste_carriers_engine/assign_site_details_service_spec.rb
+++ b/spec/services/waste_carriers_engine/assign_site_details_service_spec.rb
@@ -8,59 +8,64 @@ module WasteCarriersEngine
       let(:x) { 123_456 }
       let(:y) { 654_321 }
       let(:area) { "Area Name" }
-      let(:registration) { build(:registration, :has_required_data) }
+      let(:registration) { create(:registration, :has_required_data) }
+
+      subject(:run_service) { described_class.run(registration_id: registration.id) }
+
+      before do
+        # We will replace the factory-generated company address with one of our own for test purposes
+        registration.addresses.delete_if { |address| address.address_type == "REGISTERED" }
+
+        allow(DetermineEastingAndNorthingService).to receive(:run)
+        allow(DetermineAreaService).to receive(:run)
+      end
 
       context "when address has a postcode and area is not present" do
-        let(:address) { build(:address, :has_required_data, registration: registration) }
 
         before do
+          create(:address, :has_required_data, address_type: "REGISTERED", registration: registration)
           allow(DetermineEastingAndNorthingService).to receive(:run).and_return(easting: x, northing: y)
           allow(DetermineAreaService).to receive(:run).and_return(area)
         end
 
         it "assigns area" do
-          described_class.run(address: address)
-          expect(address.area).to eq(area)
+          expect { run_service }.to change { registration.reload.company_address.area }.to(area)
         end
       end
 
       context "when address has an area" do
-        let(:address) { build(:address, :has_required_data, area: area, registration: registration) }
+        before { create(:address, :has_required_data, address_type: "REGISTERED", area: area, registration: registration) }
 
         it "does not change the area" do
-          allow(DetermineEastingAndNorthingService).to receive(:run)
-          allow(DetermineAreaService).to receive(:run)
-
-          described_class.run(address: address)
+          expect { run_service }.not_to change { registration.reload.company_address.area }
 
           expect(DetermineEastingAndNorthingService).not_to have_received(:run)
           expect(DetermineAreaService).not_to have_received(:run)
-          expect(address.area).to eq(area)
         end
       end
 
       context "when address does not have a postcode" do
-        let(:address) { build(:address, :has_required_data, postcode: nil, registration: registration) }
+        before { create(:address, :has_required_data, address_type: "REGISTERED", postcode: nil, registration: registration) }
 
         it "does not assign area" do
-          allow(DetermineEastingAndNorthingService).to receive(:run)
-          allow(DetermineAreaService).to receive(:run)
-
-          described_class.run(address: address)
+          expect { run_service }.not_to change { registration.reload.company_address.area }
 
           expect(DetermineEastingAndNorthingService).not_to have_received(:run)
           expect(DetermineAreaService).not_to have_received(:run)
-          expect(address.area).to be_nil
         end
       end
 
       context "when address has an overseas registration" do
-        let(:overseas_registration) { build(:registration, :has_required_overseas_data) }
-        let(:address) { build(:address, :has_required_data, registration: overseas_registration) }
+        let(:registration) { create(:registration, :has_required_overseas_data) }
+
+        before do
+          # Replace the factory-generated registered address with one of our own for test purposes
+          registration.addresses.delete_if { |address| address.address_type == "REGISTERED" }
+          create(:address, :has_required_data, address_type: "REGISTERED", registration: registration)
+        end
 
         it "assigns area as 'Outside England'" do
-          described_class.run(address: address)
-          expect(address.area).to eq("Outside England")
+          expect { run_service }.to change { registration.reload.company_address.area }.to("Outside England")
         end
       end
     end

--- a/spec/services/waste_carriers_engine/determine_area_service_spec.rb
+++ b/spec/services/waste_carriers_engine/determine_area_service_spec.rb
@@ -45,8 +45,8 @@ module WasteCarriersEngine
         context "with a failure" do
           let(:response) { instance_double(DefraRuby::Area::Response, successful?: false, error: StandardError.new) }
 
-          it "returns 'Not found'" do
-            expect(described_class.run(coordinates)).to eq "Not found"
+          it "returns nil" do
+            expect(described_class.run(coordinates)).to be_nil
           end
 
           it "uses Airbrake to notify Errbit of the error" do


### PR DESCRIPTION
This change leaves EA area as nil if the API call fails, instead of setting it to "Not found". This is so that the address can be retried on a subsequent run of the service.
https://eaflood.atlassian.net/browse/RUBY-2558