### PR TITLE
Fix/ruby 2860 missing registration attributes

### DIFF
--- a/app/services/waste_carriers_engine/registration_completion_service.rb
+++ b/app/services/waste_carriers_engine/registration_completion_service.rb
@@ -120,7 +120,7 @@ module WasteCarriersEngine
     end
 
     def copy_data_from_transient_registration
-      # Make sure data are loaded into attributes if setted on this instance
+      # Make sure data are loaded into attributes if set on this instance
       transient_registration.reload
 
       do_not_copy_attributes = %w[

--- a/app/services/waste_carriers_engine/renewal_completion_service.rb
+++ b/app/services/waste_carriers_engine/renewal_completion_service.rb
@@ -152,7 +152,7 @@ module WasteCarriersEngine
       renewal_attributes = SafeCopyAttributesService.run(
         source_instance: transient_registration,
         target_class: Registration,
-        embedded_documents: %w[addresses metaData financeDetails],
+        embedded_documents: %w[addresses metaData financeDetails key_people],
         attributes_to_exclude: do_not_copy_attributes
       )
 

--- a/spec/services/waste_carriers_engine/registration_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/registration_completion_service_spec.rb
@@ -6,86 +6,51 @@ require "faker"
 module WasteCarriersEngine
   RSpec.describe RegistrationCompletionService do
     describe ".run" do
-      let(:transient_registration) do
-        create(
-          :new_registration,
-          :has_required_data
-        )
-      end
+      subject(:complete_registration) { described_class.run(transient_registration) }
 
-      it "generates a new registration and copies data to it" do
-        registration_scope = WasteCarriersEngine::Registration.where(reg_identifier: transient_registration.reg_identifier)
+      shared_examples "specs for all transient registration types" do
 
-        expect(registration_scope.to_a).to be_empty
+        it { expect(complete_registration.reg_identifier).to be_present }
+        it { expect(complete_registration.contact_address).to be_present }
+        it { expect(complete_registration.metaData.route).to be_present }
+        it { expect(complete_registration.metaData.date_registered).to be_present }
+        it { expect(complete_registration.finance_details).to be_present }
+        it { expect(complete_registration.finance_details.orders.count).to eq(1) }
 
-        registration = described_class.run(transient_registration)
-
-        expect(registration.reg_identifier).to be_present
-        expect(registration.contact_address).to be_present
-        expect(registration.company_address).to be_present
-        expect(registration.expires_on).to be_present
-        expect(registration.metaData.route).to be_present
-        expect(registration.metaData.date_registered).to be_present
-        expect(registration).to be_pending
-      end
-
-      context "when all temporary attributes are populated" do
-        before do
-          TransientRegistration.fields.keys.select { |t| t.start_with?("temp_") }.each do |temp_field|
-            transient_registration.send("#{temp_field}=", "yes") unless transient_registration.send(temp_field).present?
+        context "when all temporary attributes are populated" do
+          before do
+            TransientRegistration.fields.keys.select { |t| t.start_with?("temp_") }.each do |temp_field|
+              unless transient_registration.send(temp_field).present?
+                transient_registration.send("#{temp_field}=", "yes")
+              end
+            end
+            transient_registration.save!
           end
-          transient_registration.save!
+
+          it "does not raise an exception" do
+            expect { described_class.run(transient_registration) }.not_to raise_error
+          end
         end
 
-        it "does not raise an exception" do
-          expect { described_class.run(transient_registration) }.not_to raise_error
-        end
-      end
+        it "deletes the transient registration" do
+          token = transient_registration.token
 
-      it "deletes the transient registration" do
-        token = transient_registration.token
+          described_class.run(transient_registration)
 
-        described_class.run(transient_registration)
+          new_registration_scope = WasteCarriersEngine::NewRegistration.where(token: token)
 
-        new_registration_scope = WasteCarriersEngine::NewRegistration.where(token: token)
-
-        expect(new_registration_scope.to_a).to be_empty
-      end
-
-      context "when the activation service raises an exception" do
-        let(:registration_completion_service) { described_class.new }
-        let(:activation_service_instance) { instance_double(RegistrationActivationService) }
-
-        before do
-          allow(registration_completion_service).to receive(:log_transient_registration_details)
-          allow(RegistrationActivationService).to receive(:new).and_return(activation_service_instance)
-          allow(activation_service_instance).to receive(:run).and_raise(StandardError)
-        end
-
-        it "logs the transient registration details" do
-          registration_completion_service.run(transient_registration)
-
-          expect(registration_completion_service).to have_received(:log_transient_registration_details)
+          expect(new_registration_scope.to_a).to be_empty
         end
       end
 
-      context "when the registration is a lower tier registration" do
-        let(:transient_registration) do
-          create(
-            :new_registration,
-            :has_required_lower_tier_data
-          )
-        end
+      context "when the registration is lower tier" do
+        let(:transient_registration) { create(:new_registration, :has_required_lower_tier_data) }
 
-        it "activates the registration, set up finance details and does not set an expire date" do
-          registration = described_class.run(transient_registration)
+        it_behaves_like "specs for all transient registration types"
 
-          expect(registration.expires_on).to be_nil
-          expect(registration).to be_active
-          expect(registration.finance_details).to be_present
-          expect(registration.finance_details.orders.count).to eq(1)
-          expect(registration.finance_details.balance).to eq(0)
-        end
+        it { expect(complete_registration.expires_on).to be_nil }
+        it { expect(complete_registration).to be_active }
+        it { expect(complete_registration.finance_details.balance).to eq(0) }
 
         it "does not set conviction search result and sign offs" do
           transient_registration.conviction_search_result = { match_result: "NO", confirmed: "no" }
@@ -97,147 +62,20 @@ module WasteCarriersEngine
         end
       end
 
-      context "when the balance has been cleared and there are no pending convictions checks" do
-        let(:finance_details) { build(:finance_details, :has_paid_order_and_payment) }
-        let(:registration) { described_class.run(transient_registration) }
+      context "when the registration is upper tier" do
+        let(:transient_registration) { create(:new_registration, :has_required_data) }
 
-        before do
-          transient_registration.finance_details = finance_details
-          transient_registration.save
+        it_behaves_like "specs for all transient registration types"
+
+        it "generates a new registration" do
+          expect { complete_registration }.to change(WasteCarriersEngine::Registration, :count).by(1)
         end
 
-        it "activates the registration" do
-          expect(registration).to be_active
-        end
+        it { expect(complete_registration.company_address).to be_present }
+        it { expect(complete_registration.expires_on).to be_present }
+        it { expect(complete_registration).to be_pending }
 
-        it "creates the correct number of order item logs" do
-          expect { registration }.to change(OrderItemLog, :count)
-            .from(0)
-            .to(transient_registration.finance_details.orders.sum { |o| o.order_items.length })
-        end
-
-        context "with multiple orders and multiple order items" do
-          # Allow for multiple orders per registration, multiple order items per order and a variable quantity per order item
-          before do
-            orders = []
-            order_count = Faker::Number.between(from: 1, to: 3)
-            order_count.times do
-              order = build(:order)
-              order_item_count = Faker::Number.between(from: 1, to: 5)
-              order.order_items = build_list(
-                :order_item,
-                order_item_count,
-                quantity: Faker::Number.between(from: 1, to: 7),
-                type: OrderItem::TYPES.values[rand(OrderItem::TYPES.size)]
-              )
-              orders << order
-            end
-            transient_registration.finance_details.orders = orders
-          end
-
-          it "creates the correct number of order item logs" do
-            expect { registration }.to change(OrderItemLog, :count)
-              .from(0)
-              .to(transient_registration.finance_details.orders.sum { |o| o.order_items.length })
-          end
-
-          it "captures the order item types correctly" do
-            order_items_by_type = {}
-            registration.finance_details.orders.map do |o|
-              o.order_items.each do |oi|
-                order_items_by_type[oi["type"]] ||= 0
-                order_items_by_type[oi["type"]] += 1
-              end
-            end
-            order_items_by_type.each do |k, _v|
-              expect(OrderItemLog.where(type: k).count).to eq order_items_by_type[k]
-            end
-          end
-
-          it "stores the registration activation date for all order items" do
-            expect(OrderItemLog.where(activated_at: registration.metaData.dateActivated).count).to eq OrderItemLog.count
-          end
-        end
-      end
-
-      context "when there is a pending govpay balance" do
-        let(:finance_details) { build(:finance_details, :has_pending_govpay_order) }
-
-        before do
-          transient_registration.finance_details = finance_details
-          transient_registration.save
-        end
-
-        it "sends a pending online payment confirmation email with notify" do
-          allow(Notify::RegistrationPendingOnlinePaymentEmailService)
-            .to receive(:run)
-            .and_call_original
-
-          registration = described_class.run(transient_registration)
-
-          expect(Notify::RegistrationPendingOnlinePaymentEmailService)
-            .to have_received(:run)
-            .with(registration: registration)
-            .once
-        end
-      end
-
-      context "when there is a pending balance" do
-        let(:finance_details) { build(:finance_details, :has_required_data) }
-
-        before do
-          transient_registration.finance_details = finance_details
-          transient_registration.save
-        end
-
-        it "sends a confirmation email with notify" do
-          allow(Notify::RegistrationPendingPaymentEmailService)
-            .to receive(:run)
-            .and_call_original
-
-          registration = described_class.run(transient_registration)
-
-          expect(Notify::RegistrationPendingPaymentEmailService)
-            .to have_received(:run)
-            .with(registration: registration)
-            .once
-        end
-
-        context "when the mailer fails" do
-          before do
-            the_error = StandardError.new("Oops!")
-
-            allow(Notify::RegistrationPendingPaymentEmailService)
-              .to receive(:run)
-              .and_raise(the_error)
-
-            allow(Airbrake)
-              .to receive(:notify)
-              .with(the_error, { registration_no: transient_registration.reg_identifier })
-          end
-
-          it "does not create an order item log" do
-            expect { described_class.run(transient_registration) }.not_to change(OrderItemLog, :count).from(0)
-          end
-
-          it "notifies Airbrake" do
-            described_class.run(transient_registration)
-
-            expect(Airbrake).to have_received(:notify)
-          end
-        end
-      end
-
-      context "when there is a pending convictions check" do
-        let(:transient_registration) do
-          create(
-            :new_registration,
-            :has_required_data,
-            :requires_conviction_check
-          )
-        end
-
-        context "when the balance has been paid" do
+        context "when the balance has been cleared and there are no pending convictions checks" do
           let(:finance_details) { build(:finance_details, :has_paid_order_and_payment) }
 
           before do
@@ -245,24 +83,108 @@ module WasteCarriersEngine
             transient_registration.save
           end
 
-          it "sends a confirmation email with notify" do
-            allow(Notify::RegistrationPendingConvictionCheckEmailService)
+          it "activates the registration" do
+            expect(complete_registration).to be_active
+          end
+
+          it "creates the correct number of order item logs" do
+            expect { complete_registration }.to change(OrderItemLog, :count)
+              .from(0)
+              .to(transient_registration.finance_details.orders.sum { |o| o.order_items.length })
+          end
+
+          context "with multiple orders and multiple order items" do
+            # Allow for multiple orders per registration, multiple order items per order and a variable quantity per order item
+            before do
+              orders = []
+              order_count = Faker::Number.between(from: 1, to: 3)
+              order_count.times do
+                order = build(:order)
+                order_item_count = Faker::Number.between(from: 1, to: 5)
+                order.order_items = build_list(
+                  :order_item,
+                  order_item_count,
+                  quantity: Faker::Number.between(from: 1, to: 7),
+                  type: OrderItem::TYPES.values[rand(OrderItem::TYPES.size)]
+                )
+                orders << order
+              end
+              transient_registration.finance_details.orders = orders
+            end
+
+            it "creates the correct number of order item logs" do
+              expect { complete_registration }.to change(OrderItemLog, :count)
+                .from(0)
+                .to(transient_registration.finance_details.orders.sum { |o| o.order_items.length })
+            end
+
+            it "captures the order item types correctly" do
+              order_items_by_type = {}
+              complete_registration.finance_details.orders.map do |o|
+                o.order_items.each do |oi|
+                  order_items_by_type[oi["type"]] ||= 0
+                  order_items_by_type[oi["type"]] += 1
+                end
+              end
+              order_items_by_type.each do |k, _v|
+                expect(OrderItemLog.where(type: k).count).to eq order_items_by_type[k]
+              end
+            end
+
+            it "stores the registration activation date for all order items" do
+              expect(OrderItemLog.where(activated_at: complete_registration.metaData.dateActivated).count).to eq OrderItemLog.count
+            end
+          end
+        end
+
+        context "when there is a pending govpay balance" do
+          let(:finance_details) { build(:finance_details, :has_pending_govpay_order) }
+
+          before do
+            transient_registration.finance_details = finance_details
+            transient_registration.save
+          end
+
+          it "sends a pending online payment confirmation email with notify" do
+            allow(Notify::RegistrationPendingOnlinePaymentEmailService)
               .to receive(:run)
               .and_call_original
 
             registration = described_class.run(transient_registration)
 
-            expect(Notify::RegistrationPendingConvictionCheckEmailService)
+            expect(Notify::RegistrationPendingOnlinePaymentEmailService)
+              .to have_received(:run)
+              .with(registration: registration)
+              .once
+          end
+        end
+
+        context "when there is a pending balance" do
+          let(:finance_details) { build(:finance_details, :has_required_data) }
+
+          before do
+            transient_registration.finance_details = finance_details
+            transient_registration.save
+          end
+
+          it "sends a confirmation email with notify" do
+            allow(Notify::RegistrationPendingPaymentEmailService)
+              .to receive(:run)
+              .and_call_original
+
+            registration = described_class.run(transient_registration)
+
+            expect(Notify::RegistrationPendingPaymentEmailService)
               .to have_received(:run)
               .with(registration: registration)
               .once
           end
 
-          context "when the notify service fails" do
+          context "when the mailer fails" do
             before do
               the_error = StandardError.new("Oops!")
 
-              allow(Notify::RegistrationPendingConvictionCheckEmailService)
+              allow(Notify::RegistrationPendingPaymentEmailService)
                 .to receive(:run)
                 .and_raise(the_error)
 
@@ -283,28 +205,104 @@ module WasteCarriersEngine
           end
         end
 
-        context "when there is an unpaid balance" do
-          let(:finance_details) { build(:finance_details, :has_required_data) }
-
-          before do
-            allow(Notify::RegistrationPendingConvictionCheckEmailService).to receive(:run)
-
-            transient_registration.finance_details = finance_details
-            transient_registration.save
+        context "when there is a pending convictions check" do
+          let(:transient_registration) do
+            create(
+              :new_registration,
+              :has_required_data,
+              :requires_conviction_check
+            )
           end
 
-          it "does not send the pending conviction check email" do
-            described_class.run(transient_registration)
+          context "when the balance has been paid" do
+            let(:finance_details) { build(:finance_details, :has_paid_order_and_payment) }
 
-            expect(Notify::RegistrationPendingConvictionCheckEmailService).not_to have_received(:run)
+            before do
+              transient_registration.finance_details = finance_details
+              transient_registration.save
+            end
+
+            it "sends a confirmation email with notify" do
+              allow(Notify::RegistrationPendingConvictionCheckEmailService)
+                .to receive(:run)
+                .and_call_original
+
+              registration = described_class.run(transient_registration)
+
+              expect(Notify::RegistrationPendingConvictionCheckEmailService)
+                .to have_received(:run)
+                .with(registration: registration)
+                .once
+            end
+
+            context "when the notify service fails" do
+              before do
+                the_error = StandardError.new("Oops!")
+
+                allow(Notify::RegistrationPendingConvictionCheckEmailService)
+                  .to receive(:run)
+                  .and_raise(the_error)
+
+                allow(Airbrake)
+                  .to receive(:notify)
+                  .with(the_error, { registration_no: transient_registration.reg_identifier })
+              end
+
+              it "does not create an order item log" do
+                expect { described_class.run(transient_registration) }.not_to change(OrderItemLog, :count).from(0)
+              end
+
+              it "notifies Airbrake" do
+                described_class.run(transient_registration)
+
+                expect(Airbrake).to have_received(:notify)
+              end
+            end
           end
 
-          it "does not create an order item log" do
-            described_class.run(transient_registration)
-            expect(OrderItemLog.count).to be_zero
+          context "when there is an unpaid balance" do
+            let(:finance_details) { build(:finance_details, :has_required_data) }
+
+            before do
+              allow(Notify::RegistrationPendingConvictionCheckEmailService).to receive(:run)
+
+              transient_registration.finance_details = finance_details
+              transient_registration.save
+            end
+
+            it "does not send the pending conviction check email" do
+              described_class.run(transient_registration)
+
+              expect(Notify::RegistrationPendingConvictionCheckEmailService).not_to have_received(:run)
+            end
+
+            it "does not create an order item log" do
+              described_class.run(transient_registration)
+              expect(OrderItemLog.count).to be_zero
+            end
           end
         end
       end
+
+      context "when the activation service raises an exception" do
+        let(:transient_registration) { create(:new_registration, :has_required_data) }
+        let(:registration_completion_service) { described_class.new }
+        let(:activation_service_instance) { instance_double(RegistrationActivationService) }
+
+        before do
+          allow(described_class).to receive(:new).and_return(registration_completion_service)
+          allow(registration_completion_service).to receive(:log_transient_registration_details)
+          allow(RegistrationActivationService).to receive(:new).and_return(activation_service_instance)
+          allow(activation_service_instance).to receive(:run).and_raise(StandardError)
+        end
+
+        it "logs the transient registration details" do
+          complete_registration
+
+          expect(registration_completion_service).to have_received(:log_transient_registration_details)
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
- Revamp and extend unit test coverage for registration and renewal completion services
- Add key_people to the set of embedded attributes to be copied during renewal completion
https://eaflood.atlassian.net/browse/RUBY-2860