### PR TITLE
Remove redundant logging

### DIFF
--- a/app/jobs/waste_carriers_engine/govpay_webhook_job.rb
+++ b/app/jobs/waste_carriers_engine/govpay_webhook_job.rb
@@ -6,9 +6,9 @@ module WasteCarriersEngine
   class GovpayWebhookJob < ApplicationJob
     def perform(webhook_body)
       if webhook_body["resource_type"]&.downcase == "payment"
-        process_payment_webhook(webhook_body)
+        GovpayPaymentWebhookHandler.run(webhook_body)
       elsif webhook_body["refund_id"].present?
-        process_refund_webhook(webhook_body)
+        GovpayRefundWebhookHandler.run(webhook_body)
       else
         raise ArgumentError, "Unrecognised Govpay webhook type"
       end
@@ -17,18 +17,6 @@ module WasteCarriersEngine
     end
 
     private
-
-    def process_payment_webhook(webhook_body)
-      result = GovpayPaymentWebhookHandler.run(webhook_body)
-
-      Rails.logger.info "Processed payment webhook for payment_id: #{result[:id]}, status: #{result[:status]}"
-    end
-
-    def process_refund_webhook(webhook_body)
-      result = GovpayRefundWebhookHandler.run(webhook_body)
-
-      Rails.logger.info "Processed refund webhook for refund_id: #{result[:id]}, status: #{result[:status]}"
-    end
 
     def sanitize_webhook_body(body)
       DefraRubyGovpay::WebhookSanitizerService.call(body)

--- a/spec/jobs/waste_carriers_engine/govpay_webhook_job_spec.rb
+++ b/spec/jobs/waste_carriers_engine/govpay_webhook_job_spec.rb
@@ -41,7 +41,6 @@ module WasteCarriersEngine
         allow(FeatureToggle).to receive(:active?).with(:detailed_logging)
         allow(GovpayPaymentWebhookHandler).to receive(:run).and_return(payment_service_result)
         allow(GovpayRefundWebhookHandler).to receive(:run).and_return(refund_service_result)
-        allow(Rails.logger).to receive(:info)
       end
 
       context "when handling errors" do
@@ -146,11 +145,6 @@ module WasteCarriersEngine
           perform_now
           expect(GovpayPaymentWebhookHandler).to have_received(:run).with(webhook_body)
         end
-
-        it "logs the payment webhook processing" do
-          perform_now
-          expect(Rails.logger).to have_received(:info).with(/Processed payment webhook for payment_id: hu20sqlact5260q2nanm0q8u93, status:/)
-        end
       end
 
       context "with a refund webhook" do
@@ -160,11 +154,6 @@ module WasteCarriersEngine
         it "processes the refund webhook using GovpayRefundWebhookHandler" do
           perform_now
           expect(GovpayRefundWebhookHandler).to have_received(:run).with(webhook_body)
-        end
-
-        it "logs the refund webhook processing" do
-          perform_now
-          expect(Rails.logger).to have_received(:info).with(/Processed refund webhook for refund_id: 345, status:/)
         end
       end
     end


### PR DESCRIPTION
This change removes some redundant and broken logging which was causing errors while processing govpay webhooks.
https://eaflood.atlassian.net/browse/RUBY-3819
