### PR TITLE
Fix/ruby 3459 payment callbacks

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -177,9 +177,7 @@ module WasteCarriersEngine
       end
 
       def pending_online_payment?
-        return false unless finance_details.present? &&
-                            finance_details.orders.present? &&
-                            finance_details.orders.first.present?
+        return false unless finance_details&.orders&.first.present?
 
         GovpayValidatorService.valid_govpay_status?(:pending, finance_details.orders.first.govpay_status)
       end

--- a/app/services/waste_carriers_engine/govpay_callback_service.rb
+++ b/app/services/waste_carriers_engine/govpay_callback_service.rb
@@ -28,7 +28,7 @@ module WasteCarriersEngine
                             "payment status #{@payment_status}"
 
         case payment_status
-        when :success
+        when :success, :pending
           update_payment_data
         else
           update_order_status
@@ -58,7 +58,7 @@ module WasteCarriersEngine
       DetailedLogger.warn "Creating payment after online payment"
       payment = Payment.new_from_online_payment(@order, user_email)
       payment.update_after_online_payment(
-        govpay_status: Payment::STATUS_SUCCESS,
+        govpay_status: @payment_status,
         govpay_id: @order.govpay_id
       )
       @transient_registration.finance_details.update_balance

--- a/app/services/waste_carriers_engine/govpay_webhook_payment_service.rb
+++ b/app/services/waste_carriers_engine/govpay_webhook_payment_service.rb
@@ -17,6 +17,8 @@ module WasteCarriersEngine
 
     def update_payment_or_refund_status
       wcr_payment.update(govpay_payment_status: webhook_payment_or_refund_status)
+      wcr_payment.finance_details.update_balance
+      wcr_payment.finance_details.registration.save!
 
       Rails.logger.info "Updated status from #{previous_status} to #{webhook_payment_or_refund_status} " \
                         "for #{log_webhook_context}"

--- a/spec/services/waste_carriers_engine/govpay_callback_service_spec.rb
+++ b/spec/services/waste_carriers_engine/govpay_callback_service_spec.rb
@@ -5,11 +5,10 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe GovpayCallbackService do
-    let(:govpay_host) { "https://publicapi.payments.service.gov.uk" }
-    let(:payment_uuid) { order.payment_uuid }
-    let(:action) { "success" }
-    let(:govpay_callback_service) { described_class.new(payment_uuid, action) }
+    let(:govpay_callback_service) { described_class.new(payment_uuid, govpay_payment_status) }
+
     let(:govpay_payment_details_service) { instance_double(GovpayPaymentDetailsService) }
+    let(:payment_uuid) { order.payment_uuid }
     let(:transient_registration) do
       create(:renewing_registration,
              :has_required_data,
@@ -18,24 +17,22 @@ module WasteCarriersEngine
              temp_cards: 0)
     end
     let(:order) { transient_registration.finance_details.orders.first }
-    let(:govpay_validator_service) { instance_double(GovpayValidatorService) }
 
     before do
       allow(GovpayPaymentDetailsService).to receive(:new).and_return(govpay_payment_details_service)
-      allow(GovpayValidatorService).to receive(:new).and_return(govpay_validator_service)
-      allow(Rails.configuration).to receive(:govpay_url).and_return(govpay_host)
       allow(Rails.configuration).to receive(:renewal_charge).and_return(10_500)
       transient_registration.prepare_for_payment(:govpay)
       order.govpay_id = "a_govpay_id"
       order.save!
-      allow(govpay_payment_details_service).to receive(:govpay_payment_status).and_return(Payment::STATUS_CREATED)
     end
 
     describe "#process_payment" do
-      context "when the response is valid" do
-        before do
-          allow(govpay_validator_service).to receive(:valid_success?).and_return(true)
-        end
+
+      before do
+        allow(govpay_payment_details_service).to receive(:govpay_payment_status).and_return(govpay_payment_status)
+      end
+
+      shared_examples "a valid response" do
 
         it "returns true" do
           expect(govpay_callback_service.process_payment).to be true
@@ -43,17 +40,12 @@ module WasteCarriersEngine
 
         it "updates the payment status" do
           govpay_callback_service.process_payment
-          expect(transient_registration.reload.finance_details.payments.first.govpay_payment_status).to eq(Payment::STATUS_SUCCESS)
+          expect(transient_registration.reload.finance_details.payments.first.govpay_payment_status).to eq(govpay_payment_status)
         end
 
         it "updates the order status" do
           govpay_callback_service.process_payment
