### PR TITLE
Fix/ruby 3929 payment webhook logging

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    aasm (5.5.0)
+    aasm (5.5.1)
       concurrent-ruby (~> 1.0)
     actioncable (7.2.2.1)
       actionpack (= 7.2.2.1)
@@ -164,7 +164,7 @@ GEM
       rest-client (~> 2.1)
     defra_ruby_style (0.3.0)
       rubocop (>= 1.0, < 2.0)
-    defra_ruby_template (5.4.1)
+    defra_ruby_template (5.11.0)
     defra_ruby_validators (3.0.0)
       activemodel
       defra_ruby_companies_house
@@ -212,7 +212,7 @@ GEM
       rake (>= 10.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    govuk_design_system_formbuilder (5.10.1)
+    govuk_design_system_formbuilder (5.11.0)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
@@ -248,7 +248,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
-    matrix (0.4.2)
+    matrix (0.4.3)
     method_source (1.1.0)
     mime-types (3.6.2)
       logger

--- a/app/controllers/waste_carriers_engine/govpay_webhook_callbacks_controller.rb
+++ b/app/controllers/waste_carriers_engine/govpay_webhook_callbacks_controller.rb
@@ -17,7 +17,7 @@ module WasteCarriersEngine
       GovpayWebhookJob.perform_later(JSON.parse(body))
     rescue StandardError, Mongoid::Errors::DocumentNotFound => e
       Rails.logger.error "Govpay payment webhook body validation failed: #{e}"
-      Airbrake.notify(e, body: body, signature: pay_signature)
+      Airbrake.notify(e, body: DefraRubyGovpay::WebhookSanitizerService.call(body), signature: pay_signature)
     ensure
       # always return 200 to Govpay even if validation fails
       render nothing: true, layout: false, status: 200

--- a/config/initializers/suppress_parameter_logging.rb
+++ b/config/initializers/suppress_parameter_logging.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+SENSITIVE_ROUTES = [
+  %r{/govpay_payment_update$}
+].freeze
+
+LOG_FORMAT = "Processing by %s#%s as %s"
+
+ActiveSupport.on_load(:action_controller) do
+  ActionController::LogSubscriber.class_eval do
+
+    alias_method :original_start_processing, :start_processing
+
+    def start_processing(event)
+      payload = event.payload
+
+      if SENSITIVE_ROUTES.any? { |route_regex| payload[:path]&.match?(route_regex) }
+        info format(LOG_FORMAT, payload[:controller], payload[:action], payload[:format])
+
+      else
+        original_start_processing(event)
+      end
+    end
+  end
+end

--- a/spec/requests/suppress_parameter_logging_spec.rb
+++ b/spec/requests/suppress_parameter_logging_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe "SuppressParameterLogging" do
+
+    before do
+      allow(Rails.logger).to receive(:info).and_call_original ### this to enable output to test.log
+    end
+
+    it "does not suppress logging for routes not specified for suppression" do
+      post new_start_form_path(token: "foo"), params: { temp_site_postcode: "BS1 5AH" }
+
+      expect(Rails.logger).to have_received(:info).with(/Parameters: .*temp_site_postcode.*BS1 5AH/)
+    end
+
+    it "suppresses logging for a route specified for suppression" do
+      post process_govpay_webhook_path, params: { foo: :bar }
+
+      expect(Rails.logger).not_to have_received(:info).with(/Parameters:/)
+    end
+  end
+end

--- a/spec/requests/waste_carriers_engine/govpay_webhook_callbacks_spec.rb
+++ b/spec/requests/waste_carriers_engine/govpay_webhook_callbacks_spec.rb
@@ -9,11 +9,16 @@ module WasteCarriersEngine
       subject(:webhook_request) { post webhook_route, headers: headers, params: webhook_body }
 
       let(:webhook_route) { "/govpay_payment_update" }
-      let(:headers) { "Pay-Signature" => signature }
       let(:webhook_body) { file_fixture("govpay/webhook_payment_update_body.json").read }
       let(:webhook_signing_secret) { ENV.fetch("WCRS_GOVPAY_CALLBACK_WEBHOOK_SIGNING_SECRET") }
       let(:digest) { OpenSSL::Digest.new("sha256") }
       let(:valid_signature) { OpenSSL::HMAC.hexdigest(digest, webhook_signing_secret, webhook_body) }
+      let(:headers) do
+        {
+          "Pay-Signature" => valid_signature,
+          "Content-Type" => "application/json"
+        }
+      end
 
       let(:webhook_validation_service) { class_double(DefraRubyGovpay::WebhookBodyValidatorService) }
 


### PR DESCRIPTION
This suppresses govpay payment webhook parameter logging by Rails.
https://eaflood.atlassian.net/browse/RUBY-3929