### PR TITLE
Feature/ruby 2612 fb tech debt unit tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem "defra_ruby_template"
 # Use MongoDB as the database
 gem "mongoid", "~> 7.5"
 # Implement document-level locking
-gem "mongoid-locker", "~> 2.0.0"
+gem "mongoid-locker", "~> 2.0.2"
 
 gem "mongo_session_store"
 # Use CanCanCan for user roles and permissions

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ PATH
       jbuilder (~> 2.11)
       mongo_session_store
       mongoid
-      mongoid-locker (= 2.0.0)
+      mongoid-locker (= 2.0.2)
       nokogiri
       notifications-ruby-client
       rails (>= 6.1.4)
@@ -254,8 +254,8 @@ GEM
       activemodel (>= 5.1, < 7.1, != 7.0.0)
       mongo (>= 2.10.5, < 3.0.0)
       ruby2_keywords (~> 0.0.5)
-    mongoid-locker (2.0.0)
-      mongoid (>= 5.0, < 8)
+    mongoid-locker (2.0.2)
+      mongoid (>= 5.0, < 9)
     multi_json (1.15.0)
     multipart-post (2.1.1)
     net-imap (0.3.4)
@@ -478,7 +478,7 @@ DEPENDENCIES
   matrix
   mongo_session_store
   mongoid (~> 7.5)
-  mongoid-locker (~> 2.0.0)
+  mongoid-locker (~> 2.0.2)
   net-smtp
   pry-byebug
   rails-controller-testing

--- a/app/models/waste_carriers_engine/order_copy_cards_registration.rb
+++ b/app/models/waste_carriers_engine/order_copy_cards_registration.rb
@@ -2,12 +2,13 @@
 
 module WasteCarriersEngine
   class OrderCopyCardsRegistration < TransientRegistration
+    # due to issues with mongoid-locker v2.0.2, delegate has to be added to the top of the class
+    delegate :contact_address, :contact_email, :registered_address, to: :registration
+
     include CanUseOrderCopyCardsWorkflow
     include CanUseLock
 
     validates :reg_identifier, "waste_carriers_engine/reg_identifier": true
-
-    delegate :contact_address, :contact_email, :registered_address, to: :registration
 
     def registration
       @_registration ||= Registration.find_by(reg_identifier: reg_identifier)

--- a/spec/factories/order.rb
+++ b/spec/factories/order.rb
@@ -4,8 +4,10 @@ FactoryBot.define do
   factory :order, class: "WasteCarriersEngine::Order" do
     trait :has_required_data do
       order_items do
-        [WasteCarriersEngine::OrderItem.new_renewal_item,
-         WasteCarriersEngine::OrderItem.new_copy_cards_item(1)]
+        [
+          build(:order_item, :new_renewal_item),
+          build(:order_item, :new_copy_cards_item)
+        ]
       end
       total_amount { order_items.sum { |item| item[:amount] } }
     end
@@ -20,7 +22,7 @@ FactoryBot.define do
       date_created { Time.now }
 
       order_items do
-        [WasteCarriersEngine::OrderItem.new_copy_cards_item(1)]
+        [build(:order_item, :new_copy_cards_item)]
       end
       total_amount { order_items.sum { |item| item[:amount] } }
     end
@@ -29,7 +31,7 @@ FactoryBot.define do
       date_created { Time.now }
 
       order_items do
-        [WasteCarriersEngine::OrderItem.new_type_change_item]
+        [build(:order_item, :new_type_change_item)]
       end
       total_amount { order_items.sum { |item| item[:amount] } }
     end

--- a/spec/factories/order_item.rb
+++ b/spec/factories/order_item.rb
@@ -2,6 +2,29 @@
 
 FactoryBot.define do
   factory :order_item, class: "WasteCarriersEngine::OrderItem" do
-    # Default factory implementation is sufficient
+
+    trait :new_renewal_item do
+      currency { "GBP" }
+      amount { Rails.configuration.renewal_charge }
+      description { "renewal of registration" }
+      type { "RENEW" }
+      quantity { 1 }
+    end
+
+    trait :new_copy_cards_item do
+      currency { "GBP" }
+      amount { Rails.configuration.card_charge }
+      description { "1 registration card" }
+      type { "COPY_CARDS" }
+      quantity { 1 }
+    end
+
+    trait :new_type_change_item do
+      currency { "GBP" }
+      amount { Rails.configuration.type_change_charge }
+      description { "changing carrier type" }
+      type { "EDIT" }
+      quantity { 1 }
+    end
   end
 end

--- a/waste_carriers_engine.gemspec
+++ b/waste_carriers_engine.gemspec
@@ -24,8 +24,7 @@ Gem::Specification.new do |s|
   # Use MongoDB as the database
   s.add_dependency "mongoid"
   # Implement document-level locking
-  # Note v2.0.1 interferes with the delegate method
-  s.add_dependency "mongoid-locker", "2.0.0"
+  s.add_dependency "mongoid-locker", "2.0.2"
 
   s.add_dependency "mongo_session_store"
   # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks


### PR DESCRIPTION
1. Performance improvements by refactoring tests to use factories instead of real objects
2. Bump mongoid-locker dependency version from version 2.0.0 to 2.0.2 (required for upgrading mongoid gem in the future)
