### PR TITLE
fix/RUBY-2762_legacy_account_email_values

### DIFF
--- a/app/models/waste_carriers_engine/past_registration.rb
+++ b/app/models/waste_carriers_engine/past_registration.rb
@@ -21,6 +21,7 @@ module WasteCarriersEngine
 
       attributes = registration.attributes.except(
         "_id",
+        "accountEmail",
         "past_registrations",
         "locking_name",
         "locked_at",

--- a/app/models/waste_carriers_engine/renewing_registration.rb
+++ b/app/models/waste_carriers_engine/renewing_registration.rb
@@ -14,26 +14,27 @@ module WasteCarriersEngine
 
     COPY_DATA_OPTIONS = {
       ignorable_attributes: %w[_id
-                               otherBusinesses
-                               renew_token
-                               isMainService
+                               accountEmail
                                constructionWaste
-                               onlyAMF
-                               key_people
-                               financeDetails
-                               declaredConvictions
+                               contactEmail
                                conviction_search_result
                                conviction_sign_offs
-                               declaration
-                               past_registrations
                                copy_cards
-                               receipt_email
-                               firstName
-                               lastName
-                               phoneNumber
-                               contactEmail
+                               declaration
+                               declaredConvictions
                                deregistration_token
-                               deregistration_token_created_at],
+                               deregistration_token_created_at
+                               isMainService
+                               firstName
+                               financeDetails
+                               key_people
+                               lastName
+                               onlyAMF
+                               otherBusinesses
+                               past_registrations
+                               phoneNumber
+                               receipt_email
+                               renew_token],
       remove_revoked_reason: true
     }.freeze
 

--- a/spec/models/waste_carriers_engine/past_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/past_registration_spec.rb
@@ -27,6 +27,22 @@ module WasteCarriersEngine
         expect(past_registration.registered_address).to eq(registration.registered_address)
       end
 
+      context "with non-copyable attribute values" do
+        # Non-copyable attributes include legacy attributes which may have values in the DB
+        # but no accessors in the model, so we need to populate test values below the mongoid layer.
+        before do
+          WasteCarriersEngine::Registration.collection.update_one(
+            { regIdentifier: registration.regIdentifier },
+            { "$set": { accountEmail: "foo@example.com" } }
+          )
+          registration.reload
+        end
+
+        it "builds without error" do
+          expect { described_class.build_past_registration(registration) }.not_to raise_error
+        end
+      end
+
       context "when :edit is given as an argument" do
         let(:past_registration) { described_class.build_past_registration(registration, :edit) }
 

--- a/spec/models/waste_carriers_engine/renewing_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_spec.rb
@@ -83,6 +83,24 @@ module WasteCarriersEngine
           expect(renewing_registration.contact_email).to be_nil
         end
       end
+
+      context "with non-copyable attribute values" do
+        let(:registration) { create(:registration, :has_required_data) }
+
+        # Non-copyable attributes include legacy attributes which may have values in the DB
+        # but no accessors in the model, so we need to populate test values below the mongoid layer.
+        before do
+          WasteCarriersEngine::Registration.collection.update_one(
+            { regIdentifier: registration.regIdentifier },
+            { "$set": { accountEmail: "foo@example.com" } }
+          )
+          registration.reload
+        end
+
+        it "builds without error" do
+          expect { described_class.new(reg_identifier: registration.reg_identifier) }.not_to raise_error
+        end
+      end
     end
 
     describe "status" do


### PR DESCRIPTION
Cope with legacy accountEmail values when copying attributes from renewing_registrations and past_registrations.
https://eaflood.atlassian.net/browse/RUBY-2762