### PR TITLE
RUBY-4266 Update defra_ruby_validators

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       defra_ruby_companies_house
       defra_ruby_email (~> 1.3.0)
       defra_ruby_govpay
-      defra_ruby_validators (~> 3.0)
+      defra_ruby_validators
       high_voltage (~> 3.1.2)
       jbuilder (~> 2.11.5)
       mongo_session_store (~> 3.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,7 @@ GEM
     defra_ruby_style (0.3.0)
       rubocop (>= 1.0, < 2.0)
     defra_ruby_template (5.11.1)
-    defra_ruby_validators (3.0.0)
+    defra_ruby_validators (3.0.1)
       activemodel
       defra_ruby_companies_house
       i18n

--- a/waste_carriers_engine.gemspec
+++ b/waste_carriers_engine.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |s|
   s.add_dependency "high_voltage", "~> 3.1.2"
 
   # Validations
-  s.add_dependency "defra_ruby_validators", "~> 3.0"
+  s.add_dependency "defra_ruby_validators"
   s.add_dependency "uk_postcode", "~> 2.1.8"
 
   s.add_dependency "defra_ruby_govpay"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-4266
Removes the pinned defra_ruby_validators dependency constraint and updates defra_ruby_validators.