-          expect(transient_registration.reload.finance_details.orders.first.govpay_status).to eq(Payment::STATUS_SUCCESS)
-        end
-
-        it "updates the balance" do
-          govpay_callback_service.process_payment
-          expect(transient_registration.reload.finance_details.balance).to eq(0)
+          expect(transient_registration.reload.finance_details.orders.first.govpay_status).to eq(govpay_payment_status)
         end
 
         context "when run in the front office" do
@@ -81,11 +73,47 @@ module WasteCarriersEngine
         end
       end
 
+      context "when the response is valid" do
+        context "when the govpay status is 'created'" do
+          let(:govpay_payment_status) { Payment::STATUS_CREATED }
+
+          it_behaves_like "a valid response"
+
+          it "does not update the balance" do
+            expect { govpay_callback_service.process_payment }
+              .not_to change { transient_registration.reload.finance_details.balance }
+          end
+        end
+
+        context "when the govpay status is 'started'" do
+          let(:govpay_payment_status) { Payment::STATUS_STARTED }
+
+          it_behaves_like "a valid response"
+
+          it "does not update the balance" do
+            expect { govpay_callback_service.process_payment }
+              .not_to change { transient_registration.reload.finance_details.balance }
+          end
+        end
+
+        context "when the govpay status is 'success'" do
+          let(:govpay_payment_status) { Payment::STATUS_SUCCESS }
+
+          it_behaves_like "a valid response"
+
+          it "updates the balance" do
+            expect { govpay_callback_service.process_payment }
+              .to change { transient_registration.reload.finance_details.balance }.to(0)
+          end
+        end
+      end
+
       context "when the response is invalid" do
         let(:payment_uuid) { "invalid_uuid" }
+        let(:govpay_payment_status) { "started" }
 
         before do
-          allow(govpay_validator_service).to receive(:valid_success?).and_return(false)
+          allow(govpay_payment_details_service).to receive(:govpay_payment_status)
         end
 
         it "returns false" do
@@ -101,23 +129,6 @@ module WasteCarriersEngine
         it "does not create a payment" do
           govpay_callback_service.process_payment
           expect(transient_registration.reload.finance_details.payments.count).to eq(0)
-        end
-      end
-
-      context "when the action is not success" do
-        let(:action) { "failure" }
-
-        before do
-          allow(govpay_validator_service).to receive(:valid_failure?).and_return(true)
-        end
-
-        it "returns true" do
-          expect(govpay_callback_service.process_payment).to be true
-        end
-
-        it "updates only the order status" do
-          govpay_callback_service.process_payment
-          expect(transient_registration.reload.finance_details.payments).to be_empty
         end
       end
     end

--- a/spec/services/waste_carriers_engine/govpay_webhook_refund_service_spec.rb
+++ b/spec/services/waste_carriers_engine/govpay_webhook_refund_service_spec.rb
@@ -30,6 +30,9 @@ module WasteCarriersEngine
 
       let(:update_refund_service) { instance_double(WasteCarriersEngine::GovpayUpdateRefundStatusService) }
 
+      # # Make finance details refundable
+      # before { registration.finance_details.orders.first.update(total_amount: 1) }
+
       include_examples "Govpay webhook services error logging"
 
       shared_examples "failed refund update" do
@@ -87,6 +90,19 @@ module WasteCarriersEngine
               # finished statuses
               it_behaves_like "no valid transitions", Payment::STATUS_SUCCESS
               it_behaves_like "no valid transitions", "error"
+
+              # There are no valid transitions other than to success other than to success.
+              # context "when the webhook changes the status to a non-success value" do
+
+              context "when the webhook changes the status to success" do
+                let(:prior_payment_status) { Payment::STATUS_SUBMITTED }
+
+                before { assign_webhook_status("success") }
+
+                it "updates the balance" do
+                  expect { run_service }.to change { wcr_payment.finance_details.reload.balance }
+                end
+              end
             end
           end
         end


### PR DESCRIPTION
This change fixes two defects:
1. Payments were not being created in the system when a valid govpay payment callback indicated that the payment had a pending status.
2. Payment balance was not being updated when a valid govpay webhook callback updated payment status to "success".
https://eaflood.atlassian.net/browse/RUBY-3459
