### PR TITLE
Fix/ruby 3145 missing refund update logic

### DIFF
--- a/app/models/waste_carriers_engine/payment.rb
+++ b/app/models/waste_carriers_engine/payment.rb
@@ -54,9 +54,9 @@ module WasteCarriersEngine
                 { "$and": [{ payment_type: "WORLDPAY" },
                            { world_pay_payment_status: "AUTHORISED" }] },
                 { "$and": [{ payment_type: "GOVPAY" },
-                           { govpay_payment_status: WasteCarriersEngine::Payment::STATUS_SUCCESS }] },
+                           { govpay_payment_status: Payment::STATUS_SUCCESS }] },
                 { "$and": [{ payment_type: "REFUND" },
-                           { govpay_payment_status: WasteCarriersEngine::Payment::STATUS_SUCCESS }] },
+                           { govpay_payment_status: Payment::STATUS_SUCCESS }] },
                 { "$and": [{ payment_type: "REFUND" },
                            { govpay_payment_status: nil },
                            { world_pay_payment_status: nil }] }

--- a/app/models/waste_carriers_engine/payment.rb
+++ b/app/models/waste_carriers_engine/payment.rb
@@ -5,6 +5,19 @@ module WasteCarriersEngine
     include Mongoid::Document
     include CanHavePaymentType
 
+    # Govpay payment statuses:
+    STATUS_STARTED = "started"
+    STATUS_CREATED = "created"
+    STATUS_SUBMITTED = "submitted"
+    STATUS_CANCELLED = "cancelled"
+    STATUS_FAILED = "failed"
+    STATUS_SUCCESS = "success"
+    STATUS_COMPLETE = "complete"
+
+    # Historic Worldpay payment statuses:
+    STATUS_REFUSED = "REFUSED"
+    STATUS_AUTHORISED = "AUTHORISED"
+
     embedded_in :finance_details, class_name: "WasteCarriersEngine::FinanceDetails"
 
     field :orderKey, as: :order_key,                              type: String
