### PR TITLE
[RUBY-2845] Refactor certificate token generation and update services

### DIFF
--- a/app/services/waste_carriers_engine/certificate_renewal_service.rb
+++ b/app/services/waste_carriers_engine/certificate_renewal_service.rb
@@ -4,7 +4,6 @@ module WasteCarriersEngine
   class CertificateRenewalService < BaseService
     def run(registration:)
       @registration = registration
-      @registration.generate_view_certificate_token!
       send_email
       true
     rescue StandardError => e

--- a/app/services/waste_carriers_engine/notify/certificate_renewal_email_service.rb
+++ b/app/services/waste_carriers_engine/notify/certificate_renewal_email_service.rb
@@ -23,7 +23,8 @@ module WasteCarriersEngine
             registered_address: registered_address,
             date_registered: date_registered,
             phone_number: @registration.phone_number,
-            link_to_file: WasteCarriersEngine::ViewCertificateLinkService.run(registration: @registration)
+            link_to_file: WasteCarriersEngine::ViewCertificateLinkService.run(registration: @registration,
+                                                                              renew_token: true)
           }
         }
       end

--- a/app/services/waste_carriers_engine/registration_confirmation_service.rb
+++ b/app/services/waste_carriers_engine/registration_confirmation_service.rb
@@ -3,7 +3,6 @@
 module WasteCarriersEngine
   class RegistrationConfirmationService < BaseService
     def run(registration:)
-      registration.generate_view_certificate_token!
       send_email_or_letter(registration)
     rescue StandardError => e
       Airbrake.notify(e, registration_no: registration.reg_identifier) if defined?(Airbrake)

--- a/app/services/waste_carriers_engine/view_certificate_link_service.rb
+++ b/app/services/waste_carriers_engine/view_certificate_link_service.rb
@@ -2,14 +2,29 @@
 
 module WasteCarriersEngine
   class ViewCertificateLinkService < BaseService
-    def run(registration:)
+    def run(registration:, renew_token: false)
+      @registration = registration
+      @renew_token = renew_token
+
       [
         Rails.configuration.wcrs_fo_link_domain,
         "/fo/",
-        registration.reg_identifier,
+        @registration.reg_identifier,
         "/certificate?token=",
-        registration.view_certificate_token
+        view_certificate_token
       ].join
+    end
+
+    private
+
+    attr_reader :registration, :renew_token
+
+    def view_certificate_token
+      if renew_token || registration.view_certificate_token.blank?
+        registration.generate_view_certificate_token!
+      else
+        registration.view_certificate_token
+      end
     end
   end
 end

--- a/app/views/waste_carriers_engine/certificates/confirm_email.html.erb
+++ b/app/views/waste_carriers_engine/certificates/confirm_email.html.erb
@@ -6,7 +6,7 @@
       </div>
     <% end %>
 
-    <h2 class="govuk-heading-l"><%=t('.heading')%></h2>
+    <h1 class="govuk-heading-l"><%=t('.heading')%></h1>
     <%= form_with url: certificate_process_email_path(@registration.reg_identifier), method: :post, html: { class: 'govuk-form-group' }, local: true do |form| %>
       <div class="govuk-form-group">
         <%= form.label :email,  t('.email_label'), class: 'govuk-label' %>

--- a/config/locales/certificates.en.yml
+++ b/config/locales/certificates.en.yml
@@ -5,6 +5,7 @@ en:
         token: "You do not have permission to view this page"
       show:
         view_as_pdf: "View certificate as PDF (opens in new window)"
+        title: "Certificate of Registration"
         heading: "Certificate of Registration under the Waste (England and Wales) Regulations 2011"
         authority: "Regulation authority"
         name: "Name"

--- a/spec/services/waste_carriers_engine/certificate_renewal_service_spec.rb
+++ b/spec/services/waste_carriers_engine/certificate_renewal_service_spec.rb
@@ -15,11 +15,6 @@ module WasteCarriersEngine
       end
 
       context "when the process is successful" do
-        it "generates a new view certificate token" do
-          service
-          expect(registration).to have_received(:generate_view_certificate_token!)
-        end
-
         it "sends an email" do
           service
           expect(Notify::CertificateRenewalEmailService).to have_received(:run).with(registration: registration)
@@ -34,7 +29,7 @@ module WasteCarriersEngine
         let(:error) { StandardError.new("Unexpected error") }
 
         before do
