### PR TITLE
Fix/ruby 3330 duplicate text

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,7 +209,7 @@ GEM
       rake (>= 10.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    govuk_design_system_formbuilder (5.5.0)
+    govuk_design_system_formbuilder (5.6.0)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)

--- a/app/views/waste_carriers_engine/check_registered_company_name_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/check_registered_company_name_forms/new.html.erb
@@ -5,9 +5,6 @@
     <h1 class="govuk-heading-l">
       <%= t(".heading") %>
     </h1>
-    <legend class="govuk-visually-hidden">
-      <%= t(".heading") %>
-    </legend>
     
     <%= form_for @check_registered_company_name_form do |f| %>
       <%= render partial: "waste_carriers_engine/shared/error_summary", locals: { f: f } %>

--- a/app/views/waste_carriers_engine/check_your_answers_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/check_your_answers_forms/new.html.erb
@@ -19,7 +19,6 @@
     <% else %>
       <%= form_for(@check_your_answers_form) do |f| %>
         <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
-        <legend class="govuk-visually-hidden"><%= t(".heading") %></legend>
 
         <% if @presenter.new_registration? %>
           <p class="govuk-body"><%= t(".new_registration.#{@presenter.tier}") %></p>

--- a/app/views/waste_carriers_engine/company_address_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/company_address_forms/new.html.erb
@@ -11,9 +11,6 @@
       <h1 class="govuk-heading-l">
         <%= t(".heading.#{@company_address_form.business_type}") %>
       </h1>
-      <legend class="govuk-visually-hidden">
-        <%= t(".heading.#{@company_address_form.business_type}") %>
-      </legend>
 
       <p class="govuk-body">
         <%= t(".postcode_label") %>

--- a/app/views/waste_carriers_engine/company_address_manual_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/company_address_manual_forms/new.html.erb
@@ -16,9 +16,6 @@
       <h1 class="govuk-heading-l">
         <%= t(".heading.#{@company_address_manual_form.business_type}") %>
       </h1>
-      <legend class="govuk-visually-hidden">
-        <%= t(".heading.#{@company_address_manual_form.business_type}") %>
-      </legend>
 
 
       <% unless @company_address_manual_form.overseas? %>

--- a/app/views/waste_carriers_engine/company_postcode_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/company_postcode_forms/new.html.erb
@@ -9,9 +9,6 @@
         <%= t(".heading.#{@company_postcode_form.business_type}") %>
       </h1>
        <p class="govuk-body"><%= t(".page_hint") %></p>
