### PR TITLE
fix/RUBY-3819_payment_webhook_reg_activation

### DIFF
--- a/app/services/waste_carriers_engine/govpay_payment_webhook_handler.rb
+++ b/app/services/waste_carriers_engine/govpay_payment_webhook_handler.rb
@@ -56,6 +56,8 @@ module WasteCarriersEngine
       return unless webhook_payment_status == "success"
 
       case registration
+      when WasteCarriersEngine::Registration
+        RegistrationActivationService.run(registration:)
       when WasteCarriersEngine::NewRegistration
         RegistrationCompletionService.run(registration)
       when WasteCarriersEngine::RenewingRegistration

--- a/spec/services/waste_carriers_engine/govpay_payment_webhook_handler_spec.rb
+++ b/spec/services/waste_carriers_engine/govpay_payment_webhook_handler_spec.rb
@@ -21,17 +21,21 @@ module WasteCarriersEngine
                govpay_payment_status: prior_payment_status)
       end
 
+      before { allow(WasteCarriersEngine::RegistrationConfirmationService).to receive(:run) }
+
       include_examples "Govpay webhook services error logging"
 
-      context "when the update is not for a payment" do
-        before { webhook_body["resource_type"] = "refund" }
+      describe "invalid webhook errors" do
+        include_examples "Govpay webhook services error logging"
 
-        it { expect { run_service }.to raise_error(ArgumentError) }
+        context "when the update is not for a payment" do
+          before { webhook_body["resource_type"] = "refund" }
 
-        it_behaves_like "logs an error"
-      end
+          it { expect { run_service }.to raise_error(ArgumentError) }
 
-      context "when the update is for a payment" do
+          it_behaves_like "logs an error"
+        end
+
         context "when status is not present in the update" do
           before { assign_webhook_status(nil) }
 
@@ -39,180 +43,181 @@ module WasteCarriersEngine
 
           it_behaves_like "logs an error"
         end
+      end
 
-        shared_examples "status is present in the update" do
-          context "when the payment is not found" do
-            before { webhook_resource["payment_id"] = "foo" }
+      describe "resource not found errors" do
+        context "when the payment is not found" do
+          before { webhook_resource["payment_id"] = "foo" }
 
-            it { expect { run_service }.to raise_error(ArgumentError) }
+          it { expect { run_service }.to raise_error(ArgumentError) }
 
-            it_behaves_like "logs an error"
-          end
-
-          context "when the payment is found" do
-            before do
-              registration.finance_details.update_balance
-              registration.save!
-            end
-
-            context "when the registration is not found" do
-              before do
-                allow(GovpayFindRegistrationService).to receive(:run).and_return(nil)
-                allow(RegistrationCompletionService).to receive(:new)
-              end
-
-              it "does not call the registration completion service" do
-                run_service
-
-                expect(RegistrationCompletionService).not_to have_received(:new)
-              end
-            end
-
-            context "when the payment status has not changed" do
-              let(:prior_payment_status) { Payment::STATUS_SUCCESS }
-
-              it { expect { run_service }.not_to change(wcr_payment, :govpay_payment_status) }
-
-              it "writes a warning to the Rails log" do
-                run_service
-
-                expect(Rails.logger).to have_received(:warn)
-              end
-            end
-
-            context "when the payment status has changed" do
-
-              include_examples "Govpay webhook status transitions"
-
-              # unfinished statuses
-              it_behaves_like "valid and invalid transitions", Payment::STATUS_CREATED, %w[started submitted success failed cancelled error], %w[]
-              it_behaves_like "valid and invalid transitions", "started", %w[submitted success failed cancelled error], %w[created]
-              it_behaves_like "valid and invalid transitions", Payment::STATUS_SUBMITTED, %w[success failed cancelled error], %w[started]
-
-              # finished statuses
-              it_behaves_like "no valid transitions", Payment::STATUS_SUCCESS
-              it_behaves_like "no valid transitions", Payment::STATUS_FAILED
-              it_behaves_like "no valid transitions", Payment::STATUS_CANCELLED
-              it_behaves_like "no valid transitions", "error"
-
-              context "when the webhook changes the status to a non-success value" do
-                let(:prior_payment_status) { Payment::STATUS_STARTED }
-
-                before { assign_webhook_status("cancelled") }
-
-                it "does not update the balance" do
-                  expect { run_service }.not_to change { wcr_payment.finance_details.reload.balance }
-                end
-              end
-
-              context "when the webhook changes the status to success" do
-                let(:prior_payment_status) { Payment::STATUS_STARTED }
-
-                before { assign_webhook_status("success") }
-
-                it "updates the balance" do
-                  expect { run_service }.to change { wcr_payment.finance_details.reload.balance }
-                end
-              end
-            end
-          end
+          it_behaves_like "logs an error"
         end
 