@@ -38,10 +51,14 @@ module WasteCarriersEngine
             where(
               "$or": [
                 { payment_type: { "$nin" => %w[WORLDPAY GOVPAY REFUND] } },
-                { "$and": [{ payment_type: "WORLDPAY" }, { world_pay_payment_status: "AUTHORISED" }] },
-                { "$and": [{ payment_type: "GOVPAY" }, { govpay_payment_status: "success" }] },
-                { "$and": [{ payment_type: "REFUND" }, { govpay_payment_status: "success" }] },
-                { "$and": [{ payment_type: "REFUND" }, { govpay_payment_status: nil },
+                { "$and": [{ payment_type: "WORLDPAY" },
+                           { world_pay_payment_status: "AUTHORISED" }] },
+                { "$and": [{ payment_type: "GOVPAY" },
+                           { govpay_payment_status: WasteCarriersEngine::Payment::STATUS_SUCCESS }] },
+                { "$and": [{ payment_type: "REFUND" },
+                           { govpay_payment_status: WasteCarriersEngine::Payment::STATUS_SUCCESS }] },
+                { "$and": [{ payment_type: "REFUND" },
+                           { govpay_payment_status: nil },
                            { world_pay_payment_status: nil }] }
               ]
             )

--- a/app/services/waste_carriers_engine/govpay_callback_service.rb
+++ b/app/services/waste_carriers_engine/govpay_callback_service.rb
@@ -13,7 +13,7 @@ module WasteCarriersEngine
     end
 
     def valid_success?
-      return false unless govpay_response_validator(WasteCarriersEngine::Payment::STATUS_SUCCESS).valid_success?
+      return false unless govpay_response_validator(Payment::STATUS_SUCCESS).valid_success?
 
       update_payment_data
 
@@ -59,10 +59,10 @@ module WasteCarriersEngine
     end
 
     def update_payment_data
-      @order.update_after_online_payment(WasteCarriersEngine::Payment::STATUS_SUCCESS)
+      @order.update_after_online_payment(Payment::STATUS_SUCCESS)
       payment = Payment.new_from_online_payment(@order, user_email)
       payment.update_after_online_payment(
-        govpay_status: WasteCarriersEngine::Payment::STATUS_SUCCESS,
+        govpay_status: Payment::STATUS_SUCCESS,
         govpay_id: @order.govpay_id
       )
 

--- a/app/services/waste_carriers_engine/govpay_callback_service.rb
+++ b/app/services/waste_carriers_engine/govpay_callback_service.rb
@@ -13,7 +13,7 @@ module WasteCarriersEngine
     end
 
     def valid_success?
-      return false unless govpay_response_validator("success").valid_success?
+      return false unless govpay_response_validator(WasteCarriersEngine::Payment::STATUS_SUCCESS).valid_success?
 
       update_payment_data
 
@@ -59,9 +59,12 @@ module WasteCarriersEngine
     end
 
     def update_payment_data
-      @order.update_after_online_payment("success")
+      @order.update_after_online_payment(WasteCarriersEngine::Payment::STATUS_SUCCESS)
       payment = Payment.new_from_online_payment(@order, user_email)
-      payment.update_after_online_payment(govpay_status: "success", govpay_id: @order.govpay_id)
+      payment.update_after_online_payment(
+        govpay_status: WasteCarriersEngine::Payment::STATUS_SUCCESS,
+        govpay_id: @order.govpay_id
+      )
 
       @transient_registration.finance_details.update_balance
       @transient_registration.finance_details.save!

--- a/app/services/waste_carriers_engine/govpay_find_payment_service.rb
+++ b/app/services/waste_carriers_engine/govpay_find_payment_service.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class GovpayFindPaymentService < WasteCarriersEngine::BaseService
+
+    def run(payment_id:)
+      # Because payments are embedded in finance_details, they don't have their own
+      # collection so we can't search for them directly. We need to:
+      # 1. find the registration which contains the payment with this govpay_id
+      # 2. within that registration, find which payment has that govpay_id
+      WasteCarriersEngine::Registration
+        .find_by("financeDetails.payments.govpay_id": payment_id)
+        .finance_details
+        .payments
+        .find_by(govpay_id: payment_id)
+    rescue Mongoid::Errors::DocumentNotFound, NoMethodError => e
+      Rails.logger.error "Govpay payment not found for govpay_id #{payment_id}"
+      Airbrake.notify(e, message: "Govpay payment not found", payment_id:)
+      raise ArgumentError, "invalid govpay_id"
+    end
+  end
+end

--- a/app/services/waste_carriers_engine/govpay_payment_details_service.rb
+++ b/app/services/waste_carriers_engine/govpay_payment_details_service.rb
@@ -18,7 +18,7 @@ module WasteCarriersEngine
       status = response&.dig("state", "status") || "error"
 
       # Special case: If failed, check whether this was because of a cancellation
-      status = WasteCarriersEngine::Payment::STATUS_CANCELLED if payment_cancelled(status, response)
+      status = Payment::STATUS_CANCELLED if payment_cancelled(status, response)
 
       status
     rescue StandardError => e
@@ -39,11 +39,11 @@ module WasteCarriersEngine
     # Payment status in application terms
     def self.payment_status(status)
       {
-        WasteCarriersEngine::Payment::STATUS_CREATED => :pending,
-        WasteCarriersEngine::Payment::STATUS_STARTED => :pending,
-        WasteCarriersEngine::Payment::STATUS_SUBMITTED => :pending,
-        WasteCarriersEngine::Payment::STATUS_CANCELLED => :cancel,
-        WasteCarriersEngine::Payment::STATUS_FAILED => :failure,
+        Payment::STATUS_CREATED => :pending,
+        Payment::STATUS_STARTED => :pending,
+        Payment::STATUS_SUBMITTED => :pending,
+        Payment::STATUS_CANCELLED => :cancel,
+        Payment::STATUS_FAILED => :failure,
         nil => :error
       }.freeze[status] || status.to_sym
     end
@@ -69,7 +69,7 @@ module WasteCarriersEngine
     end
 
     def payment_cancelled(status, response)
-      status == WasteCarriersEngine::Payment::STATUS_FAILED && response.dig("state", "code") == "P0030"
+      status == Payment::STATUS_FAILED && response.dig("state", "code") == "P0030"
     end
 
     # Because orders are embedded in finance_details, we can't search directly on orders so we need to:

--- a/app/services/waste_carriers_engine/govpay_update_refund_status_service.rb
+++ b/app/services/waste_carriers_engine/govpay_update_refund_status_service.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class GovpayUpdateRefundStatusService < WasteCarriersEngine::BaseService
+
+    def run(registration:, refund_id:, new_status:)
+      return false if new_status != "success"
+
+      refund = WasteCarriersEngine::GovpayFindPaymentService.run(payment_id: refund_id)
+      return false if refund.blank?
+
+      payment = WasteCarriersEngine::GovpayFindPaymentService.run(payment_id: refund.refunded_payment_govpay_id)
+      return false if payment.blank?
+
+      payment_id = payment.govpay_id
+      previous_status = refund.reload.govpay_payment_status
+
+      return false if new_status == previous_status
+
+      process_success(registration, refund)
+
+      true
+    rescue StandardError => e
+      Rails.logger.error "#{e.class} error in Govpay update refund details service for payment " \
+                         "#{payment_id}, refund #{refund_id}"
+      Airbrake.notify(e, message: "Error in Govpay update refund details service", payment_id:, refund_id:)
+      raise e
+    end
+
+    private
+
+    def process_success(registration, refund)
+      refund.update(
+        {
+          govpay_payment_status: "success",
+          comment: I18n.t("refunds.comments.card_complete"),
+          order_key: refund.order_key.sub("_PENDING", "_REFUNDED")
+        }
+      )
+      refund.save!
+
+      registration.reload.finance_details.update_balance
+      registration.save!
+    end
+  end
+end

--- a/app/services/waste_carriers_engine/govpay_update_refund_status_service.rb
+++ b/app/services/waste_carriers_engine/govpay_update_refund_status_service.rb
@@ -4,7 +4,7 @@ module WasteCarriersEngine
   class GovpayUpdateRefundStatusService < WasteCarriersEngine::BaseService
 
     def run(registration:, refund_id:, new_status:)
-      return false if new_status != WasteCarriersEngine::Payment::STATUS_SUCCESS
+      return false if new_status != Payment::STATUS_SUCCESS
 
       refund = WasteCarriersEngine::GovpayFindPaymentService.run(payment_id: refund_id)
       return false if refund.blank?
@@ -32,7 +32,7 @@ module WasteCarriersEngine
     def process_success(registration, refund)
       refund.update(
         {
-          govpay_payment_status: WasteCarriersEngine::Payment::STATUS_SUCCESS,
+          govpay_payment_status: Payment::STATUS_SUCCESS,
           comment: I18n.t("refunds.comments.card_complete"),
           order_key: refund.order_key.sub("_PENDING", "_REFUNDED")
         }

--- a/app/services/waste_carriers_engine/govpay_update_refund_status_service.rb
+++ b/app/services/waste_carriers_engine/govpay_update_refund_status_service.rb
@@ -4,7 +4,7 @@ module WasteCarriersEngine
   class GovpayUpdateRefundStatusService < WasteCarriersEngine::BaseService
 
     def run(registration:, refund_id:, new_status:)
-      return false if new_status != "success"
+      return false if new_status != WasteCarriersEngine::Payment::STATUS_SUCCESS
 
       refund = WasteCarriersEngine::GovpayFindPaymentService.run(payment_id: refund_id)
       return false if refund.blank?
@@ -32,7 +32,7 @@ module WasteCarriersEngine
     def process_success(registration, refund)
       refund.update(
         {
-          govpay_payment_status: "success",
+          govpay_payment_status: WasteCarriersEngine::Payment::STATUS_SUCCESS,
           comment: I18n.t("refunds.comments.card_complete"),
           order_key: refund.order_key.sub("_PENDING", "_REFUNDED")
         }

--- a/app/services/waste_carriers_engine/govpay_webhook_base_service.rb
+++ b/app/services/waste_carriers_engine/govpay_webhook_base_service.rb
@@ -36,10 +36,7 @@ module WasteCarriersEngine
     end
 
     def update_payment_or_refund_status
-      wcr_payment.update(govpay_payment_status: webhook_payment_or_refund_status)
-
-      Rails.logger.info "Updated status from #{previous_status} to #{webhook_payment_or_refund_status} " \
-                        "for #{log_webhook_context}"
+      raise NotImplementedError
     end
 
     def wcr_payment

--- a/app/services/waste_carriers_engine/govpay_webhook_base_service.rb
+++ b/app/services/waste_carriers_engine/govpay_webhook_base_service.rb
@@ -36,7 +36,9 @@ module WasteCarriersEngine
     end
 
     def update_payment_or_refund_status
+      # :nocov:
       raise NotImplementedError
+      # :nocov:
     end
 
     def wcr_payment
@@ -68,23 +70,33 @@ module WasteCarriersEngine
 
     # the following methods differ for refunds vs card payments
     def log_webhook_context
+      # :nocov:
       raise NotImplementedError
+      # :nocov:
     end
 
     def payment_or_refund_str
+      # :nocov:
       NotImplementedError
+      # :nocov:
     end
 
     def validate_webhook_body
+      # :nocov:
       raise NotImplementedError
+      # :nocov:
     end
 
     def webhook_payment_or_refund_id
+      # :nocov:
       raise NotImplementedError
+      # :nocov:
     end
 
     def webhook_payment_or_refund_status
+      # :nocov:
       raise NotImplementedError
+      # :nocov:
     end
   end
 end

--- a/app/services/waste_carriers_engine/govpay_webhook_payment_service.rb
+++ b/app/services/waste_carriers_engine/govpay_webhook_payment_service.rb
@@ -4,12 +4,12 @@ module WasteCarriersEngine
   class GovpayWebhookPaymentService < GovpayWebhookBaseService
 
     VALID_STATUS_TRANSITIONS = {
-      "created" => %w[started submitted success failed cancelled error],
-      "started" => %w[submitted success failed cancelled error],
-      "submitted" => %w[success failed cancelled error],
-      "success" => %w[],
-      "failed" => %w[],
-      "cancelled" => %w[],
+      WasteCarriersEngine::Payment::STATUS_CREATED => %w[started submitted success failed cancelled error],
+      WasteCarriersEngine::Payment::STATUS_STARTED => %w[submitted success failed cancelled error],
+      WasteCarriersEngine::Payment::STATUS_SUBMITTED => %w[success failed cancelled error],
+      WasteCarriersEngine::Payment::STATUS_SUCCESS => %w[],
+      WasteCarriersEngine::Payment::STATUS_FAILED => %w[],
+      WasteCarriersEngine::Payment::STATUS_CANCELLED => %w[],
       "error" => %w[]
     }.freeze
 

--- a/app/services/waste_carriers_engine/govpay_webhook_payment_service.rb
+++ b/app/services/waste_carriers_engine/govpay_webhook_payment_service.rb
@@ -4,12 +4,12 @@ module WasteCarriersEngine
   class GovpayWebhookPaymentService < GovpayWebhookBaseService
 
     VALID_STATUS_TRANSITIONS = {
-      WasteCarriersEngine::Payment::STATUS_CREATED => %w[started submitted success failed cancelled error],
-      WasteCarriersEngine::Payment::STATUS_STARTED => %w[submitted success failed cancelled error],
-      WasteCarriersEngine::Payment::STATUS_SUBMITTED => %w[success failed cancelled error],
-      WasteCarriersEngine::Payment::STATUS_SUCCESS => %w[],
-      WasteCarriersEngine::Payment::STATUS_FAILED => %w[],
-      WasteCarriersEngine::Payment::STATUS_CANCELLED => %w[],
+      Payment::STATUS_CREATED => %w[started submitted success failed cancelled error],
+      Payment::STATUS_STARTED => %w[submitted success failed cancelled error],
+      Payment::STATUS_SUBMITTED => %w[success failed cancelled error],
+      Payment::STATUS_SUCCESS => %w[],
+      Payment::STATUS_FAILED => %w[],
+      Payment::STATUS_CANCELLED => %w[],
       "error" => %w[]
     }.freeze
 

--- a/app/services/waste_carriers_engine/govpay_webhook_payment_service.rb
+++ b/app/services/waste_carriers_engine/govpay_webhook_payment_service.rb
@@ -15,6 +15,13 @@ module WasteCarriersEngine
 
     private
 
+    def update_payment_or_refund_status
+      wcr_payment.update(govpay_payment_status: webhook_payment_or_refund_status)
+
+      Rails.logger.info "Updated status from #{previous_status} to #{webhook_payment_or_refund_status} " \
+                        "for #{log_webhook_context}"
+    end
+
     def log_webhook_context
       "for payment #{webhook_payment_or_refund_id}, registration #{@registration.regIdentifier}"
     end

--- a/app/services/waste_carriers_engine/govpay_webhook_refund_service.rb
+++ b/app/services/waste_carriers_engine/govpay_webhook_refund_service.rb
@@ -17,7 +17,7 @@ module WasteCarriersEngine
       Rails.logger.info "Updated status from #{previous_status} to #{webhook_payment_or_refund_status} " \
                         "for #{log_webhook_context}"
     rescue StandardError => e
-      Rails.logger.warn "Error processing webhook for #{log_webhook_context}: #{e}"
+      Rails.logger.error "Error processing webhook for #{log_webhook_context}: #{e}"
       Airbrake.notify "Error processing webhook for #{log_webhook_context}", e
     end
 

--- a/app/services/waste_carriers_engine/govpay_webhook_refund_service.rb
+++ b/app/services/waste_carriers_engine/govpay_webhook_refund_service.rb
@@ -4,16 +4,26 @@ module WasteCarriersEngine
   class GovpayWebhookRefundService < GovpayWebhookBaseService
 
     VALID_STATUS_TRANSITIONS = {
-      "submitted" => %w[success error],
+      "submitted" => %w[success],
       "success" => %w[],
       "error" => %w[]
     }.freeze
 
     private
 
+    def update_payment_or_refund_status
+      WasteCarriersEngine::GovpayUpdateRefundStatusService.run(registration:, refund_id: webhook_payment_or_refund_id,
+                                                               new_status: webhook_payment_or_refund_status)
+      Rails.logger.info "Updated status from #{previous_status} to #{webhook_payment_or_refund_status} " \
+                        "for #{log_webhook_context}"
+    rescue StandardError => e
+      Rails.logger.warn "Error processing webhook for #{log_webhook_context}: #{e}"
+      Airbrake.notify "Error processing webhook for #{log_webhook_context}", e
+    end
+
     def log_webhook_context
-      "for refund #{webhook_payment_or_refund_id}, payment #{webhook_payment_id}, " \
-        "registration #{@registration.regIdentifier}"
+      "refund #{webhook_payment_or_refund_id}, payment #{webhook_payment_id}, " \
+        "registration #{registration.regIdentifier}"
     end
 
     def payment_or_refund_str

--- a/app/services/waste_carriers_engine/govpay_webhook_refund_service.rb
+++ b/app/services/waste_carriers_engine/govpay_webhook_refund_service.rb
@@ -4,8 +4,8 @@ module WasteCarriersEngine
   class GovpayWebhookRefundService < GovpayWebhookBaseService
 
     VALID_STATUS_TRANSITIONS = {
-      "submitted" => %w[success],
-      "success" => %w[],
+      WasteCarriersEngine::Payment::STATUS_SUBMITTED => %w[success],
+      WasteCarriersEngine::Payment::STATUS_SUCCESS => %w[],
       "error" => %w[]
     }.freeze
 

--- a/app/services/waste_carriers_engine/govpay_webhook_refund_service.rb
+++ b/app/services/waste_carriers_engine/govpay_webhook_refund_service.rb
@@ -4,8 +4,8 @@ module WasteCarriersEngine
   class GovpayWebhookRefundService < GovpayWebhookBaseService
 
     VALID_STATUS_TRANSITIONS = {
-      WasteCarriersEngine::Payment::STATUS_SUBMITTED => %w[success],
-      WasteCarriersEngine::Payment::STATUS_SUCCESS => %w[],
+      Payment::STATUS_SUBMITTED => %w[success],
+      Payment::STATUS_SUCCESS => %w[],
       "error" => %w[]
     }.freeze
 

--- a/spec/factories/finance_details.rb
+++ b/spec/factories/finance_details.rb
@@ -62,6 +62,14 @@ FactoryBot.define do
       after(:build, :create, &:update_balance)
     end
 
+    trait :has_overpaid_order_and_payment_govpay do
+      orders { [build(:order, :has_required_data)] }
+      payments do
+        [build(:payment, :govpay, govpay_payment_status: "success", amount: 100_500)]
+      end
+      after(:build, :create, &:update_balance)
+    end
+
     trait :has_outstanding_copy_card do
       orders { [build(:order, :has_required_data)] }
       payments { [build(:payment, :bank_transfer, amount: 10_500)] }

--- a/spec/factories/finance_details.rb
+++ b/spec/factories/finance_details.rb
@@ -65,7 +65,7 @@ FactoryBot.define do
     trait :has_overpaid_order_and_payment_govpay do
       orders { [build(:order, :has_required_data)] }
       payments do
-        [build(:payment, :govpay, govpay_payment_status: "success", amount: 100_500)]
+        [build(:payment, :govpay, govpay_payment_status: WasteCarriersEngine::Payment::STATUS_SUCCESS, amount: 100_500)]
       end
       after(:build, :create, &:update_balance)
     end

--- a/spec/factories/order.rb
+++ b/spec/factories/order.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
     trait :has_pending_govpay_status do
       has_required_data
 
-      govpay_status { "created" }
+      govpay_status { WasteCarriersEngine::Payment::STATUS_CREATED }
     end
 
     trait :has_copy_cards_item do

--- a/spec/factories/payment.rb
+++ b/spec/factories/payment.rb
@@ -2,6 +2,9 @@
 
 FactoryBot.define do
   factory :payment, class: "WasteCarriersEngine::Payment" do
+    order_key { SecureRandom.uuid.split("-").last }
+    amount { Faker::Number.number(digits: 4) }
+
     trait :worldpay do
       payment_type { "WORLDPAY" }
     end
@@ -17,6 +20,12 @@ FactoryBot.define do
     trait :govpay_refund do
       payment_type { WasteCarriersEngine::Payment::REFUND }
       govpay_id { SecureRandom.hex(22) }
+    end
+
+    trait :govpay_refund_pending do
+      payment_type { WasteCarriersEngine::Payment::REFUND }
+      govpay_id { SecureRandom.hex(22) }
+      govpay_payment_status { "submitted" }
     end
   end
 end

--- a/spec/factories/payment.rb
+++ b/spec/factories/payment.rb
@@ -25,7 +25,7 @@ FactoryBot.define do
     trait :govpay_refund_pending do
       payment_type { WasteCarriersEngine::Payment::REFUND }
       govpay_id { SecureRandom.hex(22) }
-      govpay_payment_status { "submitted" }
+      govpay_payment_status { WasteCarriersEngine::Payment::STATUS_SUBMITTED }
     end
   end
 end

--- a/spec/models/waste_carriers_engine/finance_details_spec.rb
+++ b/spec/models/waste_carriers_engine/finance_details_spec.rb
@@ -196,13 +196,13 @@ module WasteCarriersEngine
         end
 
         context "when the refund is pending" do
-          let(:refund_status) { WasteCarriersEngine::Payment::STATUS_SUBMITTED }
+          let(:refund_status) { Payment::STATUS_SUBMITTED }
 
           it { expect(finance_details.balance).to be_zero }
         end
 
         context "when the refund is complete" do
-          let(:refund_status) { WasteCarriersEngine::Payment::STATUS_SUCCESS }
+          let(:refund_status) { Payment::STATUS_SUCCESS }
 
           it { expect(finance_details.balance).to eq(-refund_amount) }
         end

--- a/spec/models/waste_carriers_engine/finance_details_spec.rb
+++ b/spec/models/waste_carriers_engine/finance_details_spec.rb
@@ -196,13 +196,13 @@ module WasteCarriersEngine
         end
 
         context "when the refund is pending" do
-          let(:refund_status) { "submitted" }
+          let(:refund_status) { WasteCarriersEngine::Payment::STATUS_SUBMITTED }
 
           it { expect(finance_details.balance).to be_zero }
         end
 
         context "when the refund is complete" do
-          let(:refund_status) { "success" }
+          let(:refund_status) { WasteCarriersEngine::Payment::STATUS_SUCCESS }
 
           it { expect(finance_details.balance).to eq(-refund_amount) }
         end

--- a/spec/models/waste_carriers_engine/order_spec.rb
+++ b/spec/models/waste_carriers_engine/order_spec.rb
@@ -18,8 +18,8 @@ module WasteCarriersEngine
       let(:order) { finance_details.orders.first }
 
       it "copies the govpay status to the order" do
-        order.update_after_online_payment(WasteCarriersEngine::Payment::STATUS_CREATED)
-        expect(order.govpay_status).to eq(WasteCarriersEngine::Payment::STATUS_CREATED)
+        order.update_after_online_payment(Payment::STATUS_CREATED)
+        expect(order.govpay_status).to eq(Payment::STATUS_CREATED)
       end
 
       it "updates the date_last_updated" do
@@ -27,7 +27,7 @@ module WasteCarriersEngine
           # Wipe the date first so we know the value has been added
           order.update_attributes(date_last_updated: nil)
 
-          order.update_after_online_payment(WasteCarriersEngine::Payment::STATUS_CREATED)
+          order.update_after_online_payment(Payment::STATUS_CREATED)
           expect(order.date_last_updated).to eq(Time.new(2004, 8, 15, 16, 23, 42))
         end
       end

--- a/spec/models/waste_carriers_engine/order_spec.rb
+++ b/spec/models/waste_carriers_engine/order_spec.rb
@@ -18,8 +18,8 @@ module WasteCarriersEngine
       let(:order) { finance_details.orders.first }
 
       it "copies the govpay status to the order" do
-        order.update_after_online_payment("created")
-        expect(order.govpay_status).to eq("created")
+        order.update_after_online_payment(WasteCarriersEngine::Payment::STATUS_CREATED)
+        expect(order.govpay_status).to eq(WasteCarriersEngine::Payment::STATUS_CREATED)
       end
 
       it "updates the date_last_updated" do
@@ -27,7 +27,7 @@ module WasteCarriersEngine
           # Wipe the date first so we know the value has been added
           order.update_attributes(date_last_updated: nil)
 
-          order.update_after_online_payment("created")
+          order.update_after_online_payment(WasteCarriersEngine::Payment::STATUS_CREATED)
           expect(order.date_last_updated).to eq(Time.new(2004, 8, 15, 16, 23, 42))
         end
       end

--- a/spec/models/waste_carriers_engine/payment_spec.rb
+++ b/spec/models/waste_carriers_engine/payment_spec.rb
@@ -61,11 +61,11 @@ module WasteCarriersEngine
       describe ".except_online_not_authorised" do
         let(:transient_registration) { build(:renewing_registration, :has_required_data, :has_finance_details) }
         let(:cash_payment) { described_class.new(payment_type: "CASH") }
-        let(:govpay_payment_authorised) { described_class.new(payment_type: "GOVPAY", govpay_payment_status: WasteCarriersEngine::Payment::STATUS_SUCCESS) }
-        let(:govpay_payment_refused) { described_class.new(payment_type: "GOVPAY", govpay_payment_status: WasteCarriersEngine::Payment::STATUS_FAILED) }
-        let(:refund_payment_success) { described_class.new(payment_type: "REFUND", govpay_payment_status: WasteCarriersEngine::Payment::STATUS_SUCCESS) }
+        let(:govpay_payment_authorised) { described_class.new(payment_type: "GOVPAY", govpay_payment_status: Payment::STATUS_SUCCESS) }
+        let(:govpay_payment_refused) { described_class.new(payment_type: "GOVPAY", govpay_payment_status: Payment::STATUS_FAILED) }
+        let(:refund_payment_success) { described_class.new(payment_type: "REFUND", govpay_payment_status: Payment::STATUS_SUCCESS) }
         let(:refund_payment_nil_status) { described_class.new(payment_type: "REFUND", govpay_payment_status: nil) }
-        let(:refund_payment_failed) { described_class.new(payment_type: "REFUND", govpay_payment_status: WasteCarriersEngine::Payment::STATUS_FAILED) }
+        let(:refund_payment_failed) { described_class.new(payment_type: "REFUND", govpay_payment_status: Payment::STATUS_FAILED) }
 
         before do
           transient_registration.finance_details.payments << cash_payment << govpay_payment_authorised << govpay_payment_refused
@@ -210,12 +210,12 @@ module WasteCarriersEngine
       before do
         Timecop.freeze(Time.new(2018, 3, 4)) do
           transient_registration.prepare_for_payment(:govpay, current_user)
-          payment.update_after_online_payment({ govpay_status: WasteCarriersEngine::Payment::STATUS_CREATED })
+          payment.update_after_online_payment({ govpay_status: Payment::STATUS_CREATED })
         end
       end
 
       it "updates the payment status" do
-        expect(payment.govpay_payment_status).to eq(WasteCarriersEngine::Payment::STATUS_CREATED)
+        expect(payment.govpay_payment_status).to eq(Payment::STATUS_CREATED)
       end
 
       it "updates the payment date_received" do

--- a/spec/models/waste_carriers_engine/payment_spec.rb
+++ b/spec/models/waste_carriers_engine/payment_spec.rb
@@ -61,11 +61,11 @@ module WasteCarriersEngine
       describe ".except_online_not_authorised" do
         let(:transient_registration) { build(:renewing_registration, :has_required_data, :has_finance_details) }
         let(:cash_payment) { described_class.new(payment_type: "CASH") }
-        let(:govpay_payment_authorised) { described_class.new(payment_type: "GOVPAY", govpay_payment_status: "success") }
-        let(:govpay_payment_refused) { described_class.new(payment_type: "GOVPAY", govpay_payment_status: "failed") }
-        let(:refund_payment_success) { described_class.new(payment_type: "REFUND", govpay_payment_status: "success") }
+        let(:govpay_payment_authorised) { described_class.new(payment_type: "GOVPAY", govpay_payment_status: WasteCarriersEngine::Payment::STATUS_SUCCESS) }
+        let(:govpay_payment_refused) { described_class.new(payment_type: "GOVPAY", govpay_payment_status: WasteCarriersEngine::Payment::STATUS_FAILED) }
+        let(:refund_payment_success) { described_class.new(payment_type: "REFUND", govpay_payment_status: WasteCarriersEngine::Payment::STATUS_SUCCESS) }
         let(:refund_payment_nil_status) { described_class.new(payment_type: "REFUND", govpay_payment_status: nil) }
-        let(:refund_payment_failed) { described_class.new(payment_type: "REFUND", govpay_payment_status: "failed") }
+        let(:refund_payment_failed) { described_class.new(payment_type: "REFUND", govpay_payment_status: WasteCarriersEngine::Payment::STATUS_FAILED) }
 
         before do
           transient_registration.finance_details.payments << cash_payment << govpay_payment_authorised << govpay_payment_refused
@@ -210,12 +210,12 @@ module WasteCarriersEngine
       before do
         Timecop.freeze(Time.new(2018, 3, 4)) do
           transient_registration.prepare_for_payment(:govpay, current_user)
-          payment.update_after_online_payment({ govpay_status: "created" })
+          payment.update_after_online_payment({ govpay_status: WasteCarriersEngine::Payment::STATUS_CREATED })
         end
       end
 
       it "updates the payment status" do
-        expect(payment.govpay_payment_status).to eq("created")
+        expect(payment.govpay_payment_status).to eq(WasteCarriersEngine::Payment::STATUS_CREATED)
       end
 
       it "updates the payment date_received" do

--- a/spec/requests/waste_carriers_engine/confirm_bank_transfer_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/confirm_bank_transfer_forms_spec.rb
@@ -40,7 +40,7 @@ module WasteCarriersEngine
         context "when a govpay order already exists" do
           before do
             transient_registration.prepare_for_payment(:govpay, user)
-            transient_registration.finance_details.orders.first.world_pay_status = WasteCarriersEngine::Payment::STATUS_CANCELLED
+            transient_registration.finance_details.orders.first.world_pay_status = Payment::STATUS_CANCELLED
           end
 
           it "replaces the old order and does not increase the order count" do

--- a/spec/requests/waste_carriers_engine/confirm_bank_transfer_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/confirm_bank_transfer_forms_spec.rb
@@ -40,7 +40,7 @@ module WasteCarriersEngine
         context "when a govpay order already exists" do
           before do
             transient_registration.prepare_for_payment(:govpay, user)
-            transient_registration.finance_details.orders.first.world_pay_status = "CANCELLED"
+            transient_registration.finance_details.orders.first.world_pay_status = WasteCarriersEngine::Payment::STATUS_CANCELLED
           end
 
           it "replaces the old order and does not increase the order count" do

--- a/spec/requests/waste_carriers_engine/govpay_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/govpay_forms_spec.rb
@@ -105,7 +105,7 @@ module WasteCarriersEngine
           end
 
           context "when govpay status is success" do
-            let(:govpay_status) { WasteCarriersEngine::Payment::STATUS_SUCCESS }
+            let(:govpay_status) { Payment::STATUS_SUCCESS }
 
             context "when the payment_uuid is valid and the balance is paid" do
 
@@ -177,7 +177,7 @@ module WasteCarriersEngine
 
               context "when the payment uuid is valid" do
                 before do
-                  order.update!(govpay_status: WasteCarriersEngine::Payment::STATUS_CREATED)
+                  order.update!(govpay_status: Payment::STATUS_CREATED)
                 end
 
                 it "redirects to renewal_received_pending_govpay_payment_form" do
@@ -195,13 +195,13 @@ module WasteCarriersEngine
             end
 
             context "when govpay status is created" do
-              let(:govpay_status) { WasteCarriersEngine::Payment::STATUS_CREATED }
+              let(:govpay_status) { Payment::STATUS_CREATED }
 
               it_behaves_like "payment is pending"
             end
 
             context "when govpay status is submitted" do
-              let(:govpay_status) { WasteCarriersEngine::Payment::STATUS_SUBMITTED }
+              let(:govpay_status) { Payment::STATUS_SUBMITTED }
 
               it_behaves_like "payment is pending"
             end
@@ -240,13 +240,13 @@ module WasteCarriersEngine
             end
 
             context "with cancelled status" do
-              let(:govpay_status) { WasteCarriersEngine::Payment::STATUS_CANCELLED }
+              let(:govpay_status) { Payment::STATUS_CANCELLED }
 
               it_behaves_like "payment is unsuccessful but no error"
             end
 
             context "with failure status" do
-              let(:govpay_status) { WasteCarriersEngine::Payment::STATUS_FAILED }
+              let(:govpay_status) { Payment::STATUS_FAILED }
 
               it_behaves_like "payment is unsuccessful but no error"
             end
@@ -261,7 +261,7 @@ module WasteCarriersEngine
           context "with an invalid success status" do
             before { allow(GovpayValidatorService).to receive(:valid_govpay_status?).and_return(false) }
 
-            let(:govpay_status) { WasteCarriersEngine::Payment::STATUS_SUCCESS }
+            let(:govpay_status) { Payment::STATUS_SUCCESS }
 
             it_behaves_like "payment is unsuccessful with an error"
           end
@@ -269,7 +269,7 @@ module WasteCarriersEngine
           context "with an invalid failure status" do
             before { allow(GovpayValidatorService).to receive(:valid_govpay_status?).and_return(false) }
 
-            let(:govpay_status) { WasteCarriersEngine::Payment::STATUS_CANCELLED }
+            let(:govpay_status) { Payment::STATUS_CANCELLED }
 
             it_behaves_like "payment is unsuccessful with an error"
           end

--- a/spec/requests/waste_carriers_engine/govpay_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/govpay_forms_spec.rb
@@ -105,7 +105,7 @@ module WasteCarriersEngine
           end
 
           context "when govpay status is success" do
-            let(:govpay_status) { "success" }
+            let(:govpay_status) { WasteCarriersEngine::Payment::STATUS_SUCCESS }
 
             context "when the payment_uuid is valid and the balance is paid" do
 
@@ -177,7 +177,7 @@ module WasteCarriersEngine
 
               context "when the payment uuid is valid" do
                 before do
-                  order.update!(govpay_status: "created")
+                  order.update!(govpay_status: WasteCarriersEngine::Payment::STATUS_CREATED)
                 end
 
                 it "redirects to renewal_received_pending_govpay_payment_form" do
@@ -195,13 +195,13 @@ module WasteCarriersEngine
             end
 
             context "when govpay status is created" do
-              let(:govpay_status) { "created" }
+              let(:govpay_status) { WasteCarriersEngine::Payment::STATUS_CREATED }
 
               it_behaves_like "payment is pending"
             end
 
             context "when govpay status is submitted" do
-              let(:govpay_status) { "submitted" }
+              let(:govpay_status) { WasteCarriersEngine::Payment::STATUS_SUBMITTED }
 
               it_behaves_like "payment is pending"
             end
@@ -240,13 +240,13 @@ module WasteCarriersEngine
             end
 
             context "with cancelled status" do
-              let(:govpay_status) { "cancelled" }
+              let(:govpay_status) { WasteCarriersEngine::Payment::STATUS_CANCELLED }
 
               it_behaves_like "payment is unsuccessful but no error"
             end
 
             context "with failure status" do
-              let(:govpay_status) { "failed" }
+              let(:govpay_status) { WasteCarriersEngine::Payment::STATUS_FAILED }
 
               it_behaves_like "payment is unsuccessful but no error"
             end
@@ -261,7 +261,7 @@ module WasteCarriersEngine
           context "with an invalid success status" do
             before { allow(GovpayValidatorService).to receive(:valid_govpay_status?).and_return(false) }
 
-            let(:govpay_status) { "success" }
+            let(:govpay_status) { WasteCarriersEngine::Payment::STATUS_SUCCESS }
 
             it_behaves_like "payment is unsuccessful with an error"
           end
@@ -269,7 +269,7 @@ module WasteCarriersEngine
           context "with an invalid failure status" do
             before { allow(GovpayValidatorService).to receive(:valid_govpay_status?).and_return(false) }
 
-            let(:govpay_status) { "cancelled" }
+            let(:govpay_status) { WasteCarriersEngine::Payment::STATUS_CANCELLED }
 
             it_behaves_like "payment is unsuccessful with an error"
           end

--- a/spec/services/waste_carriers_engine/govpay_callback_service_spec.rb
+++ b/spec/services/waste_carriers_engine/govpay_callback_service_spec.rb
@@ -32,7 +32,7 @@ module WasteCarriersEngine
 
     describe "#payment_callback" do
 
-      before { allow(govpay_payment_details_service).to receive(:govpay_payment_status).and_return(WasteCarriersEngine::Payment::STATUS_CREATED) }
+      before { allow(govpay_payment_details_service).to receive(:govpay_payment_status).and_return(Payment::STATUS_CREATED) }
 
       context "when the status is valid" do
         it "returns true" do
@@ -41,12 +41,12 @@ module WasteCarriersEngine
 
         it "updates the payment status" do
           govpay_callback_service.valid_success?
-          expect(transient_registration.reload.finance_details.payments.first.govpay_payment_status).to eq(WasteCarriersEngine::Payment::STATUS_SUCCESS)
+          expect(transient_registration.reload.finance_details.payments.first.govpay_payment_status).to eq(Payment::STATUS_SUCCESS)
         end
 
         it "updates the order status" do
           govpay_callback_service.valid_success?
-          expect(transient_registration.reload.finance_details.orders.first.govpay_status).to eq(WasteCarriersEngine::Payment::STATUS_SUCCESS)
+          expect(transient_registration.reload.finance_details.orders.first.govpay_status).to eq(Payment::STATUS_SUCCESS)
         end
 
         it "updates the balance" do

--- a/spec/services/waste_carriers_engine/govpay_callback_service_spec.rb
+++ b/spec/services/waste_carriers_engine/govpay_callback_service_spec.rb
@@ -32,7 +32,7 @@ module WasteCarriersEngine
 
     describe "#payment_callback" do
 
-      before { allow(govpay_payment_details_service).to receive(:govpay_payment_status).and_return("created") }
+      before { allow(govpay_payment_details_service).to receive(:govpay_payment_status).and_return(WasteCarriersEngine::Payment::STATUS_CREATED) }
 
       context "when the status is valid" do
         it "returns true" do
@@ -41,12 +41,12 @@ module WasteCarriersEngine
 
         it "updates the payment status" do
           govpay_callback_service.valid_success?
-          expect(transient_registration.reload.finance_details.payments.first.govpay_payment_status).to eq("success")
+          expect(transient_registration.reload.finance_details.payments.first.govpay_payment_status).to eq(WasteCarriersEngine::Payment::STATUS_SUCCESS)
         end
 
         it "updates the order status" do
           govpay_callback_service.valid_success?
-          expect(transient_registration.reload.finance_details.orders.first.govpay_status).to eq("success")
+          expect(transient_registration.reload.finance_details.orders.first.govpay_status).to eq(WasteCarriersEngine::Payment::STATUS_SUCCESS)
         end
 
         it "updates the balance" do

--- a/spec/services/waste_carriers_engine/govpay_find_payment_service_spec.rb
+++ b/spec/services/waste_carriers_engine/govpay_find_payment_service_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe GovpayFindPaymentService do
+
+    describe "#run" do
+
+      subject(:run_service) { described_class.run(payment_id:) }
+
+      context "with an invalid payment id" do
+        let(:payment_id) { "bad_id" }
+
+        it "raises an exception" do
+          expect { run_service }.to raise_exception(ArgumentError)
+        end
+      end
+
+      context "with a valid payment id" do
+        let(:registration) { create(:registration, :has_required_data, finance_details: build(:finance_details, :has_overpaid_order_and_payment_govpay)) }
+        let(:payment) { registration.finance_details.payments.first }
+        let(:payment_id) { payment.govpay_id }
+
+        it "returns the payment" do
+          expect(run_service).to eq payment
+        end
+      end
+    end
+  end
+end

--- a/spec/services/waste_carriers_engine/govpay_payment_details_service_spec.rb
+++ b/spec/services/waste_carriers_engine/govpay_payment_details_service_spec.rb
@@ -71,13 +71,13 @@ module WasteCarriersEngine
             )
           end
 
-          it_behaves_like "expected status is returned", "created", "created"
+          it_behaves_like "expected status is returned", WasteCarriersEngine::Payment::STATUS_CREATED, WasteCarriersEngine::Payment::STATUS_CREATED
 
-          it_behaves_like "expected status is returned", "submitted", "submitted"
+          it_behaves_like "expected status is returned", WasteCarriersEngine::Payment::STATUS_SUBMITTED, WasteCarriersEngine::Payment::STATUS_SUBMITTED
 
-          it_behaves_like "expected status is returned", "success", "success"
+          it_behaves_like "expected status is returned", WasteCarriersEngine::Payment::STATUS_SUCCESS, WasteCarriersEngine::Payment::STATUS_SUCCESS
 
-          it_behaves_like "expected status is returned", "cancelled", "cancelled"
+          it_behaves_like "expected status is returned", WasteCarriersEngine::Payment::STATUS_CANCELLED, WasteCarriersEngine::Payment::STATUS_CANCELLED
 
           it_behaves_like "expected status is returned", "not_found", "error"
         end
@@ -106,7 +106,7 @@ module WasteCarriersEngine
             end
 
             it "returns created" do
-              expect(service.govpay_payment_status).to eq "created"
+              expect(service.govpay_payment_status).to eq WasteCarriersEngine::Payment::STATUS_CREATED
             end
           end
 
@@ -127,7 +127,7 @@ module WasteCarriersEngine
             end
 
             it "returns created" do
-              expect(service.govpay_payment_status).to eq "created"
+              expect(service.govpay_payment_status).to eq WasteCarriersEngine::Payment::STATUS_CREATED
             end
           end
         end
@@ -159,15 +159,15 @@ module WasteCarriersEngine
         end
       end
 
-      it_behaves_like "maps to the expected status", "created", :pending
+      it_behaves_like "maps to the expected status", WasteCarriersEngine::Payment::STATUS_CREATED, :pending
 
-      it_behaves_like "maps to the expected status", "submitted", :pending
+      it_behaves_like "maps to the expected status", WasteCarriersEngine::Payment::STATUS_SUBMITTED, :pending
 
-      it_behaves_like "maps to the expected status", "success", :success
+      it_behaves_like "maps to the expected status", WasteCarriersEngine::Payment::STATUS_SUCCESS, :success
 
-      it_behaves_like "maps to the expected status", "failed", :failure
+      it_behaves_like "maps to the expected status", WasteCarriersEngine::Payment::STATUS_FAILED, :failure
 
-      it_behaves_like "maps to the expected status", "cancelled", :cancel
+      it_behaves_like "maps to the expected status", WasteCarriersEngine::Payment::STATUS_CANCELLED, :cancel
 
       it_behaves_like "maps to the expected status", nil, :error
     end

--- a/spec/services/waste_carriers_engine/govpay_payment_details_service_spec.rb
+++ b/spec/services/waste_carriers_engine/govpay_payment_details_service_spec.rb
@@ -71,13 +71,13 @@ module WasteCarriersEngine
             )
           end
 
-          it_behaves_like "expected status is returned", WasteCarriersEngine::Payment::STATUS_CREATED, WasteCarriersEngine::Payment::STATUS_CREATED
+          it_behaves_like "expected status is returned", Payment::STATUS_CREATED, Payment::STATUS_CREATED
 
-          it_behaves_like "expected status is returned", WasteCarriersEngine::Payment::STATUS_SUBMITTED, WasteCarriersEngine::Payment::STATUS_SUBMITTED
+          it_behaves_like "expected status is returned", Payment::STATUS_SUBMITTED, Payment::STATUS_SUBMITTED
 
-          it_behaves_like "expected status is returned", WasteCarriersEngine::Payment::STATUS_SUCCESS, WasteCarriersEngine::Payment::STATUS_SUCCESS
+          it_behaves_like "expected status is returned", Payment::STATUS_SUCCESS, Payment::STATUS_SUCCESS
 
-          it_behaves_like "expected status is returned", WasteCarriersEngine::Payment::STATUS_CANCELLED, WasteCarriersEngine::Payment::STATUS_CANCELLED
+          it_behaves_like "expected status is returned", Payment::STATUS_CANCELLED, Payment::STATUS_CANCELLED
 
           it_behaves_like "expected status is returned", "not_found", "error"
         end
@@ -106,7 +106,7 @@ module WasteCarriersEngine
             end
 
             it "returns created" do
-              expect(service.govpay_payment_status).to eq WasteCarriersEngine::Payment::STATUS_CREATED
+              expect(service.govpay_payment_status).to eq Payment::STATUS_CREATED
             end
           end
 
@@ -127,7 +127,7 @@ module WasteCarriersEngine
             end
 
             it "returns created" do
-              expect(service.govpay_payment_status).to eq WasteCarriersEngine::Payment::STATUS_CREATED
+              expect(service.govpay_payment_status).to eq Payment::STATUS_CREATED
             end
           end
         end
@@ -159,15 +159,15 @@ module WasteCarriersEngine
         end
       end
 
-      it_behaves_like "maps to the expected status", WasteCarriersEngine::Payment::STATUS_CREATED, :pending
+      it_behaves_like "maps to the expected status", Payment::STATUS_CREATED, :pending
 
-      it_behaves_like "maps to the expected status", WasteCarriersEngine::Payment::STATUS_SUBMITTED, :pending
+      it_behaves_like "maps to the expected status", Payment::STATUS_SUBMITTED, :pending
 
-      it_behaves_like "maps to the expected status", WasteCarriersEngine::Payment::STATUS_SUCCESS, :success
+      it_behaves_like "maps to the expected status", Payment::STATUS_SUCCESS, :success
 
-      it_behaves_like "maps to the expected status", WasteCarriersEngine::Payment::STATUS_FAILED, :failure
+      it_behaves_like "maps to the expected status", Payment::STATUS_FAILED, :failure
 
-      it_behaves_like "maps to the expected status", WasteCarriersEngine::Payment::STATUS_CANCELLED, :cancel
+      it_behaves_like "maps to the expected status", Payment::STATUS_CANCELLED, :cancel
 
       it_behaves_like "maps to the expected status", nil, :error
     end

--- a/spec/services/waste_carriers_engine/govpay_update_refund_status_service_spec.rb
+++ b/spec/services/waste_carriers_engine/govpay_update_refund_status_service_spec.rb
@@ -17,7 +17,7 @@ module WasteCarriersEngine
       subject(:run_service) { described_class.new.run(registration:, refund_id:, new_status: refund_status) }
 
       context "when the refund status has not changed" do
-        let(:refund_status) { WasteCarriersEngine::Payment::STATUS_SUBMITTED }
+        let(:refund_status) { Payment::STATUS_SUBMITTED }
 
         it { expect(run_service).to be false }
         it { expect { run_service }.not_to change { refund.reload.govpay_payment_status } }
@@ -33,10 +33,10 @@ module WasteCarriersEngine
       end
 
       context "when the refund status has changed to success" do
-        let(:refund_status) { WasteCarriersEngine::Payment::STATUS_SUCCESS }
+        let(:refund_status) { Payment::STATUS_SUCCESS }
 
         it { expect(run_service).to be true }
-        it { expect { run_service }.to change { refund.reload.govpay_payment_status }.to(WasteCarriersEngine::Payment::STATUS_SUCCESS) }
+        it { expect { run_service }.to change { refund.reload.govpay_payment_status }.to(Payment::STATUS_SUCCESS) }
         it { expect { run_service }.to change { registration.reload.finance_details.balance }.by(-refund_amount) }
       end
     end

--- a/spec/services/waste_carriers_engine/govpay_update_refund_status_service_spec.rb
+++ b/spec/services/waste_carriers_engine/govpay_update_refund_status_service_spec.rb
@@ -17,7 +17,7 @@ module WasteCarriersEngine
       subject(:run_service) { described_class.new.run(registration:, refund_id:, new_status: refund_status) }
 
       context "when the refund status has not changed" do
-        let(:refund_status) { "submitted" }
+        let(:refund_status) { WasteCarriersEngine::Payment::STATUS_SUBMITTED }
 
         it { expect(run_service).to be false }
         it { expect { run_service }.not_to change { refund.reload.govpay_payment_status } }
@@ -33,10 +33,10 @@ module WasteCarriersEngine
       end
 
       context "when the refund status has changed to success" do
-        let(:refund_status) { "success" }
+        let(:refund_status) { WasteCarriersEngine::Payment::STATUS_SUCCESS }
 
         it { expect(run_service).to be true }
-        it { expect { run_service }.to change { refund.reload.govpay_payment_status }.to("success") }
+        it { expect { run_service }.to change { refund.reload.govpay_payment_status }.to(WasteCarriersEngine::Payment::STATUS_SUCCESS) }
         it { expect { run_service }.to change { registration.reload.finance_details.balance }.by(-refund_amount) }
       end
     end

--- a/spec/services/waste_carriers_engine/govpay_update_refund_status_service_spec.rb
+++ b/spec/services/waste_carriers_engine/govpay_update_refund_status_service_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe GovpayUpdateRefundStatusService do
+
+    describe "#run" do
+      let(:registration) { create(:registration, :has_required_data, finance_details: build(:finance_details, :has_overpaid_order_and_payment_govpay)) }
+      let(:payment) { registration.finance_details.payments.first }
+      let(:refund_amount) { payment.amount - 100 }
+      let(:refund) { build(:payment, :govpay_refund_pending, amount: refund_amount, refunded_payment_govpay_id: payment.govpay_id) }
+      let(:refund_id) { refund.govpay_id }
+
+      before { registration.finance_details.payments << refund }
+
+      subject(:run_service) { described_class.new.run(registration:, refund_id:, new_status: refund_status) }
+
+      context "when the refund status has not changed" do
+        let(:refund_status) { "submitted" }
+
+        it { expect(run_service).to be false }
+        it { expect { run_service }.not_to change { refund.reload.govpay_payment_status } }
+        it { expect { run_service }.not_to change { registration.reload.finance_details.balance } }
+      end
+
+      context "when the refund status has changed to error" do
+        let(:refund_status) { "error" }
+
+        it { expect(run_service).to be false }
+        it { expect { run_service }.not_to change { refund.reload.govpay_payment_status } }
+        it { expect { run_service }.not_to change { registration.reload.finance_details.balance } }
+      end
+
+      context "when the refund status has changed to success" do
+        let(:refund_status) { "success" }
+
+        it { expect(run_service).to be true }
+        it { expect { run_service }.to change { refund.reload.govpay_payment_status }.to("success") }
+        it { expect { run_service }.to change { registration.reload.finance_details.balance }.by(-refund_amount) }
+      end
+    end
+  end
+end

--- a/spec/services/waste_carriers_engine/govpay_validator_service_spec.rb
+++ b/spec/services/waste_carriers_engine/govpay_validator_service_spec.rb
@@ -40,7 +40,7 @@ module WasteCarriersEngine
     end
 
     describe "valid_success?" do
-      let(:govpay_status) { "success" }
+      let(:govpay_status) { WasteCarriersEngine::Payment::STATUS_SUCCESS }
 
       context "when the govpay status is valid" do
 
@@ -51,7 +51,7 @@ module WasteCarriersEngine
 
       context "when the govpay status is not valid" do
 
-        let(:govpay_status) { "failed" }
+        let(:govpay_status) { WasteCarriersEngine::Payment::STATUS_FAILED }
 
         it "returns false" do
           expect(govpay_validator_service.valid_success?).to be false
@@ -84,15 +84,15 @@ module WasteCarriersEngine
     end
 
     describe "valid_failure?" do
-      it_behaves_like "valid and invalid Govpay status", "valid_failure?", "failed"
+      it_behaves_like "valid and invalid Govpay status", "valid_failure?", WasteCarriersEngine::Payment::STATUS_FAILED
     end
 
     describe "valid_pending?" do
-      it_behaves_like "valid and invalid Govpay status", "valid_pending?", "created"
+      it_behaves_like "valid and invalid Govpay status", "valid_pending?", WasteCarriersEngine::Payment::STATUS_CREATED
     end
 
     describe "valid_cancel?" do
-      it_behaves_like "valid and invalid Govpay status", "valid_cancel?", "cancelled"
+      it_behaves_like "valid and invalid Govpay status", "valid_cancel?", WasteCarriersEngine::Payment::STATUS_CANCELLED
     end
 
     describe "valid_error?" do
@@ -101,7 +101,7 @@ module WasteCarriersEngine
 
     describe "valid_govpay_status?" do
       it "returns true when the status matches the values for the response type" do
-        expect(described_class.valid_govpay_status?(:success, "success")).to be true
+        expect(described_class.valid_govpay_status?(:success, WasteCarriersEngine::Payment::STATUS_SUCCESS)).to be true
       end
 
       it "returns false when the status does not match the values for the response type" do

--- a/spec/services/waste_carriers_engine/govpay_validator_service_spec.rb
+++ b/spec/services/waste_carriers_engine/govpay_validator_service_spec.rb
@@ -40,7 +40,7 @@ module WasteCarriersEngine
     end
 
     describe "valid_success?" do
-      let(:govpay_status) { WasteCarriersEngine::Payment::STATUS_SUCCESS }
+      let(:govpay_status) { Payment::STATUS_SUCCESS }
 
       context "when the govpay status is valid" do
 
@@ -51,7 +51,7 @@ module WasteCarriersEngine
 
       context "when the govpay status is not valid" do
 
-        let(:govpay_status) { WasteCarriersEngine::Payment::STATUS_FAILED }
+        let(:govpay_status) { Payment::STATUS_FAILED }
 
         it "returns false" do
           expect(govpay_validator_service.valid_success?).to be false
@@ -84,15 +84,15 @@ module WasteCarriersEngine
     end
 
     describe "valid_failure?" do
-      it_behaves_like "valid and invalid Govpay status", "valid_failure?", WasteCarriersEngine::Payment::STATUS_FAILED
+      it_behaves_like "valid and invalid Govpay status", "valid_failure?", Payment::STATUS_FAILED
     end
 
     describe "valid_pending?" do
-      it_behaves_like "valid and invalid Govpay status", "valid_pending?", WasteCarriersEngine::Payment::STATUS_CREATED
+      it_behaves_like "valid and invalid Govpay status", "valid_pending?", Payment::STATUS_CREATED
     end
 
     describe "valid_cancel?" do
-      it_behaves_like "valid and invalid Govpay status", "valid_cancel?", WasteCarriersEngine::Payment::STATUS_CANCELLED
+      it_behaves_like "valid and invalid Govpay status", "valid_cancel?", Payment::STATUS_CANCELLED
     end
 
     describe "valid_error?" do
@@ -101,7 +101,7 @@ module WasteCarriersEngine
 
     describe "valid_govpay_status?" do
       it "returns true when the status matches the values for the response type" do
-        expect(described_class.valid_govpay_status?(:success, WasteCarriersEngine::Payment::STATUS_SUCCESS)).to be true
+        expect(described_class.valid_govpay_status?(:success, Payment::STATUS_SUCCESS)).to be true
       end
 
       it "returns false when the status does not match the values for the response type" do

--- a/spec/services/waste_carriers_engine/govpay_webhook_payment_service_spec.rb
+++ b/spec/services/waste_carriers_engine/govpay_webhook_payment_service_spec.rb
@@ -50,7 +50,7 @@ module WasteCarriersEngine
 
           context "when the payment is found" do
             context "when the payment status has not changed" do
-              let(:prior_payment_status) { "submitted" }
+              let(:prior_payment_status) { WasteCarriersEngine::Payment::STATUS_SUBMITTED }
 
               it { expect { run_service }.not_to change(wcr_payment, :govpay_payment_status) }
 
@@ -66,14 +66,14 @@ module WasteCarriersEngine
               include_examples "Govpay webhook status transitions"
 
               # unfinished statuses
-              it_behaves_like "valid and invalid transitions", "created", %w[started submitted success failed cancelled error], %w[]
+              it_behaves_like "valid and invalid transitions", WasteCarriersEngine::Payment::STATUS_CREATED, %w[started submitted success failed cancelled error], %w[]
               it_behaves_like "valid and invalid transitions", "started", %w[submitted success failed cancelled error], %w[created]
-              it_behaves_like "valid and invalid transitions", "submitted", %w[success failed cancelled error], %w[started]
+              it_behaves_like "valid and invalid transitions", WasteCarriersEngine::Payment::STATUS_SUBMITTED, %w[success failed cancelled error], %w[started]
 
               # finished statuses
-              it_behaves_like "no valid transitions", "success"
-              it_behaves_like "no valid transitions", "failed"
-              it_behaves_like "no valid transitions", "cancelled"
+              it_behaves_like "no valid transitions", WasteCarriersEngine::Payment::STATUS_SUCCESS
+              it_behaves_like "no valid transitions", WasteCarriersEngine::Payment::STATUS_FAILED
+              it_behaves_like "no valid transitions", WasteCarriersEngine::Payment::STATUS_CANCELLED
               it_behaves_like "no valid transitions", "error"
             end
           end

--- a/spec/services/waste_carriers_engine/govpay_webhook_payment_service_spec.rb
+++ b/spec/services/waste_carriers_engine/govpay_webhook_payment_service_spec.rb
@@ -50,7 +50,7 @@ module WasteCarriersEngine
 
           context "when the payment is found" do
             context "when the payment status has not changed" do
-              let(:prior_payment_status) { WasteCarriersEngine::Payment::STATUS_SUBMITTED }
+              let(:prior_payment_status) { Payment::STATUS_SUBMITTED }
 
               it { expect { run_service }.not_to change(wcr_payment, :govpay_payment_status) }
 
@@ -66,14 +66,14 @@ module WasteCarriersEngine
               include_examples "Govpay webhook status transitions"
 
               # unfinished statuses
-              it_behaves_like "valid and invalid transitions", WasteCarriersEngine::Payment::STATUS_CREATED, %w[started submitted success failed cancelled error], %w[]
+              it_behaves_like "valid and invalid transitions", Payment::STATUS_CREATED, %w[started submitted success failed cancelled error], %w[]
               it_behaves_like "valid and invalid transitions", "started", %w[submitted success failed cancelled error], %w[created]
-              it_behaves_like "valid and invalid transitions", WasteCarriersEngine::Payment::STATUS_SUBMITTED, %w[success failed cancelled error], %w[started]
+              it_behaves_like "valid and invalid transitions", Payment::STATUS_SUBMITTED, %w[success failed cancelled error], %w[started]
 
               # finished statuses
-              it_behaves_like "no valid transitions", WasteCarriersEngine::Payment::STATUS_SUCCESS
-              it_behaves_like "no valid transitions", WasteCarriersEngine::Payment::STATUS_FAILED
-              it_behaves_like "no valid transitions", WasteCarriersEngine::Payment::STATUS_CANCELLED
+              it_behaves_like "no valid transitions", Payment::STATUS_SUCCESS
+              it_behaves_like "no valid transitions", Payment::STATUS_FAILED
+              it_behaves_like "no valid transitions", Payment::STATUS_CANCELLED
               it_behaves_like "no valid transitions", "error"
             end
           end

--- a/spec/services/waste_carriers_engine/govpay_webhook_refund_service_spec.rb
+++ b/spec/services/waste_carriers_engine/govpay_webhook_refund_service_spec.rb
@@ -17,9 +17,9 @@ module WasteCarriersEngine
         create(:payment, :govpay,
                finance_details: registration.finance_details,
                govpay_id: govpay_payment_id,
-               govpay_payment_status: "complete")
+               govpay_payment_status: WasteCarriersEngine::Payment::STATUS_COMPLETE)
       end
-      let(:prior_payment_status) { "submitted" }
+      let(:prior_payment_status) { WasteCarriersEngine::Payment::STATUS_SUBMITTED }
       let!(:wcr_payment) do
         create(:payment, :govpay_refund,
                finance_details: registration.finance_details,
@@ -60,7 +60,7 @@ module WasteCarriersEngine
 
           context "when the refund is found" do
             context "when the refund status has not changed" do
-              let(:prior_payment_status) { "success" }
+              let(:prior_payment_status) { WasteCarriersEngine::Payment::STATUS_SUCCESS }
 
               it { expect { run_service }.not_to change(wcr_payment, :govpay_payment_status) }
 
@@ -82,10 +82,10 @@ module WasteCarriersEngine
               include_examples "Govpay webhook status transitions"
 
               # unfinished statuses
-              it_behaves_like "valid and invalid transitions", "submitted", %w[success], %w[error]
+              it_behaves_like "valid and invalid transitions", WasteCarriersEngine::Payment::STATUS_SUBMITTED, %w[success], %w[error]
 
               # finished statuses
-              it_behaves_like "no valid transitions", "success"
+              it_behaves_like "no valid transitions", WasteCarriersEngine::Payment::STATUS_SUCCESS
               it_behaves_like "no valid transitions", "error"
             end
           end

--- a/spec/services/waste_carriers_engine/govpay_webhook_refund_service_spec.rb
+++ b/spec/services/waste_carriers_engine/govpay_webhook_refund_service_spec.rb
@@ -71,6 +71,12 @@ module WasteCarriersEngine
               end
             end
 
+            context "when the update service raises an exception" do
+              before { allow(WasteCarriersEngine::GovpayUpdateRefundStatusService).to receive(:run).and_raise(StandardError) }
+
+              it_behaves_like "logs an error"
+            end
+
             context "when the refund status has changed" do
 
               include_examples "Govpay webhook status transitions"

--- a/spec/services/waste_carriers_engine/govpay_webhook_refund_service_spec.rb
+++ b/spec/services/waste_carriers_engine/govpay_webhook_refund_service_spec.rb
@@ -17,9 +17,9 @@ module WasteCarriersEngine
         create(:payment, :govpay,
                finance_details: registration.finance_details,
                govpay_id: govpay_payment_id,
-               govpay_payment_status: WasteCarriersEngine::Payment::STATUS_COMPLETE)
+               govpay_payment_status: Payment::STATUS_COMPLETE)
       end
-      let(:prior_payment_status) { WasteCarriersEngine::Payment::STATUS_SUBMITTED }
+      let(:prior_payment_status) { Payment::STATUS_SUBMITTED }
       let!(:wcr_payment) do
         create(:payment, :govpay_refund,
                finance_details: registration.finance_details,
@@ -60,7 +60,7 @@ module WasteCarriersEngine
 
           context "when the refund is found" do
             context "when the refund status has not changed" do
-              let(:prior_payment_status) { WasteCarriersEngine::Payment::STATUS_SUCCESS }
+              let(:prior_payment_status) { Payment::STATUS_SUCCESS }
 
               it { expect { run_service }.not_to change(wcr_payment, :govpay_payment_status) }
 
@@ -82,10 +82,10 @@ module WasteCarriersEngine
               include_examples "Govpay webhook status transitions"
 
               # unfinished statuses
-              it_behaves_like "valid and invalid transitions", WasteCarriersEngine::Payment::STATUS_SUBMITTED, %w[success], %w[error]
+              it_behaves_like "valid and invalid transitions", Payment::STATUS_SUBMITTED, %w[success], %w[error]
 
               # finished statuses
-              it_behaves_like "no valid transitions", WasteCarriersEngine::Payment::STATUS_SUCCESS
+              it_behaves_like "no valid transitions", Payment::STATUS_SUCCESS
               it_behaves_like "no valid transitions", "error"
             end
           end


### PR DESCRIPTION
This change moves two govpay services from the back-office to the engine and uses them to process refund webhook calls.
https://eaflood.atlassian.net/browse/RUBY-3145