### PR TITLE
Fix/ruby 4317 wcr govpay investigate callback errors

### DIFF
--- a/app/services/waste_carriers_engine/govpay_find_payment_service.rb
+++ b/app/services/waste_carriers_engine/govpay_find_payment_service.rb
@@ -42,7 +42,7 @@ module WasteCarriersEngine
 
     def handle_payment_not_found(payment_id)
       Rails.logger.error "Govpay payment not found for govpay_id #{payment_id}"
-      Airbrake.notify(@last_error, message: "Govpay payment not found", payment_id: payment_id)
+      Airbrake.notify("Govpay payment not found", payment_id: payment_id, error: @last_error&.message)
       raise ArgumentError, "invalid govpay_id"
     end
   end

--- a/app/services/waste_carriers_engine/govpay_find_payment_service.rb
+++ b/app/services/waste_carriers_engine/govpay_find_payment_service.rb
@@ -2,13 +2,13 @@
 
 module WasteCarriersEngine
   class GovpayFindPaymentService < WasteCarriersEngine::BaseService
-    def run(payment_id:)
+    def run(payment_id:, raise_on_missing: true)
       Rails.logger.tagged("GovpayFindPaymentService") do
         @last_error = nil
 
         payment = find_payment_in_registration(payment_id) || find_payment_in_transient_registration(payment_id)
 
-        payment || handle_payment_not_found(payment_id)
+        payment || handle_payment_not_found(payment_id, raise_on_missing)
       end
     end
 
@@ -40,8 +40,10 @@ module WasteCarriersEngine
       nil
     end
 
-    def handle_payment_not_found(payment_id)
+    def handle_payment_not_found(payment_id, raise_on_missing)
       Rails.logger.error "Govpay payment not found for govpay_id #{payment_id}"
+      return nil unless raise_on_missing
+
       Airbrake.notify("Govpay payment not found", payment_id: payment_id, error: @last_error&.message)
       raise ArgumentError, "invalid govpay_id"
     end

--- a/app/services/waste_carriers_engine/govpay_payment_webhook_handler.rb
+++ b/app/services/waste_carriers_engine/govpay_payment_webhook_handler.rb
@@ -6,8 +6,9 @@ module WasteCarriersEngine
 
     def run(webhook_body)
       @webhook_body = webhook_body
-      @payment_id = webhook_body.dig("resource", "payment_id")
-      @payment = GovpayFindPaymentService.run(payment_id: payment_id)
+      @payment = find_payment
+
+      return log_unrecorded_payment if payment.blank?
 
       @previous_status = payment.govpay_payment_status
 
@@ -28,6 +29,26 @@ module WasteCarriersEngine
       Rails.logger.error "Error processing webhook for payment #{payment_id}: #{e}"
       Airbrake.notify(e, message: "Error processing webhook for payment", payment_id: payment_id)
       raise
+    end
+
+    # A payment document is only persisted once a payment succeeds, so a
+    # missing payment is only a concern if the webhook reports success.
+    # Uses the raw status here because webhook_payment_status memoizes the
+    # gem result, which must not happen before previous_status is known.
+    def find_payment
+      @payment_id = webhook_body.dig("resource", "payment_id")
+      GovpayFindPaymentService.run(
+        payment_id: payment_id,
+        raise_on_missing: raw_webhook_status == Payment::STATUS_SUCCESS
+      )
+    end
+
+    def raw_webhook_status
+      webhook_body.dig("resource", "state", "status")
+    end
+
+    def log_unrecorded_payment
+      Rails.logger.warn "Ignoring \"#{raw_webhook_status}\" webhook for unrecorded payment #{payment_id}"
     end
 
     def webhook_payment_status

--- a/spec/services/waste_carriers_engine/govpay_find_payment_service_spec.rb
+++ b/spec/services/waste_carriers_engine/govpay_find_payment_service_spec.rb
@@ -26,6 +26,20 @@ module WasteCarriersEngine
             hash_including(payment_id: payment_id)
           )
         end
+
+        context "with raise_on_missing: false" do
+          subject(:run_service) { described_class.run(payment_id:, raise_on_missing: false) }
+
+          it "returns nil" do
+            expect(run_service).to be_nil
+          end
+
+          it "does not notify Airbrake" do
+            run_service
+
+            expect(Airbrake).not_to have_received(:notify)
+          end
+        end
       end
 
       context "with a valid payment id in a Registration" do

--- a/spec/services/waste_carriers_engine/govpay_find_payment_service_spec.rb
+++ b/spec/services/waste_carriers_engine/govpay_find_payment_service_spec.rb
@@ -12,8 +12,19 @@ module WasteCarriersEngine
       context "with an invalid payment id" do
         let(:payment_id) { "bad_id" }
 
+        before { allow(Airbrake).to receive(:notify) }
+
         it "raises an exception" do
           expect { run_service }.to raise_exception(ArgumentError)
+        end
+
+        it "notifies Airbrake with a message, not the rescued Mongoid error" do
+          expect { run_service }.to raise_exception(ArgumentError)
+
+          expect(Airbrake).to have_received(:notify).with(
+            "Govpay payment not found",
+            hash_including(payment_id: payment_id)
+          )
         end
       end
 

--- a/spec/services/waste_carriers_engine/govpay_payment_webhook_handler_spec.rb
+++ b/spec/services/waste_carriers_engine/govpay_payment_webhook_handler_spec.rb
@@ -49,16 +49,54 @@ module WasteCarriersEngine
         context "when the payment is not found" do
           before { webhook_resource["payment_id"] = "foo" }
 
-          it { expect { run_service }.to raise_error(ArgumentError) }
+          context "when the webhook status is success" do
+            it { expect { run_service }.to raise_error(ArgumentError) }
 
-          it_behaves_like "logs an error"
+            it_behaves_like "logs an error"
 
-          it "notifies Airbrake with the error and a params hash" do
-            allow(Airbrake).to receive(:notify)
+            it "notifies Airbrake with the error and a params hash" do
+              allow(Airbrake).to receive(:notify)
 
-            expect { run_service }.to raise_error(ArgumentError)
+              expect { run_service }.to raise_error(ArgumentError)
 
-            expect(Airbrake).to have_received(:notify).with(instance_of(ArgumentError), instance_of(Hash))
+              expect(Airbrake).to have_received(:notify).with(instance_of(ArgumentError), instance_of(Hash))
+            end
+
+            it "notifies Airbrake that the payment was not found" do
+              allow(Airbrake).to receive(:notify)
+
+              expect { run_service }.to raise_error(ArgumentError)
+
+              expect(Airbrake).to have_received(:notify).with(
+                "Govpay payment not found",
+                hash_including(payment_id: "foo")
+              )
+            end
+          end
+
+          %w[created started submitted failed cancelled expired error].each do |status|
+            context "when the webhook status is #{status}" do
+              before do
+                assign_webhook_status(status)
+                allow(Airbrake).to receive(:notify)
+              end
+
+              it "does not raise an error" do
+                expect { run_service }.not_to raise_error
+              end
+
+              it "does not notify Airbrake" do
+                run_service
+
+                expect(Airbrake).not_to have_received(:notify)
+              end
+
+              it "logs the ignored webhook" do
+                run_service
+
+                expect(Rails.logger).to have_received(:warn).with(/Ignoring "#{status}" webhook for unrecorded payment/)
+              end
+            end
           end
         end
 


### PR DESCRIPTION
Fixed 2 GovPay Handler errors:
- Mongoid::Errors::DocumentNotFound
- invalid govpay_id