### PR TITLE
[RUBY-4238] Fix expiry date calculation to use renewal expiry date instead of current

### DIFF
--- a/app/services/waste_carriers_engine/expiry_check_service.rb
+++ b/app/services/waste_carriers_engine/expiry_check_service.rb
@@ -21,7 +21,7 @@ module WasteCarriersEngine
     end
 
     def expiry_date_after_renewal
-      expiry_date.to_date + Rails.configuration.expires_after.years
+      renewal_expiry_date.to_date + Rails.configuration.expires_after.years
     end
 
     def expired?
@@ -57,6 +57,12 @@ module WasteCarriersEngine
 
     def current_day_is_within_grace_window?(last_day_of_grace_window)
       current_day.between?(expiry_date.to_date, last_day_of_grace_window)
+    end
+
+    # Renewal extensions should be based on the stored expiry boundary of the
+    # current term, not the DST-adjusted expiry date used for status checks.
+    def renewal_expiry_date
+      expires_on
     end
 
     # We store dates and times in UTC, but want to use the current date in the

--- a/spec/models/waste_carriers_engine/renewing_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/renewing_registration_spec.rb
@@ -216,6 +216,32 @@ module WasteCarriersEngine
       end
     end
 
+    describe "#projected_renewal_end_date" do
+      let(:registration) do
+        create(
+          :registration,
+          :has_required_data,
+          expires_on: Time.utc(2023, 4, 3, 0, 0, 0),
+          metaData: build(
+            :metaData,
+            :has_required_data,
+            date_registered: Time.utc(2020, 2, 24, 16, 0, 53),
+            date_activated: Time.utc(2020, 2, 24, 16, 0, 53)
+          )
+        )
+      end
+
+      subject(:renewing_registration) { described_class.new(reg_identifier: registration.reg_identifier) }
+
+      before do
+        allow(Rails.configuration).to receive(:expires_after).and_return(3)
+      end
+
+      it "uses the stored expiry date when projecting the renewed term" do
+        expect(renewing_registration.projected_renewal_end_date).to eq(Date.new(2026, 4, 3))
+      end
+    end
+
     describe "#ready_to_complete?" do
       context "when the transient registration is ready to complete" do
         let(:renewing_registration) { build(:renewing_registration, :is_ready_to_complete) }

--- a/spec/services/waste_carriers_engine/expiry_check_service_spec.rb
+++ b/spec/services/waste_carriers_engine/expiry_check_service_spec.rb
@@ -110,6 +110,60 @@ module WasteCarriersEngine
           expect(check_service.expiry_date_after_renewal).to eq(Date.new(2021, 3, 25))
         end
       end
+
+      context "when a renewed registration was submitted early in GMT and expires in BST" do
+        before do
+          allow(Rails.configuration).to receive(:expires_after).and_return(3)
+        end
+
+        let(:registration) do
+          build(
+            :registration,
+            :has_required_data,
+            expires_on: Time.utc(2023, 4, 3, 0, 0, 0),
+            metaData: build(
+              :metaData,
+              :has_required_data,
+              date_registered: Time.utc(2020, 2, 24, 16, 0, 53),
+              date_activated: Time.utc(2020, 2, 24, 16, 0, 53)
+            )
+          )
+        end
+
+        subject(:check_service) { described_class.new(registration) }
+
+        it "uses the stored expiry date as the renewal basis" do
+          expect(check_service.expiry_date).to eq(Time.utc(2023, 4, 2, 23, 0, 0))
+          expect(check_service.expiry_date_after_renewal).to eq(Date.new(2026, 4, 3))
+        end
+      end
+
+      context "when a renewed registration was submitted early in BST and expires in GMT" do
+        before do
+          allow(Rails.configuration).to receive(:expires_after).and_return(3)
+        end
+
+        let(:registration) do
+          build(
+            :registration,
+            :has_required_data,
+            expires_on: Time.utc(2019, 1, 19, 23, 35, 38),
+            metaData: build(
+              :metaData,
+              :has_required_data,
+              date_registered: Time.utc(2015, 7, 19, 22, 28, 6),
+              date_activated: Time.utc(2015, 7, 19, 22, 35, 38)
+            )
+          )
+        end
+
+        subject(:check_service) { described_class.new(registration) }
+
+        it "does not let the DST correction move the renewal on by a day" do
+          expect(check_service.expiry_date).to eq(Time.utc(2019, 1, 20, 0, 35, 38))
+          expect(check_service.expiry_date_after_renewal).to eq(Date.new(2022, 1, 19))
+        end
+      end
     end
 
     describe "#expired?" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-4238

Fix renewal expiry calculation to use the stored previous expiry date directly, instead of the DST-corrected expiry used for status checks. This prevents renewals from being calculated a day early or late when dateRegistered and expires_on fall in different DST periods.
