### PR TITLE
Fix/ruby 2805 postcode validation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       defra_ruby_area (~> 2.2)
       defra_ruby_email (~> 1.3.0)
       defra_ruby_govpay
-      defra_ruby_validators (~> 2.5.1)
+      defra_ruby_validators (~> 2.6)
       high_voltage (~> 3.1.2)
       jbuilder (~> 2.11.5)
       mongo_session_store (~> 3.2.1)
@@ -158,13 +158,14 @@ GEM
     defra_ruby_style (0.3.0)
       rubocop (>= 1.0, < 2.0)
     defra_ruby_template (3.13.0)
-    defra_ruby_validators (2.5.2)
+    defra_ruby_validators (2.6.0)
       activemodel
       i18n
       matrix
       os_map_ref
       phonelib
       rest-client (~> 2.0)
+      uk_postcode
       validates_email_format_of
     devise (4.9.3)
       bcrypt (~> 3.0)
@@ -283,7 +284,7 @@ GEM
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
-    phonelib (0.8.5)
+    phonelib (0.8.6)
     protocol-hpack (1.4.2)
     protocol-http (0.25.0)
     protocol-http1 (0.16.0)

--- a/app/forms/waste_carriers_engine/company_postcode_form.rb
+++ b/app/forms/waste_carriers_engine/company_postcode_form.rb
@@ -4,7 +4,8 @@ module WasteCarriersEngine
   class CompanyPostcodeForm < PostcodeForm
     delegate :business_type, :temp_company_postcode, to: :transient_registration
 
-    validates :temp_company_postcode, "waste_carriers_engine/postcode": true
+    validates :temp_company_postcode, "defra_ruby/validators/postcode": true
+    validates :temp_company_postcode, "waste_carriers_engine/address_lookup": true
 
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating

--- a/app/forms/waste_carriers_engine/contact_postcode_form.rb
+++ b/app/forms/waste_carriers_engine/contact_postcode_form.rb
@@ -4,7 +4,8 @@ module WasteCarriersEngine
   class ContactPostcodeForm < PostcodeForm
     delegate :temp_contact_postcode, to: :transient_registration
 
-    validates :temp_contact_postcode, "waste_carriers_engine/postcode": true
+    validates :temp_contact_postcode, "defra_ruby/validators/postcode": true
+    validates :temp_contact_postcode, "waste_carriers_engine/address_lookup": true
 
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating

--- a/app/validators/waste_carriers_engine/address_lookup_validator.rb
+++ b/app/validators/waste_carriers_engine/address_lookup_validator.rb
@@ -1,14 +1,11 @@
 # frozen_string_literal: true
 
-require "uk_postcode"
-
 module WasteCarriersEngine
-  class PostcodeValidator < ActiveModel::EachValidator
+  class AddressLookupValidator < ActiveModel::EachValidator
     include CanAddValidationErrors
 
     def validate_each(record, attribute, value)
       return unless value_is_present?(record, attribute, value)
-      return unless value_uses_correct_format?(record, attribute, value)
 
       postcode_returns_results?(record, attribute, value)
     end
@@ -19,13 +16,6 @@ module WasteCarriersEngine
       return true if value.present?
 
       add_validation_error(record, attribute, :blank)
-      false
-    end
-
-    def value_uses_correct_format?(record, attribute, value)
-      return true if UKPostcode.parse(value).full_valid?
-
-      add_validation_error(record, attribute, :wrong_format)
       false
     end
 

--- a/spec/requests/waste_carriers_engine/company_address_manual_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/company_address_manual_forms_spec.rb
@@ -21,7 +21,7 @@ module WasteCarriersEngine
           let(:valid_params) do
             {
               company_address: {
-                house_number: "42",
+                house_number: "41",
                 address_line_1: "Foo Terrace",
                 town_city: "Barton"
               }
@@ -29,9 +29,10 @@ module WasteCarriersEngine
           end
 
           it "updates the transient registration and returns a 302 response" do
+
             post company_address_manual_forms_path(transient_registration.token), params: { company_address_manual_form: valid_params }
 
-            expect(transient_registration.reload.registered_address.house_number).to eq("42")
+            expect(transient_registration.reload.registered_address.house_number).to eq("41")
             expect(response).to have_http_status(:found)
           end
 

--- a/spec/requests/waste_carriers_engine/contact_address_manual_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/contact_address_manual_forms_spec.rb
@@ -20,7 +20,7 @@ module WasteCarriersEngine
             {
               token: transient_registration[:token],
               contact_address: {
-                house_number: "42",
+                house_number: "43",
                 address_line_1: "Foo Terrace",
                 town_city: "Barton"
               }
@@ -30,7 +30,7 @@ module WasteCarriersEngine
           it "updates the transient registration, returns a 302 response and redirects to the check_your_answers form" do
             post contact_address_manual_forms_path(transient_registration.token), params: { contact_address_manual_form: valid_params }
 
-            expect(transient_registration.reload.contact_address.house_number).to eq("42")
+            expect(transient_registration.reload.contact_address.house_number).to eq("43")
             expect(response).to have_http_status(:found)
             expect(response).to redirect_to(new_check_your_answers_form_path(transient_registration[:token]))
           end

--- a/waste_carriers_engine.gemspec
+++ b/waste_carriers_engine.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |s|
   s.add_dependency "high_voltage", "~> 3.1.2"
 
   # Validations
-  s.add_dependency "defra_ruby_validators", "~> 2.5.1"
+  s.add_dependency "defra_ruby_validators", "~> 2.6"
   s.add_dependency "uk_postcode", "~> 2.1.8"
 
   s.add_dependency "defra_ruby_govpay"


### PR DESCRIPTION
Use the new defra_ruby_validators postcode validator to ensure 0/O and 1/I errors are handled.
https://eaflood.atlassian.net/browse/RUBY-2805