### PR TITLE
Allow wicked_pdf to use local file storage

### DIFF
--- a/app/services/concerns/waste_carriers_engine/can_attach_certificate.rb
+++ b/app/services/concerns/waste_carriers_engine/can_attach_certificate.rb
@@ -19,7 +19,9 @@ module WasteCarriersEngine
           template: "waste_carriers_engine/pdfs/certificate",
           encoding: "UTF-8",
           layout: false,
-          locals: { presenter: certificate_presenter }
+          locals: { presenter: certificate_presenter },
+          enable_local_file_access: true,
+          allow: [WasteCarriersEngine::Engine.root.join("app", "assets", "images", "environment_agency_logo.png").to_s]
         )
       end
     end


### PR DESCRIPTION
The EA logo was missing from certificates because wicked_pdf was not configured to explicitly allow use of local storage. This is necessary as the wicked_pdf gem relies on an application external to the Rails application to generate the PDFs.
https://eaflood.atlassian.net/browse/RUBY-2684