### PR TITLE
RUBY 3459 wcr payment not found for webhook payment id

### DIFF
--- a/app/jobs/waste_carriers_engine/govpay_webhook_job.rb
+++ b/app/jobs/waste_carriers_engine/govpay_webhook_job.rb
@@ -31,13 +31,10 @@ module WasteCarriersEngine
     def sanitize_webhook_body(body)
       return body unless body.is_a?(Hash)
 
-      # Deep clone the hash to avoid modifying the original
       sanitized = body.deep_dup
 
-      # Remove PII fields if they exist
       if sanitized["resource"].is_a?(Hash)
-        # Remove email and card details
-        sanitized["resource"].delete("email_address")
+        sanitized["resource"].delete("email")
         sanitized["resource"].delete("card_details")
       end
 


### PR DESCRIPTION
- [RUBY-3459] Enhance error logging and sanitization in `GovpayWebhookJob`
- [RUBY-3459] Improve error handling in `GovpayWebhookJob` with conditional logging


[RUBY-3459]: https://eaflood.atlassian.net/browse/RUBY-3459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RUBY-3459]: https://eaflood.atlassian.net/browse/RUBY-3459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