### PR TITLE
chore/log_rotation

### DIFF
--- a/app/views/pages/heartbeat.html.erb
+++ b/app/views/pages/heartbeat.html.erb
@@ -1,0 +1,1 @@
+<% content_for :title, "heartbeat"  %>

--- a/config/initializers/rails/rack/rack_logger_monkey_patch.rb
+++ b/config/initializers/rails/rack/rack_logger_monkey_patch.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module RackLoggerMonkeyPatch
+
+  def call(env)
+    if should_suppress?(env["PATH_INFO"])
+      Rails.logger.silence(Logger::WARN) { super }
+    else
+      super
+    end
+  end
+
+  private
+
+  # Suppress logging of heartbeat GETs as these are high volume and clutter the logs
+  def should_suppress?(path)
+    return false if WasteCarriersEngine::FeatureToggle.active?(:disable_rack_logger_filter)
+
+    path&.match(/#{heartbeat_path}/).present?
+  end
+
+  def heartbeat_path
+    @heartbeat_path ||= Rails.application.config.wcrs_logger_heartbeat_path
+  end
+end
+
+Rails::Rack::Logger.prepend RackLoggerMonkeyPatch

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -93,5 +93,16 @@ module Dummy
     config.application_version = "0.0.1".freeze
     config.application_name = "waste-carriers-renewals"
     config.git_repository_url = "https://github.com/DEFRA/#{config.application_name}"
+
+    # Logger
+    config.wcrs_logger_max_files = ENV.fetch("WCRS_LOGGER_MAX_FILES", 3).to_i
+    config.wcrs_logger_max_filesize = ENV.fetch("WCRS_LOGGER_MAX_FILESIZE", 10_000_000).to_i
+    config.wcrs_logger_heartbeat_path = ENV.fetch("wcrs_logger_heartbeat_path", "/pages/heartbeat")
+
+    config.logger = Logger.new(
+      Rails.root.join("log/#{Rails.env}.log"),
+      Rails.application.config.wcrs_logger_max_files,
+      Rails.application.config.wcrs_logger_max_filesize
+    )
   end
 end

--- a/spec/dummy/config/environment.rb
+++ b/spec/dummy/config/environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Load the Rails application.
 require File.expand_path('../application', __FILE__)
 

--- a/spec/requests/rack_logger_monkey_patch_spec.rb
+++ b/spec/requests/rack_logger_monkey_patch_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RackLoggerMonkeyPatch do
+  describe "#info" do
+    let(:log_file_path) { Rails.root.join("tmp/foo.log") }
+    let(:log_contents) { File.read(log_file_path) }
+
+    before { Rails.logger = ActiveSupport::Logger.new(log_file_path) }
+
+    after { FileUtils.rm_f(log_file_path) }
+
+    context "with a non-heartbeat route" do
+      before { get "/start" }
+
+      it { expect(log_contents).to match(/Started GET /) }
+    end
+
+    context "with the heartbeat route" do
+      before { get Rails.application.config.wcrs_logger_heartbeat_path }
+
+      it { expect(log_contents).not_to match(/Started GET /) }
+    end
+
+    context "when the 'disable_rack_logger_filter' feature-toggle is active" do
+      before do
+        allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:disable_rack_logger_filter).and_return true
+
+        get Rails.application.config.wcrs_logger_heartbeat_path
+      end
+
+      it { expect(log_contents).to match(/Started GET /) }
+    end
+  end
+end


### PR DESCRIPTION
1. Add a dedicated heartbeat route for app monitoring,
2. Filter out heartbeat requests from the logs
3. Configure log file rotation

https://eaflood.atlassian.net/browse/RUBY-2862
https://eaflood.atlassian.net/browse/RUBY-3031