### PR TITLE
[RUBY-2842] refactoring original_activation_date method to handle situation when dateActivated is missing

### DIFF
--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -102,11 +102,10 @@ module WasteCarriersEngine
     end
 
     def original_activation_date
-      if past_registrations.any?
-        past_registrations.map { |x| x.metaData&.dateActivated }.min
-      else
-        metaData&.dateActivated
+      past_activation_dates = past_registrations.filter_map do |x|
+        x.metaData.dateActivated if x.metaData.respond_to?(:dateActivated)
       end
+      past_activation_dates.any? ? past_activation_dates.min : metaData&.dateActivated
     end
 
     def increment_certificate_version(user = nil)

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -817,6 +817,14 @@ module WasteCarriersEngine
           expect(registration.reload.past_registrations.length).to eq(1)
           expect(registration.original_activation_date.to_date).to eq(old_registration.metaData.dateActivated.to_date)
         end
+
+        it "returns activation date of the next registration if the first one doesn't have activation date set" do
+          old_registration = create_past_registration
+          old_registration.metaData.update(dateActivated: nil)
+          registration.metaData.update(dateActivated: Date.today)
+          expect(registration.reload.past_registrations.length).to eq(1)
+          expect(registration.original_activation_date.to_date).to eq(registration.metaData.dateActivated.to_date)
+        end
       end
 
       describe "first and only registration" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-2842