-        context "when the payment belongs to a registration" do
-          let(:registration) { create(:registration, :has_required_data) }
-
-          it_behaves_like "status is present in the update"
-        end
-
-        context "when the payment belongs to a new registration" do
-          let(:registration) { create(:new_registration, :has_required_data, :has_pending_govpay_status) }
-          let(:registration_completion_service) { instance_double(RegistrationCompletionService) }
-
+        context "when the registration is not found" do
           before do
-            allow(RegistrationCompletionService).to receive(:new).and_return(registration_completion_service)
-            allow(registration_completion_service).to receive(:run)
+            allow(GovpayFindRegistrationService).to receive(:run).and_return(nil)
+            allow(RegistrationCompletionService).to receive(:new)
           end
 
-          it_behaves_like "status is present in the update"
+          it "does not call the registration completion service" do
+            run_service
 
-          context "when the status is not success" do
-            let(:prior_payment_status) { "started" }
-
-            before { webhook_body["resource"]["state"]["status"] = "submitted" }
-
-            it "does not call the registration completion service" do
-              run_service
-
-              expect(registration_completion_service).not_to have_received(:run)
-            end
+            expect(RegistrationCompletionService).not_to have_received(:new)
           end
+        end
+      end
 
-          context "when the status is success" do
-            before { webhook_body["resource"]["state"]["status"] = "success" }
+      shared_examples "a valid payment update" do
 
-            it "calls the registration completion service" do
-              run_service
+        before do
+          registration.finance_details.update_balance
+          registration.save!
+        end
 
-              expect(registration_completion_service).to have_received(:run)
-            end
+        context "when the payment status has not changed" do
+          let(:prior_payment_status) { Payment::STATUS_SUCCESS }
+
+          it { expect { run_service }.not_to change(wcr_payment, :govpay_payment_status) }
+
+          it "writes a warning to the Rails log" do
+            run_service
+
+            expect(Rails.logger).to have_received(:warn)
           end
         end
 
-        context "when the payment belongs to a renewing registration" do
-          let(:registration) { create(:renewing_registration, :has_required_data, :has_finance_details) }
-          let(:renewal_completion_service) { instance_double(RenewalCompletionService) }
+        context "when the payment status has changed" do
 
-          before do
-            allow(RenewalCompletionService).to receive(:new).and_return(renewal_completion_service)
-            allow(renewal_completion_service).to receive(:complete_renewal)
-          end
-
-          it_behaves_like "status is present in the update"
-
-          context "when the status is not success" do
-            let(:prior_payment_status) { "started" }
-
-            before { webhook_body["resource"]["state"]["status"] = "submitted" }
-
-            it "does not call the renewal completion service" do
-              run_service
-
-              expect(renewal_completion_service).not_to have_received(:complete_renewal)
-            end
-          end
-
-          context "when the status is success" do
-            before { webhook_body["resource"]["state"]["status"] = "success" }
-
-            it "calls the renewal completion service" do
-              run_service
-
-              expect(renewal_completion_service).to have_received(:complete_renewal)
-            end
-          end
-        end
-
-        context "when the resource_type has different casings" do
           include_examples "Govpay webhook status transitions"
 
-          shared_examples "handles case-insensitive resource_type as payment" do |resource_type_value|
-            before do
-              webhook_body["resource_type"] = resource_type_value
-            end
+          # unfinished statuses
+          it_behaves_like "valid and invalid transitions", Payment::STATUS_CREATED, %w[started submitted success failed cancelled error], %w[]
+          it_behaves_like "valid and invalid transitions", "started", %w[submitted success failed cancelled error], %w[created]
+          it_behaves_like "valid and invalid transitions", Payment::STATUS_SUBMITTED, %w[success failed cancelled error], %w[started]
 
-            it_behaves_like "valid and invalid transitions", Payment::STATUS_CREATED, %w[started submitted success failed cancelled error], %w[]
+          # finished statuses
+          it_behaves_like "no valid transitions", Payment::STATUS_SUCCESS
+          it_behaves_like "no valid transitions", Payment::STATUS_FAILED
+          it_behaves_like "no valid transitions", Payment::STATUS_CANCELLED
+          it_behaves_like "no valid transitions", "error"
+
+          context "when the webhook changes the status to a non-success value" do
+            let(:prior_payment_status) { Payment::STATUS_STARTED }
+
+            before { assign_webhook_status("cancelled") }
+
+            it "does not update the balance" do
+              expect { run_service }.not_to change { wcr_payment.finance_details.reload.balance }
+            end
           end
 
