### PR TITLE
[RUBY-3079] Add communication_records to RenewingRegistration and refactor email service specs

### DIFF
--- a/app/models/waste_carriers_engine/renewing_registration.rb
+++ b/app/models/waste_carriers_engine/renewing_registration.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ClassLength
 module WasteCarriersEngine
   class RenewingRegistration < TransientRegistration
     include CanCheckIfRegistrationTypeChanged
@@ -47,6 +48,10 @@ module WasteCarriersEngine
 
     def registration
       @_registration ||= Registration.find_by(reg_identifier: reg_identifier)
+    end
+
+    def communication_records
+      registration.communication_records
     end
 
     def fee_including_possible_type_change
@@ -141,3 +146,4 @@ module WasteCarriersEngine
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/spec/services/waste_carriers_engine/notify/renewal_pending_payment_email_service_spec.rb
+++ b/spec/services/waste_carriers_engine/notify/renewal_pending_payment_email_service_spec.rb
@@ -10,29 +10,27 @@ module WasteCarriersEngine
     RSpec.describe RenewalPendingPaymentEmailService do
       let(:template_id) { "25a54b31-cdb0-4139-9ffe-50add03d572e" }
       let(:reg_identifier) { registration.reg_identifier }
+      let(:contact_email) { "foo@example.com" }
       let(:expected_notify_options) do
         {
           email_address: "foo@example.com",
           template_id: template_id,
           personalisation: {
             reg_identifier: reg_identifier,
-            first_name: "Jane",
-            last_name: "Doe",
+            first_name: renewing_registration.first_name,
+            last_name: renewing_registration.last_name,
             sort_code: "60-70-80",
             account_number: "1001 4411",
-            payment_due: "100",
+            payment_due: "110",
             iban: "GB23 NWBK 607080 10014411",
             swiftbic: "NWBK GB2L",
             currency: "Sterling"
           }
         }
       end
-      let(:registration) { create(:registration, :has_required_data) }
 
-      before do
-        registration.finance_details = build(:finance_details, :has_required_data)
-        registration.save
-      end
+      let(:renewing_registration) { create(:renewing_registration, :has_required_data, :has_finance_details, contact_email: contact_email) }
+      let(:registration) { renewing_registration.registration }
 
       describe ".run" do
         context "with a contact_email" do
@@ -45,7 +43,7 @@ module WasteCarriersEngine
 
           subject(:run_service) do
             VCR.use_cassette("notify_renewal_pending_payment_sends_an_email") do
-              described_class.run(registration: registration)
+              described_class.run(registration: renewing_registration)
             end
           end
 
@@ -58,16 +56,15 @@ module WasteCarriersEngine
           end
 
           it_behaves_like "can create a communication record", "email"
-
         end
 
         context "with no contact_email" do
-          before { registration.contact_email = nil }
+          before { renewing_registration.contact_email = nil }
 
           it "does not attempt to send an email" do
             expect_any_instance_of(Notifications::Client).not_to receive(:send_email)
 
-            described_class.run(registration: registration)
+            described_class.run(registration: renewing_registration)
           end
         end
       end


### PR DESCRIPTION
Use transient registration rather than registration when sending renewal emails while the renewal is pending to ensure most up to date email will receive the email communications