### PR TITLE
fix/RUBY-2973_reinstate_copy_methods

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_copy_data_from_registration.rb
+++ b/app/models/concerns/waste_carriers_engine/can_copy_data_from_registration.rb
@@ -27,6 +27,18 @@ module WasteCarriersEngine
       assign_attributes(strip_whitespace(attributes))
     end
 
+    def copy_addresses_from_registration
+      registration.addresses.each do |address|
+        addresses << Address.new(address.attributes.except("_id"))
+      end
+    end
+
+    def copy_people_from_registration
+      registration.key_people.each do |key_person|
+        key_people << KeyPerson.new(key_person.attributes.except("_id", "conviction_search_result"))
+      end
+    end
+
     def remove_revoked_reason
       metaData.revoked_reason = nil
     end


### PR DESCRIPTION
Reinstate address and people copy methods on CanCopyDataFromRegistration
https://eaflood.atlassian.net/browse/RUBY-2973