-          %w[payment PAYMENT].each do |case_variant|
-            it_behaves_like "handles case-insensitive resource_type as payment", case_variant
+          context "when the webhook changes the status to success" do
+            let(:prior_payment_status) { Payment::STATUS_STARTED }
+
+            before { assign_webhook_status("success") }
+
+            it "updates the balance" do
+              expect { run_service }.to change { wcr_payment.finance_details.reload.balance }
+            end
           end
         end
       end
 
-      # used above and by shared examples - different for payment vs refund webhooks
-      def assign_webhook_status(status)
-        webhook_body["resource"]["state"]["status"] = status
+      context "when the payment belongs to a registration" do
+        let(:registration) { create(:registration, :has_required_data) }
+
+        it_behaves_like "a valid payment update"
+
+        it { expect { run_service }.to change { registration.reload.metaData.status }.from("PENDING").to("ACTIVE") }
       end
+
+      context "when the payment belongs to a new registration" do
+        let(:registration) { create(:new_registration, :has_required_data, :has_pending_govpay_status) }
+        let(:registration_completion_service) { instance_double(RegistrationCompletionService) }
+
+        before do
+          allow(RegistrationCompletionService).to receive(:new).and_return(registration_completion_service)
+          allow(registration_completion_service).to receive(:run)
+        end
+
+        it_behaves_like "a valid payment update"
+
+        context "when the status is not success" do
+          let(:prior_payment_status) { "started" }
+
+          before { webhook_body["resource"]["state"]["status"] = "submitted" }
+
+          it "does not call the registration completion service" do
+            run_service
+
+            expect(registration_completion_service).not_to have_received(:run)
+          end
+        end
+
+        context "when the status is success" do
+          before { webhook_body["resource"]["state"]["status"] = "success" }
+
+          it "calls the registration completion service" do
+            run_service
+
+            expect(registration_completion_service).to have_received(:run)
+          end
+        end
+      end
+
+      context "when the payment belongs to a renewing registration" do
+        let(:registration) { create(:renewing_registration, :has_required_data, :has_finance_details) }
+        let(:renewal_completion_service) { instance_double(RenewalCompletionService) }
+
+        before do
+          allow(RenewalCompletionService).to receive(:new).and_return(renewal_completion_service)
+          allow(renewal_completion_service).to receive(:complete_renewal)
+        end
+
+        it_behaves_like "a valid payment update"
+
+        context "when the status is not success" do
+          let(:prior_payment_status) { "started" }
+
+          before { webhook_body["resource"]["state"]["status"] = "submitted" }
+
+          it "does not call the renewal completion service" do
+            run_service
+
+            expect(renewal_completion_service).not_to have_received(:complete_renewal)
+          end
+        end
+
+        context "when the status is success" do
+          before { webhook_body["resource"]["state"]["status"] = "success" }
+
+          it "calls the renewal completion service" do
+            run_service
+
+            expect(renewal_completion_service).to have_received(:complete_renewal)
+          end
+        end
+      end
+
+      context "when the resource_type has different casings" do
+        include_examples "Govpay webhook status transitions"
+
+        shared_examples "handles case-insensitive resource_type as payment" do |resource_type_value|
+          before { webhook_body["resource_type"] = resource_type_value }
+
+          it_behaves_like "valid and invalid transitions", Payment::STATUS_CREATED, %w[started submitted success failed cancelled error], %w[]
+        end
+
+        %w[payment PAYMENT].each do |case_variant|
+          it_behaves_like "handles case-insensitive resource_type as payment", case_variant
+        end
+      end
+    end
+
+    # used above and by shared examples - different for payment vs refund webhooks
+    def assign_webhook_status(status)
+      webhook_body["resource"]["state"]["status"] = status
     end
   end
 end

--- a/spec/services/waste_carriers_engine/govpay_payment_webhook_handler_spec.rb
+++ b/spec/services/waste_carriers_engine/govpay_payment_webhook_handler_spec.rb
@@ -26,8 +26,6 @@ module WasteCarriersEngine
       include_examples "Govpay webhook services error logging"
 
       describe "invalid webhook errors" do
-        include_examples "Govpay webhook services error logging"
-
         context "when the update is not for a payment" do
           before { webhook_body["resource_type"] = "refund" }
 


### PR DESCRIPTION
Refactor payment webhook handler specs and activate registrations when notified of success status.
https://eaflood.atlassian.net/browse/RUBY-3819