### PR TITLE
Revert "[RUBY-3387] Remove `govpay_status` field from `Order` model and refactor related methods (#1566)"

### DIFF
--- a/app/models/waste_carriers_engine/order.rb
+++ b/app/models/waste_carriers_engine/order.rb
@@ -19,6 +19,7 @@ module WasteCarriersEngine
     field :dateCreated, as: :date_created,           type: DateTime
     field :worldPayStatus, as: :world_pay_status,    type: String
     field :govpayId, as: :govpay_id,                 type: String
+    field :govpayStatus, as: :govpay_status,         type: String
     field :dateLastUpdated, as: :date_last_updated,  type: DateTime
     field :updatedByUser, as: :updated_by_user,      type: String
     field :description,                              type: String
@@ -41,19 +42,13 @@ module WasteCarriersEngine
       order
     end
 
-    def govpay_status
-      return nil unless govpay_id
-
-      payment = finance_details.payments.find_by(govpay_id: govpay_id)
-      payment&.govpay_payment_status
-    end
-
     def add_bank_transfer_attributes
       self.payment_method = "OFFLINE"
     end
 
     def add_govpay_attributes
       self.payment_method = "ONLINE"
+      self.govpay_status = "IN_PROGRESS"
     end
 
     def generate_id
@@ -64,7 +59,9 @@ module WasteCarriersEngine
       self.description = generate_description
     end
 
-    def update_after_online_payment
+    def update_after_online_payment(status, govpay_id = nil)
+      self.govpay_status = status
+      self.govpay_id = govpay_id if govpay_id
       self.date_last_updated = Time.current
       save!
     end

--- a/app/services/waste_carriers_engine/govpay_callback_service.rb
+++ b/app/services/waste_carriers_engine/govpay_callback_service.rb
@@ -54,12 +54,12 @@ module WasteCarriersEngine
     def valid_unsuccessful_payment?(validation_method)
       return false unless govpay_response_validator(@payment_status).public_send(validation_method)
 
-      @order.update_after_online_payment
+      @order.update_after_online_payment(@payment_status)
       true
     end
 
     def update_payment_data