-      <legend class="govuk-visually-hidden">
-        <%= t(".heading.#{@company_postcode_form.business_type}") %>
-      </legend>
       <%= f.govuk_text_field :temp_company_postcode,
           width: "one-half",
           label: {

--- a/app/views/waste_carriers_engine/contact_address_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/contact_address_forms/new.html.erb
@@ -9,9 +9,6 @@
       <h1 class="govuk-heading-l">
         <%= t(".heading") %>
       </h1>
-      <legend class="govuk-visually-hidden">
-        <%= t(".heading") %>
-      </legend>
 
       <p class="govuk-body">
         <%= t(".postcode_label") %>

--- a/app/views/waste_carriers_engine/contact_address_manual_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/contact_address_manual_forms/new.html.erb
@@ -15,10 +15,6 @@
       <h1 class="govuk-heading-l">
         <%= t(".heading") %>
       </h1>
-      <legend class="govuk-visually-hidden">
-        <%= t(".heading") %>
-      </legend>
-
 
       <% unless @contact_address_manual_form.overseas? %>
         <p class="govuk-body">

--- a/app/views/waste_carriers_engine/contact_email_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/contact_email_forms/new.html.erb
@@ -8,9 +8,6 @@
       <h1 class="govuk-heading-l">
         <%= t(".heading") %>
       </h1>
-      <legend class="govuk-visually-hidden">
-        <%= t(".heading") %>
-      </legend>
 
       <% if @transient_registration.upper_tier? %>
         <p class="govuk-body"><%= t(".paragraph_1") %></p>

--- a/app/views/waste_carriers_engine/contact_name_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/contact_name_forms/new.html.erb
@@ -8,9 +8,6 @@
       <h1 class="govuk-heading-l">
         <%= t(".heading") %>
       </h1>
-      <legend class="govuk-visually-hidden">
-        <%= t(".heading") %>
-      </legend>
 
       <p class="govuk-body"><%= t(".description") %></p>
 

--- a/app/views/waste_carriers_engine/contact_phone_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/contact_phone_forms/new.html.erb
@@ -8,9 +8,6 @@
       <h1 class="govuk-heading-l">
         <%= t(".heading") %>
       </h1>
-      <legend class="govuk-visually-hidden">
-        <%= t(".heading") %>
-      </legend>
 
       <%= f.govuk_text_field :phone_number,
           label: { text: t(".phone_number_label") },

--- a/app/views/waste_carriers_engine/contact_postcode_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/contact_postcode_forms/new.html.erb
@@ -7,9 +7,6 @@
       <h1 class="govuk-heading-l">
         <%= t(".heading") %>
       </h1>
-      <legend class="govuk-visually-hidden">
-        <%= t(".heading") %>
-      </legend>
 
       <p class="govuk-body">
         <%= t(".detail_paragraph") %>

--- a/app/views/waste_carriers_engine/conviction_details_forms/_form.html.erb
+++ b/app/views/waste_carriers_engine/conviction_details_forms/_form.html.erb
@@ -4,9 +4,6 @@
   <h1 class="govuk-heading-l">
     <%= t(".heading") %>
   </h1>
-  <legend class="govuk-visually-hidden">
-    <%= t(".heading") %>
-  </legend>
 
   <p class="govuk-body">
     <%= t(".paragraph_1") %>

--- a/app/views/waste_carriers_engine/deregistration_complete_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/deregistration_complete_forms/new.html.erb
@@ -12,9 +12,6 @@
     <h1 class="govuk-heading-l">
       <%= t(".heading", reg_id: @transient_registration.reg_identifier) %>
     </h1>
-    <legend class="govuk-visually-hidden">
-      <%= t(".heading", reg_id: @transient_registration.reg_identifier) %>
-    </legend>
 
     <h2 class="govuk-heading-m"><%= t(".subheading_1") %></h2>
     

--- a/app/views/waste_carriers_engine/incorrect_company_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/incorrect_company_forms/new.html.erb
@@ -8,9 +8,6 @@
       <h1 class="govuk-heading-l">
         <%= t(".heading") %>
       </h1>
-      <legend class="govuk-visually-hidden">
-        <%= t(".heading") %>
-      </legend>
 
       <p class="govuk-body"><%= t(".description") %></p>
 

--- a/app/views/waste_carriers_engine/invalid_company_status_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/invalid_company_status_forms/new.html.erb
@@ -8,9 +8,6 @@
       <h1 class="govuk-heading-l">
         <%= t(".heading", ch_number: @transient_registration.company_no) %>
       </h1>
-      <legend class="govuk-visually-hidden">
-        <%= t(".heading", ch_number: @transient_registration.company_no) %>
-      </legend>
 
       <p class="govuk-body"><%= t(".description") %></p>
 

--- a/app/views/waste_carriers_engine/main_people_forms/_form.html.erb
+++ b/app/views/waste_carriers_engine/main_people_forms/_form.html.erb
@@ -5,9 +5,6 @@
   <h1 class="govuk-heading-l">
     <%= t(".heading.#{@main_people_form.business_type}") %>
   </h1>
-  <legend class="govuk-visually-hidden">
-    <%= t(".heading.#{@main_people_form.business_type}") %>
-  </legend>
 
   <p class="govuk-body">
     <%= t(".description_1.#{@main_people_form.business_type}") %>

--- a/app/views/waste_carriers_engine/must_register_in_scotland_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/must_register_in_scotland_forms/new.html.erb
@@ -3,7 +3,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for(@must_register_in_scotland_form) do |f| %>
-      <legend class="govuk-visually-hidden"><%= t(".heading") %></legend>
       <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
       <p class="govuk-body"><%= t(".paragraph_1") %></p>
       <p class="govuk-body"><%= t(".paragraph_2") %> <a href="https://www.sepa.org.uk/regulations/waste/waste-carriers-and-brokers/"><%= t(".service_link") %></a>.</p>

--- a/app/views/waste_carriers_engine/must_register_in_wales_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/must_register_in_wales_forms/new.html.erb
@@ -3,7 +3,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for(@must_register_in_wales_form) do |f| %>
-      <legend class="govuk-visually-hidden"><%= t(".heading") %></legend>
       <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
       <p class="govuk-body"><%= t(".paragraph_1") %></p>
       <p class="govuk-body"><%= t(".paragraph_2") %> <a href="https://naturalresourceswales.gov.uk/permits-and-permissions/waste-permitting/register-as-a-waste-carrier-broker-or-dealer/"><%= t(".service_link") %></a>.</p>

--- a/app/views/waste_carriers_engine/register_in_northern_ireland_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/register_in_northern_ireland_forms/new.html.erb
@@ -3,7 +3,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for(@register_in_northern_ireland_form) do |f| %>
-      <legend class="govuk-visually-hidden"><%= t(".heading") %></legend>
       <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
       <p class="govuk-body"><%= t(".paragraph_1_1") %>
       <a href="https://www.daera-ni.gov.uk/articles/registration-carriers-and-brokers">

--- a/app/views/waste_carriers_engine/register_in_scotland_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/register_in_scotland_forms/new.html.erb
@@ -3,7 +3,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for(@register_in_scotland_form) do |f| %>
-      <legend class="govuk-visually-hidden"><%= t(".heading") %></legend>
       <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
       <p class="govuk-body"><%= t(".paragraph_1") %></p>
       <p class="govuk-body"><%= t(".paragraph_2") %> <a href="https://www.sepa.org.uk/regulations/waste/waste-carriers-and-brokers/"><%= t(".service_link") %></a>.</p>

--- a/app/views/waste_carriers_engine/register_in_wales_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/register_in_wales_forms/new.html.erb
@@ -3,7 +3,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for(@register_in_wales_form) do |f| %>
-      <legend class="govuk-visually-hidden"><%= t(".heading") %></legend>
       <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
       <p class="govuk-body"><%= t(".paragraph_1") %></p>
       <p class="govuk-body"><%= t(".paragraph_2") %> <a href="https://naturalresourceswales.gov.uk/permits-and-permissions/waste-permitting/register-as-a-waste-carrier-broker-or-dealer/"><%= t(".service_link") %></a>.</p>

--- a/app/views/waste_carriers_engine/registration_number_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/registration_number_forms/new.html.erb
@@ -9,9 +9,6 @@
       <h1 class="govuk-heading-l">
         <%= t(".heading.#{@registration_number_form.business_type}") %>
       </h1>
-      <span class="govuk-visually-hidden">
-        <%= t(".heading.#{@registration_number_form.business_type}") %>
-      </span>
 
       <%= f.govuk_text_field :company_no,
           label: { text: t(".company_no_label") },

--- a/app/views/waste_carriers_engine/renew_registration_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/renew_registration_forms/new.html.erb
@@ -8,9 +8,6 @@
       <h1 class="govuk-heading-l">
         <%= t(".heading") %>
       </h1>
-      <legend class="govuk-visually-hidden">
-        <%= t(".heading") %>
-      </legend>
 
       <%= f.govuk_text_field :temp_lookup_number,
           width: "one-half",

--- a/app/views/waste_carriers_engine/use_trading_name_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/use_trading_name_forms/new.html.erb
@@ -5,9 +5,6 @@
     <h1 class="govuk-heading-l">
       <%= t(".heading") %>
     </h1>
-    <legend class="govuk-visually-hidden">
-      <%= t(".heading") %>
-    </legend>
     
     <%= form_for @use_trading_name_form do |f| %>
       <%= render partial: "waste_carriers_engine/shared/error_summary", locals: { f: f } %>

--- a/app/views/waste_carriers_engine/your_tier_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/your_tier_forms/new.html.erb
@@ -7,9 +7,6 @@
       <h1 class="govuk-heading-l">
         <%= t(".heading.#{@transient_registration.tier}") %>
       </h1>
-      <legend class="govuk-visually-hidden">
-        <%= t(".heading.#{@transient_registration.tier}") %></h1>
-      </legend>
       <p class="govuk-body">
         <%= t(".paragraph_1.#{@transient_registration.tier}") %>
       </p>

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -23,7 +23,6 @@
 <% end %>
 
 <% content_for :footer do %>
-  <span class="govuk-visually-hidden"><%= ".support_text" %></span>
   <p class="govuk-!-font-weight-bold"><%= ".support_text" %></p>
   <ul class="govuk-footer__inline-list">
     <li class="govuk-footer__inline-list-item">


### PR DESCRIPTION
This change removes redundant govuk-visually-hidden text which was causing screen readers to call out duplicate values.
https://eaflood.atlassian.net/browse/RUBY-3330