### PR TITLE
Add `logger` require statement to `engine.rb` in WasteCarriersEngine

### DIFF
--- a/lib/waste_carriers_engine/engine.rb
+++ b/lib/waste_carriers_engine/engine.rb
@@ -8,6 +8,7 @@ require "defra_ruby/address"
 require "defra_ruby/alert"
 require "defra_ruby_email"
 require "defra_ruby_validators"
+require "logger"
 
 module WasteCarriersEngine
   class Engine < ::Rails::Engine


### PR DESCRIPTION
This change ensures that the Logger library is available for use within the engine, addressing any issues related to missing logging functionality.
