### PR TITLE
[RUBY-2845] Fix issues with view certificate link

### DIFF
--- a/app/services/waste_carriers_engine/notify/certificate_renewal_email_service.rb
+++ b/app/services/waste_carriers_engine/notify/certificate_renewal_email_service.rb
@@ -5,7 +5,6 @@ module WasteCarriersEngine
     class CertificateRenewalEmailService < BaseSendEmailService
       include WasteCarriersEngine::ApplicationHelper
       include WasteCarriersEngine::CanRecordCommunication
-      include WasteCarriersEngine::CanAttachCertificate
 
       TEMPLATE_ID = "2eae1dbd-08c1-4602-a4d2-e4481a1acc97"
       COMMS_LABEL = "Resend certificate link"
@@ -24,7 +23,7 @@ module WasteCarriersEngine
             registered_address: registered_address,
             date_registered: date_registered,
             phone_number: @registration.phone_number,
-            link_to_file: link_to_certificate
+            link_to_file: WasteCarriersEngine::ViewCertificateLinkService.run(registration: @registration)
           }
         }
       end

--- a/app/services/waste_carriers_engine/notify/registration_confirmation_email_service.rb
+++ b/app/services/waste_carriers_engine/notify/registration_confirmation_email_service.rb
@@ -11,8 +11,6 @@ module WasteCarriersEngine
       UPPER_TIER_TEMPLATE_ID = "fe1e4746-c940-4ace-b111-8be64ee53b35"
       UPPER_TIER_COMMS_LABEL = "Upper tier registration complete"
 
-      include CanAttachCertificate
-
       def notify_options
         {
           email_address: @registration.contact_email,
@@ -25,7 +23,7 @@ module WasteCarriersEngine
             phone_number: @registration.phone_number,
             registered_address: registered_address,
             date_registered: date_registered,
-            link_to_file: link_to_certificate
+            link_to_file: WasteCarriersEngine::ViewCertificateLinkService.run(registration: @registration)
           }
         }
       end

--- a/app/services/waste_carriers_engine/notify/renewal_confirmation_email_service.rb
+++ b/app/services/waste_carriers_engine/notify/renewal_confirmation_email_service.rb
@@ -5,7 +5,6 @@ module WasteCarriersEngine
     class RenewalConfirmationEmailService < BaseSendEmailService
       TEMPLATE_ID = "6d54a9bc-9b62-4d93-a40a-d06d04ed58ca"
       COMMS_LABEL = "Upper tier renewal complete"
-      include CanAttachCertificate
 
       private
 
@@ -21,7 +20,7 @@ module WasteCarriersEngine
             phone_number: @registration.phone_number,
             registered_address: registered_address,
             date_activated: date_activated,
-            link_to_file: link_to_certificate
+            link_to_file: WasteCarriersEngine::ViewCertificateLinkService.run(registration: @registration)
           }
         }
       end

--- a/app/services/waste_carriers_engine/view_certificate_link_service.rb
+++ b/app/services/waste_carriers_engine/view_certificate_link_service.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class ViewCertificateLinkService < BaseService
+    def run(registration:)
+      [
+        Rails.configuration.wcrs_fo_link_domain,
+        "/fo/",
+        registration.reg_identifier,
+        "/certificate?token=",
+        registration.view_certificate_token
+      ].join
+    end
+  end
+end

--- a/spec/services/waste_carriers_engine/notify/certificate_renewal_email_service_spec.rb
+++ b/spec/services/waste_carriers_engine/notify/certificate_renewal_email_service_spec.rb
@@ -21,7 +21,7 @@ module WasteCarriersEngine
               phone_number: "03708 506506",
               registered_address: "42, Foo Gardens, Baz City, BS1 5AH",
               date_registered: registration.metaData.date_registered.to_fs(:standard),
-              link_to_file: "http://localhost:3000/#{registration.reg_identifier}/certificate?token=#{registration.view_certificate_token}"
+              link_to_file: "http://localhost:3002/fo/#{registration.reg_identifier}/certificate?token=#{registration.view_certificate_token}"
             }
           }
         end

--- a/spec/services/waste_carriers_engine/notify/registration_confirmation_email_service_spec.rb
+++ b/spec/services/waste_carriers_engine/notify/registration_confirmation_email_service_spec.rb
@@ -27,7 +27,7 @@ module WasteCarriersEngine
               phone_number: "03708 506506",
               registered_address: "42\r\nFoo Gardens\r\nBaz City\r\nBS1 5AH",
               date_registered: registration.metaData.date_registered.to_fs(:standard),
-              link_to_file: "http://localhost:3000/#{registration.reg_identifier}/certificate?token=#{registration.view_certificate_token}"
+              link_to_file: "http://localhost:3002/fo/#{registration.reg_identifier}/certificate?token=#{registration.view_certificate_token}"
             }
           }
         end

--- a/spec/services/waste_carriers_engine/notify/renewal_confirmation_email_service_spec.rb
+++ b/spec/services/waste_carriers_engine/notify/renewal_confirmation_email_service_spec.rb
@@ -26,7 +26,7 @@ module WasteCarriersEngine
               phone_number: "03708 506506",
               registered_address: "42\r\nFoo Gardens\r\nBaz City\r\nBS1 5AH",
               date_activated: registration.metaData.date_activated.to_fs(:standard),
-              link_to_file: "http://localhost:3000/#{registration.reg_identifier}/certificate?token=#{registration.view_certificate_token}"
+              link_to_file: "http://localhost:3002/fo/#{registration.reg_identifier}/certificate?token=#{registration.view_certificate_token}"
             }
           }
         end

--- a/spec/services/waste_carriers_engine/view_certificate_link_service_spec.rb
+++ b/spec/services/waste_carriers_engine/view_certificate_link_service_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe ViewCertificateLinkService do
+
+    subject(:run_service) { described_class.run(registration: registration) }
+
+    before do
+      allow(Rails.configuration).to receive(:wcrs_fo_link_domain).and_return("http://example.com")
+      registration.generate_view_certificate_token!
+    end
+
+    context "when the registration does not already have a view certificate token" do
+      let(:registration) { create(:registration, :has_required_data) }
+
+      it "returns the view certificate link with the token" do
+        expected_link = "http://example.com/fo/#{registration.reg_identifier}/certificate?token=#{registration.view_certificate_token}"
+        expect(run_service).to eq(expected_link)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Fix issue with pointing to /fo when used in back office
- Fix issue with incorrect domain from using older frontoffice url
- Refactor certificate link generation into ViewCertificateLinkService
- Use ViewCertificateLinkService and remove CanAttachCertificate mixin from email services.