-          allow(registration).to receive(:save!).and_raise(error)
+          allow(Notify::CertificateRenewalEmailService).to receive(:run).and_raise(error)
           allow(Rails.logger).to receive(:error)
           allow(Airbrake).to receive(:notify) if defined?(Airbrake)
         end

--- a/spec/services/waste_carriers_engine/notify/certificate_renewal_email_service_spec.rb
+++ b/spec/services/waste_carriers_engine/notify/certificate_renewal_email_service_spec.rb
@@ -35,6 +35,10 @@ module WasteCarriersEngine
           allow(notifications_client).to receive(:send_email).and_return(notifications_client_response_notification)
           allow(notifications_client_response_notification).to receive(:instance_of?)
             .with(Notifications::Client::ResponseNotification).and_return(true)
+          allow(WasteCarriersEngine::ViewCertificateLinkService)
+            .to receive(:run)
+            .with(registration: registration, renew_token: true)
+            .and_call_original
           registration.generate_view_certificate_token!
         end
 
@@ -47,6 +51,11 @@ module WasteCarriersEngine
           it "sends an email" do
             run_service
             expect(notifications_client).to have_received(:send_email).with(expected_notify_options)
+          end
+
+          it "calls the ViewCertificateLinkService with renew_token: true" do
+            run_service
+            expect(WasteCarriersEngine::ViewCertificateLinkService).to have_received(:run).with(registration: registration, renew_token: true)
           end
 
           it_behaves_like "can create a communication record", "email"

--- a/spec/services/waste_carriers_engine/registration_confirmation_service_spec.rb
+++ b/spec/services/waste_carriers_engine/registration_confirmation_service_spec.rb
@@ -25,12 +25,6 @@ module WasteCarriersEngine
             .once
         end
 
-        it "will generate a view certificate token" do
-          expect(registration.view_certificate_token).to be_nil
-          run_service
-          expect(registration.view_certificate_token).not_to be_nil
-        end
-
         context "when an error occurs" do
           it "notifies Airbrake" do
             the_error = StandardError.new("Oops!")

--- a/spec/services/waste_carriers_engine/view_certificate_link_service_spec.rb
+++ b/spec/services/waste_carriers_engine/view_certificate_link_service_spec.rb
@@ -5,19 +5,45 @@ require "rails_helper"
 module WasteCarriersEngine
   RSpec.describe ViewCertificateLinkService do
 
-    subject(:run_service) { described_class.run(registration: registration) }
+    subject(:run_service) { described_class.run(registration: registration, renew_token: renew_token) }
+
+    let(:registration) { create(:registration, :has_required_data) }
+    let(:renew_token) { false }
 
     before do
       allow(Rails.configuration).to receive(:wcrs_fo_link_domain).and_return("http://example.com")
-      registration.generate_view_certificate_token!
     end
 
     context "when the registration does not already have a view certificate token" do
-      let(:registration) { create(:registration, :has_required_data) }
+      before { registration.view_certificate_token = nil }
 
-      it "returns the view certificate link with the token" do
+      it "returns the view certificate link with a new token" do
+        expect(registration.view_certificate_token).to be_nil
+        link = run_service
+        expect(link).to include(registration.reload.view_certificate_token)
+      end
+    end
+
+    context "when the registration has a view certificate token and renew_token is false" do
+      before { registration.generate_view_certificate_token! }
+
+      it "returns the view certificate link with the existing token" do
         expected_link = "http://example.com/fo/#{registration.reg_identifier}/certificate?token=#{registration.view_certificate_token}"
         expect(run_service).to eq(expected_link)
+      end
+    end
+
+    context "when renew_token is true" do
+      let(:renew_token) { true }
+
+      it "regenerates the token and returns the view certificate link with the new token" do
+        old_token = registration.generate_view_certificate_token!
+        expect(run_service).not_to include(old_token)
+
+        new_token = registration.reload.view_certificate_token
+        expected_link = "http://example.com/fo/#{registration.reg_identifier}/certificate?token=#{new_token}"
+        expect(run_service).to eq(expected_link)
+        expect(new_token).not_to eq(old_token)
       end
     end
   end


### PR DESCRIPTION
PR to resolve these 3 issues:

1. certificate_confirm_email page is missing H1
2. Resend confirmation email is missing a token in the link
3. Certificate page is missing page title Certificate of Registration

In solving 2, this commit introduces a significant refactor to the way view certificate tokens are generated and handled within the application. The primary goal of these changes is to improve the logic around the generation of new tokens and ensure that they are generated when necessary, specifically so that emails will no longer be sent out without any token (and therefore a broken link).