### PR TITLE
Add renewal-stop form

### DIFF
--- a/app/controllers/waste_carriers_engine/renewal_start_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/renewal_start_forms_controller.rb
@@ -5,6 +5,11 @@ module WasteCarriersEngine
     prepend_before_action :authenticate_user!, if: :should_authenticate_user?
 
     def new
+      if !@transient_registration.from_magic_link && WasteCarriersEngine::FeatureToggle.active?(:block_front_end_logins)
+        redirect_to "/"
+        return
+      end
+
       # If the renewing_registration has an invalid workflow_state, reset it to the first form after renewal_start_form
       unless @transient_registration.may_next?
         @transient_registration.update_attributes(workflow_state: "location_form")
@@ -26,6 +31,8 @@ module WasteCarriersEngine
     end
 
     def should_authenticate_user?
+      return false if WasteCarriersEngine::FeatureToggle.active?(:block_front_end_logins)
+
       find_or_initialize_transient_registration(params[:token])
 
       return false if @transient_registration.from_magic_link

--- a/app/controllers/waste_carriers_engine/renewal_stop_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/renewal_stop_forms_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class RenewalStopFormsController < ::WasteCarriersEngine::FormsController
+    include UnsubmittableForm
+
+    def new
+      super(RenewalStopForm, "renewal_stop_form")
+    end
+  end
+end

--- a/app/forms/waste_carriers_engine/renewal_stop_form.rb
+++ b/app/forms/waste_carriers_engine/renewal_stop_form.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class RenewalStopForm < ::WasteCarriersEngine::BaseForm
+    include CannotSubmit
+  end
+end

--- a/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_carriers_engine/can_use_new_registration_workflow.rb
@@ -20,6 +20,7 @@ module WasteCarriersEngine
 
         # Renew
         state :renew_registration_form
+        state :renewal_stop_form
 
         # Location
         state :location_form
@@ -79,6 +80,9 @@ module WasteCarriersEngine
           # Start
           transitions from: :start_form, to: :location_form,
                       unless: :should_renew?
+
+          transitions from: :start_form, to: :renewal_stop_form,
+                      if: :logins_blocked?
 
           transitions from: :start_form, to: :renew_registration_form,
                       if: :should_renew?
@@ -409,6 +413,10 @@ module WasteCarriersEngine
 
       def use_trading_name?
         temp_use_trading_name == "yes"
+      end
+
+      def logins_blocked?
+        WasteCarriersEngine::FeatureToggle.active?(:block_front_end_logins)
       end
     end
     # rubocop:enable Metrics/BlockLength

--- a/app/views/waste_carriers_engine/renewal_stop_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/renewal_stop_forms/new.html.erb
@@ -1,0 +1,6 @@
+<%= render("waste_carriers_engine/shared/back", token: @renewal_stop_form.token) %>
+
+<div class="govuk-body">
+  <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+  <p><%= t(".paragraph") %></p>
+</div>

--- a/config/locales/forms/renewal_stop_forms/en.yml
+++ b/config/locales/forms/renewal_stop_forms/en.yml
@@ -1,0 +1,7 @@
+en:
+  waste_carriers_engine:
+    renewal_stop_forms:
+      new:
+        title: We will send you an email when it is time for you to renew
+        heading: We will send you an email when it is time for you to renew
+        paragraph: If you need to speak to an advisor contact the helpline on 03708 506 506

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,11 @@ WasteCarriersEngine::Engine.routes.draw do
               path: "renew-registration",
               path_names: { new: "" }
 
+    resources :renewal_stop_forms,
+              only: %i[new],
+              path: "renewal-stop",
+              path_names: { new: "" }
+
     resources :your_tier_forms,
               only: %i[new create],
               path: "your-tier",

--- a/spec/factories/forms/renewal_stop_form.rb
+++ b/spec/factories/forms/renewal_stop_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :renewal_stop_form, class: "WasteCarriersEngine::RenewalStopForm" do
+    trait :has_required_data do
+      initialize_with { new(create(:renewing_registration, :has_required_data, workflow_state: "renewal_stop_form")) }
+    end
+  end
+end

--- a/spec/forms/waste_carriers_engine/renewal_stop_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/renewal_stop_forms_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe RenewalStopForm do
+    describe "#workflow_state" do
+      it_behaves_like "a fixed final state",
+                      current_state: :renewal_stop_form,
+                      factory: :renewing_registration
+    end
+  end
+end

--- a/spec/requests/waste_carriers_engine/renewal_stop_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/renewal_stop_forms_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "RenewalStopForms" do
+    include_examples "GET flexible form", "renewal_stop_form"
+  end
+end

--- a/spec/requests/waste_carriers_engine/start_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/start_forms_spec.rb
@@ -60,14 +60,28 @@ module WasteCarriersEngine
       context "when the start option is `renew`" do
         let(:params) { { start_form: { temp_start_option: "renew" }, token: new_registration.token } }
 
-        it "updates the transient registration workflow and redirects to the renew_registration_form with a 302 status code" do
-          post new_start_form_path(params)
+        context "when the :block_front_end_logins feature toggle is inactive" do
+          before { allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:block_front_end_logins).and_return false }
 
-          new_registration.reload
+          it "updates the transient registration workflow and redirects to the renew_registration_form with a 302 status code" do
+            post new_start_form_path(params)
 
-          expect(response).to redirect_to(new_renew_registration_form_path(new_registration.token))
-          expect(response).to have_http_status(:found)
-          expect(new_registration.workflow_state).to eq("renew_registration_form")
+            new_registration.reload
+
+            expect(response).to redirect_to(new_renew_registration_form_path(new_registration.token))
+            expect(response).to have_http_status(:found)
+            expect(new_registration.workflow_state).to eq("renew_registration_form")
+          end
+        end
+
+        context "when the :block_front_end_logins feature toggle is active" do
+          before { allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:block_front_end_logins).and_return true }
+
+          it "redirects to the renewal-stop page" do
+            post new_start_form_path(params)
+
+            expect(response).to redirect_to new_renewal_stop_form_path(new_registration.token)
+          end
         end
       end
 


### PR DESCRIPTION
This change prevents progressing to the renewal request journey if the `block_front_end_logins` feature toggle is enabled.
https://eaflood.atlassian.net/browse/RUBY-2499