### PR TITLE
[RUBY-2845] Update heading tags from h2/h3 to h1 for accessibility in renewal templates

### DIFF
--- a/app/views/waste_carriers_engine/certificates/renew_token.html.erb
+++ b/app/views/waste_carriers_engine/certificates/renew_token.html.erb
@@ -6,7 +6,7 @@
       </div>
     <% end %>
 
-    <h2 class="govuk-heading-l"><%=t('.heading')%></h2>
+    <h1 class="govuk-heading-l"><%=t('.heading')%></h1>
     <%= form_with url: certificate_reset_token_path(@registration.reg_identifier), method: :post, html: { class: 'govuk-form-group' }, local: true do |form| %>
       <div class="govuk-form-group">
         <%= form.label :email,  t('.email_label'), class: 'govuk-label' %>

--- a/app/views/waste_carriers_engine/certificates/renewal_sent.html.erb
+++ b/app/views/waste_carriers_engine/certificates/renewal_sent.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-width-container">
   <main class="govuk-main-wrapper" id="main-content" role="main">
-    <h3 class="govuk-heading-m"><%= t('.heading') %></h3>
+    <h1 class="govuk-heading-m"><%= t('.heading') %></h1>
   </main>
 </div>


### PR DESCRIPTION
Update heading tags from h2/h3 to h1 for accessibility in renewal templates