### PR TITLE
[RUBY-4301] Fix Airbrake notification to include error and params hash in webhook handler

### DIFF
--- a/app/services/waste_carriers_engine/govpay_payment_webhook_handler.rb
+++ b/app/services/waste_carriers_engine/govpay_payment_webhook_handler.rb
@@ -26,7 +26,7 @@ module WasteCarriersEngine
                         "payment #{payment_id}, registration \"#{registration&.regIdentifier}\""
     rescue StandardError => e
       Rails.logger.error "Error processing webhook for payment #{payment_id}: #{e}"
-      Airbrake.notify "Error processing webhook for payment #{payment_id}", e
+      Airbrake.notify(e, message: "Error processing webhook for payment", payment_id: payment_id)
       raise
     end
 

--- a/spec/services/waste_carriers_engine/govpay_payment_webhook_handler_spec.rb
+++ b/spec/services/waste_carriers_engine/govpay_payment_webhook_handler_spec.rb
@@ -52,6 +52,14 @@ module WasteCarriersEngine
           it { expect { run_service }.to raise_error(ArgumentError) }
 
           it_behaves_like "logs an error"
+
+          it "notifies Airbrake with the error and a params hash" do
+            allow(Airbrake).to receive(:notify)
+
+            expect { run_service }.to raise_error(ArgumentError)
+
+            expect(Airbrake).to have_received(:notify).with(instance_of(ArgumentError), instance_of(Hash))
+          end
         end
 
         context "when the registration is not found" do


### PR DESCRIPTION
WCR - govPay - Got ArgumentError value, wanted a Hash
https://eaflood.atlassian.net/browse/RUBY-4301