### PR TITLE
Align with govpay gem error handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,7 +152,7 @@ GEM
       notifications-ruby-client
       rails
       sprockets-rails
-    defra_ruby_govpay (0.2.2)
+    defra_ruby_govpay (0.2.3)
       rest-client (~> 2.1)
     defra_ruby_style (0.3.0)
       rubocop (>= 1.0, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,7 +152,7 @@ GEM
       notifications-ruby-client
       rails
       sprockets-rails
-    defra_ruby_govpay (0.2.1)
+    defra_ruby_govpay (0.2.2)
       rest-client (~> 2.1)
     defra_ruby_style (0.3.0)
       rubocop (>= 1.0, < 2.0)

--- a/spec/services/waste_carriers_engine/govpay_payment_details_service_spec.rb
+++ b/spec/services/waste_carriers_engine/govpay_payment_details_service_spec.rb
@@ -152,10 +152,7 @@ module WasteCarriersEngine
           it "notifies Airbrake" do
             service.govpay_payment_status
           rescue DefraRubyGovpay::GovpayApiError
-            expect(Airbrake).to have_received(:notify).with(DefraRubyGovpay::GovpayApiError,
-                                                            hash_including(
-                                                              message: "Error sending request to govpay (get /payments/a-valid-govpay-payment-id, params: ): 500 Internal Server Error"
-                                                            ))
+            expect(Airbrake).to have_received(:notify).with(DefraRubyGovpay::GovpayApiError, anything)
           end
         end
       end


### PR DESCRIPTION
Bump govpay gem version and allow for empty govpay error response body
https://eaflood.atlassian.net/browse/RUBY-2769