### PR TITLE
Bump gem dependencies 2026-04-15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,10 +55,10 @@
 - cert creation date [\#1362](https://github.com/DEFRA/waste-carriers-engine/pull/1362) ([PaulDoyle-EA](https://github.com/PaulDoyle-EA))
 - delete person label [\#1360](https://github.com/DEFRA/waste-carriers-engine/pull/1360) ([PaulDoyle-EA](https://github.com/PaulDoyle-EA))
 - Add restore attributes to metaData [\#1349](https://github.com/DEFRA/waste-carriers-engine/pull/1349) ([PaulDoyle-EA](https://github.com/PaulDoyle-EA))
-- Email history [\#1339](https://github.com/DEFRA/waste-carriers-engine/pull/1339) ([PaulDoyle-EA](https://github.com/PaulDoyle-EA))
 
 **Fixed bugs:**
 
+- \[RUBY-4238\] Fix expiry date calculation to use renewal expiry date instead of current [\#1700](https://github.com/DEFRA/waste-carriers-engine/pull/1700) ([jjromeo](https://github.com/jjromeo))
 - \[RUBY-4145\] Add handling for payment error status in GovPay forms controller [\#1679](https://github.com/DEFRA/waste-carriers-engine/pull/1679) ([jjromeo](https://github.com/jjromeo))
 - \[RUBY-3974\] Allow retry for payments that were failed as well as cancelled [\#1673](https://github.com/DEFRA/waste-carriers-engine/pull/1673) ([jjromeo](https://github.com/jjromeo))
 - \[RUBY-4039\] Fix conviction types link in convictions form [\#1672](https://github.com/DEFRA/waste-carriers-engine/pull/1672) ([brujeo](https://github.com/brujeo))
@@ -118,11 +118,12 @@
 - add reg\_identifier to deregistration email [\#1346](https://github.com/DEFRA/waste-carriers-engine/pull/1346) ([PaulDoyle-EA](https://github.com/PaulDoyle-EA))
 - Exclude dereg attributes from attribute copying [\#1343](https://github.com/DEFRA/waste-carriers-engine/pull/1343) ([PaulDoyle-EA](https://github.com/PaulDoyle-EA))
 - Fix/dereg token copy error [\#1342](https://github.com/DEFRA/waste-carriers-engine/pull/1342) ([PaulDoyle-EA](https://github.com/PaulDoyle-EA))
-- edit registration copy error [\#1341](https://github.com/DEFRA/waste-carriers-engine/pull/1341) ([PaulDoyle-EA](https://github.com/PaulDoyle-EA))
-- Missed card payment type [\#1335](https://github.com/DEFRA/waste-carriers-engine/pull/1335) ([PaulDoyle-EA](https://github.com/PaulDoyle-EA))
 
 **Merged pull requests:**
 
+- Bump rack from 3.2.5 to 3.2.6 [\#1697](https://github.com/DEFRA/waste-carriers-engine/pull/1697) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Refactoring specs to use dynamic renewal window [\#1696](https://github.com/DEFRA/waste-carriers-engine/pull/1696) ([brujeo](https://github.com/brujeo))
+- Chore/changelog [\#1695](https://github.com/DEFRA/waste-carriers-engine/pull/1695) ([brujeo](https://github.com/brujeo))
 - Bump dependencies and fix test class namespacing [\#1685](https://github.com/DEFRA/waste-carriers-engine/pull/1685) ([brujeo](https://github.com/brujeo))
 - Bump rack from 3.2.4 to 3.2.5 [\#1684](https://github.com/DEFRA/waste-carriers-engine/pull/1684) ([dependabot[bot]](https://github.com/apps/dependabot))
 - Bump faraday from 2.14.0 to 2.14.1 [\#1683](https://github.com/DEFRA/waste-carriers-engine/pull/1683) ([dependabot[bot]](https://github.com/apps/dependabot))
@@ -261,7 +262,6 @@
 - Bump nokogiri from 1.14.2 to 1.14.3 [\#1348](https://github.com/DEFRA/waste-carriers-engine/pull/1348) ([dependabot[bot]](https://github.com/apps/dependabot))
 - Bump devise from 4.9.0 to 4.9.2 [\#1347](https://github.com/DEFRA/waste-carriers-engine/pull/1347) ([dependabot[bot]](https://github.com/apps/dependabot))
 - Bump countries from 5.3.1 to 5.3.2 [\#1344](https://github.com/DEFRA/waste-carriers-engine/pull/1344) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Update CHANGELOG [\#1340](https://github.com/DEFRA/waste-carriers-engine/pull/1340) ([PaulDoyle-EA](https://github.com/PaulDoyle-EA))
 
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
       minitest (>= 5.1, < 6)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-    addressable (2.8.9)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     airbrake (13.0.5)
       airbrake-ruby (~> 6.0)
@@ -110,7 +110,7 @@ GEM
     ast (2.4.3)
     base64 (0.3.0)
     benchmark (0.5.0)
-    bigdecimal (4.0.1)
+    bigdecimal (4.1.1)
     bindex (0.8.1)
     bson (5.2.0)
     builder (3.3.0)
@@ -177,11 +177,11 @@ GEM
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-http-cache (2.6.1)
+    faraday-http-cache (2.7.0)
       faraday (>= 0.8)
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
-    ffi (1.17.3)
+    ffi (1.17.4)
     github_changelog_generator (1.15.2)
       activesupport
       faraday-http-cache
@@ -202,7 +202,7 @@ GEM
     html-attributes-utils (1.0.2)
       activesupport (>= 6.1.4.4)
     http-accept (1.7.0)
-    http-cookie (1.1.0)
+    http-cookie (1.1.4)
       domain_name (~> 0.5)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
@@ -215,7 +215,7 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
-    json (2.19.2)
+    json (2.19.3)
     jwt (2.10.2)
       base64
     language_server-protocol (3.17.0.5)
@@ -236,7 +236,7 @@ GEM
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2026.0317)
+    mime-types-data (3.2026.0414)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
     minitest (5.27.0)
@@ -253,7 +253,7 @@ GEM
       ruby2_keywords (~> 0.0.5)
     mongoid-locker (2.0.2)
       mongoid (>= 5.0, < 9)
-    multi_json (1.19.1)
+    multi_json (1.20.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
     net-imap (0.6.3)
@@ -276,11 +276,11 @@ GEM
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     os_map_ref (0.5.0)
-    parallel (1.27.0)
-    parser (3.3.10.2)
+    parallel (1.28.0)
+    parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
-    phonelib (0.10.17)
+    phonelib (0.10.18)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -297,7 +297,7 @@ GEM
     public_suffix (7.0.5)
     racc (1.8.1)
     rack (3.2.6)
-    rack-session (2.1.1)
+    rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-test (2.2.0)
@@ -340,13 +340,13 @@ GEM
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
-    rake (13.3.1)
+    rake (13.4.1)
     rbtree3 (0.7.1)
     rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
       tsort
-    regexp_parser (2.11.3)
+    regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
     rest-client (2.1.0)
@@ -380,11 +380,11 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.13.7)
-    rubocop (1.86.0)
+    rubocop (1.86.1)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
-      parallel (~> 1.10)
+      parallel (>= 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
@@ -445,7 +445,7 @@ GEM
     stringio (3.2.0)
     thor (1.5.0)
     tilt (2.7.0)
-    timecop (0.9.10)
+    timecop (0.9.11)
     timeout (0.6.1)
     tsort (0.2.0)
     turbolinks (5.2.1)
@@ -520,4 +520,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.3.22
+   2.7.2


### PR DESCRIPTION
Updated gems:
- addressable: 2.8.9 -> 2.9.0
- bigdecimal: 4.0.1 -> 4.1.1
- faraday-http-cache: 2.6.1 -> 2.7.0
- ffi: 1.17.3 -> 1.17.4
- http-cookie: 1.1.0 -> 1.1.4
- json: 2.19.2 -> 2.19.3
- mime-types-data: 3.2026.0317 -> 3.2026.0414
- multi_json: 1.19.1 -> 1.20.1
- parallel: 1.27.0 -> 1.28.0
- parser: 3.3.10.2 -> 3.3.11.1
- phonelib: 0.10.17 -> 0.10.18
- rack-session: 2.1.1 -> 2.1.2
- rake: 13.3.1 -> 13.4.1
- regexp_parser: 2.11.3 -> 2.12.0
- rubocop: 1.86.0 -> 1.86.1
- timecop: 0.9.10 -> 0.9.11

Updated changelog