-      @order.update_after_online_payment
+      @order.update_after_online_payment(Payment::STATUS_SUCCESS)
       payment = Payment.new_from_online_payment(@order, user_email)
       payment.update_after_online_payment(
         govpay_status: Payment::STATUS_SUCCESS,

--- a/spec/factories/finance_details.rb
+++ b/spec/factories/finance_details.rb
@@ -17,17 +17,7 @@ FactoryBot.define do
     trait :has_pending_govpay_order do
       has_required_data
 
-      transient do
-        govpay_id { SecureRandom.hex(22) }
-      end
-
-      orders do
-        [build(:order, :has_required_data, govpay_id: govpay_id)]
-      end
-
-      payments do
-        [build(:payment, :govpay, govpay_id: govpay_id, govpay_payment_status: WasteCarriersEngine::Payment::STATUS_CREATED)]
-      end
+      orders { [build(:order, :has_pending_govpay_status)] }
     end
 
     trait :has_order do

--- a/spec/factories/order.rb
+++ b/spec/factories/order.rb
@@ -12,6 +12,12 @@ FactoryBot.define do
       total_amount { order_items.sum { |item| item[:amount] } }
     end
 
+    trait :has_pending_govpay_status do
+      has_required_data
+
+      govpay_status { WasteCarriersEngine::Payment::STATUS_CREATED }
+    end
+
     trait :has_copy_cards_item do
       date_created { Time.now }
 

--- a/spec/factories/payment.rb
+++ b/spec/factories/payment.rb
@@ -11,13 +11,6 @@ FactoryBot.define do
 
     trait :govpay do
       payment_type { "GOVPAY" }
-      govpay_id { SecureRandom.hex(22) }
-    end
-
-    trait :govpay_pending do
-      payment_type { "GOVPAY" }
-      govpay_id { SecureRandom.hex(22) }
-      govpay_payment_status { WasteCarriersEngine::Payment::STATUS_SUBMITTED }
     end
 
     trait :bank_transfer do

--- a/spec/models/waste_carriers_engine/new_registration_workflow/govpay_form_spec.rb
+++ b/spec/models/waste_carriers_engine/new_registration_workflow/govpay_form_spec.rb
@@ -19,9 +19,7 @@ module WasteCarriersEngine
           end
 
           context "when there is a pending govpay payment" do
-            let(:finance_details) { build(:finance_details, :has_pending_govpay_order) }
-
-            subject { create(:new_registration, :has_pending_govpay_status, finance_details: finance_details, workflow_state: "govpay_form") }
+            subject { build(:new_registration, :has_pending_govpay_status, workflow_state: "govpay_form") }
 
             include_examples "has next transition", next_state: "registration_received_pending_govpay_payment_form"
           end

--- a/spec/models/waste_carriers_engine/order_spec.rb
+++ b/spec/models/waste_carriers_engine/order_spec.rb
@@ -17,12 +17,17 @@ module WasteCarriersEngine
       let(:finance_details) { transient_registration.prepare_for_payment(:govpay, current_user) }
       let(:order) { finance_details.orders.first }
 
+      it "copies the govpay status to the order" do
+        order.update_after_online_payment(Payment::STATUS_CREATED)
+        expect(order.govpay_status).to eq(Payment::STATUS_CREATED)
+      end
+
       it "updates the date_last_updated" do
         Timecop.freeze(Time.new(2004, 8, 15, 16, 23, 42)) do
           # Wipe the date first so we know the value has been added
           order.update_attributes(date_last_updated: nil)
 
-          order.update_after_online_payment
+          order.update_after_online_payment(Payment::STATUS_CREATED)
           expect(order.date_last_updated).to eq(Time.new(2004, 8, 15, 16, 23, 42))
         end
       end
@@ -44,43 +49,6 @@ module WasteCarriersEngine
         it "returns the existing uuid" do
           uuid = order.payment_uuid
           expect(order.payment_uuid).to eq uuid
-        end
-      end
-
-      describe "#govpay_status" do
-        let(:order) { build(:order) }
-
-        context "when govpay_id is nil" do
-          before { order.govpay_id = nil }
-
-          it "returns nil" do
-            expect(order.govpay_status).to be_nil
-          end
-        end
-
-        context "when govpay_id is present" do
-          let(:transient_registration) { create(:new_registration, :has_required_data, finance_details: build(:finance_details, :has_pending_govpay_order)) }
-          let(:govpay_id) { transient_registration.finance_details.payments.first.govpay_id }
-          let(:order) { transient_registration.finance_details.orders.first }
-
-          context "when associated payment exists" do
-            let(:payment) { transient_registration.finance_details.payments.first }
-
-            it "returns the govpay_payment_status of the associated payment" do
-              expect(order.govpay_status).to eq(payment.govpay_payment_status)
-
-            end
-          end
-
-          context "when associated payment does not exist" do
-            before do
-              transient_registration.finance_details.orders = [build(:order, :has_required_data, govpay_id: "1234")]
-            end
-
-            it "returns nil" do
-              expect(order.govpay_status).to be_nil
-            end
-          end
         end
       end
     end

--- a/spec/models/waste_carriers_engine/payment_spec.rb
+++ b/spec/models/waste_carriers_engine/payment_spec.rb
@@ -214,6 +214,10 @@ module WasteCarriersEngine
         end
       end
 
+      it "updates the payment status" do
+        expect(payment.govpay_payment_status).to eq(Payment::STATUS_CREATED)
+      end
+
       it "updates the payment date_received" do
         expect(payment.date_received).to eq(Date.new(2018, 3, 4))
       end

--- a/spec/requests/waste_carriers_engine/govpay_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/govpay_forms_spec.rb
@@ -177,11 +177,7 @@ module WasteCarriersEngine
 
               context "when the payment uuid is valid" do
                 before do
-                  govpay_id = SecureRandom.hex(22)
-                  order.update!(govpay_id: govpay_id)
-                  payment = build(:payment, amount: order.total_amount, govpay_payment_status: Payment::STATUS_CREATED, govpay_id: govpay_id)
-                  transient_registration.finance_details.payments = [payment]
-                  transient_registration.finance_details.save
+                  order.update!(govpay_status: Payment::STATUS_CREATED)
                 end
 
                 it "redirects to renewal_received_pending_govpay_payment_form" do

--- a/spec/support/shared_examples/build_finance_details.rb
+++ b/spec/support/shared_examples/build_finance_details.rb
@@ -51,6 +51,10 @@ module WasteCarriersEngine
         it "has the correct payment_method" do
           expect(order.payment_method).to eq("ONLINE")
         end
+
+        it "has the correct govpay_status" do
+          expect(order.govpay_status).to eq("IN_PROGRESS")
+        end
       end
 
       context "when it is a bank transfer order" do


### PR DESCRIPTION
This reverts commit f862b77f7b1c3cf5f878879b9aa2d91bd2a9c8ef.
