### PR TITLE
Feature/ruby 4335 wcr security enable bundler cooldown give new gems a few days to be vetted

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   versioning-strategy: lockfile-only
+  cooldown:
+    default-days: 7
   ignore:
   - dependency-name: airbrake
     versions:

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-source "https://rubygems.org"
+source "https://rubygems.org", cooldown: 7
 
 ruby "3.4.6"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,7 @@ GEM
     byebug (11.1.3)
     cgi (0.5.1)
     coderay (1.1.3)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     countries (5.5.0)
       unaccent (~> 0.3)
@@ -173,13 +173,13 @@ GEM
       railties (>= 5.0.0)
     faker (3.2.3)
       i18n (>= 1.8.11, < 2)
-    faraday (2.14.1)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
     faraday-http-cache (2.7.0)
       faraday (>= 0.8)
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.4)
       net-http (~> 0.5)
     ffi (1.17.4)
     github_changelog_generator (1.15.2)
@@ -204,7 +204,7 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.1.6)
       domain_name (~> 0.5)
-    i18n (1.14.8)
+    i18n (1.15.1)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
     irb (1.18.0)
@@ -215,8 +215,8 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
-    json (2.19.5)
-    jwt (2.10.2)
+    json (2.20.0)
+    jwt (2.10.3)
       base64
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
@@ -230,7 +230,7 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.1.0)
+    marcel (1.2.1)
     matrix (0.4.3)
     method_source (1.1.0)
     mime-types (3.7.0)
@@ -240,7 +240,7 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
     minitest (5.27.0)
-    mongo (2.24.0)
+    mongo (2.24.1)
       base64
       bson (>= 4.14.1, < 6.0.0)
     mongo_session_store (3.2.1)
@@ -256,7 +256,7 @@ GEM
     multi_json (1.21.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -267,7 +267,7 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.5)
-    nokogiri (1.19.3)
+    nokogiri (1.19.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     notifications-ruby-client (5.4.0)
@@ -277,11 +277,11 @@ GEM
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     os_map_ref (0.5.0)
-    parallel (1.28.0)
+    parallel (2.1.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
-    phonelib (0.10.18)
+    phonelib (0.10.22)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -292,7 +292,7 @@ GEM
     pry-byebug (3.10.1)
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
-    psych (5.3.1)
+    psych (5.4.0)
       date
       stringio
     public_suffix (7.0.5)
@@ -355,7 +355,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    retriable (3.4.1)
+    retriable (3.8.0)
     rexml (3.4.4)
     rspec (3.13.2)
       rspec-core (~> 3.13.0)
@@ -381,7 +381,7 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.13.7)
-    rubocop (1.86.1)
+    rubocop (1.88.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -398,9 +398,10 @@ GEM
     rubocop-factory_bot (2.28.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
-    rubocop-rspec (3.9.0)
+    rubocop-rspec (3.10.2)
       lint_roller (~> 1.1)
-      rubocop (~> 1.81)
+      regexp_parser (>= 2.0)
+      rubocop (~> 1.86, >= 1.86.2)
     rubocop-rspec_rails (2.32.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
@@ -474,13 +475,13 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.1)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     wicked_pdf (2.6.3)
       activesupport
-    zeitwerk (2.7.5)
+    zeitwerk (2.8.2)
 
 PLATFORMS
   ruby
@@ -519,7 +520,7 @@ DEPENDENCIES
   webmock (~> 3.18.1)
 
 RUBY VERSION
-   ruby 3.4.6p20
+  ruby 3.4.6p20
 
 BUNDLED WITH
-   2.7.2
+  4.0.13

--- a/spec/services/waste_carriers_engine/notify/registration_pending_conviction_check_email_service_spec.rb
+++ b/spec/services/waste_carriers_engine/notify/registration_pending_conviction_check_email_service_spec.rb
@@ -42,9 +42,7 @@ module WasteCarriersEngine
           it "sends an email" do
             expect(run_service).to be_a(Notifications::Client::ResponseNotification)
             expect(run_service.template["id"]).to eq(template_id)
-            expect(run_service.content["subject"]).to match(
-              /Application received for waste carrier registration CBDU/
-            )
+            expect(run_service.content["subject"]).to include("Application received for waste carrier registration CBDU")
           end
 
           it_behaves_like "can create a communication record", "email"

--- a/spec/services/waste_carriers_engine/notify/registration_pending_online_payment_email_service_spec.rb
+++ b/spec/services/waste_carriers_engine/notify/registration_pending_online_payment_email_service_spec.rb
@@ -46,9 +46,7 @@ module WasteCarriersEngine
           it "sends an email" do
             expect(run_service).to be_a(Notifications::Client::ResponseNotification)
             expect(run_service.template["id"]).to eq(template_id)
-            expect(run_service.content["subject"]).to match(
-              /We’re processing your waste carrier registration CBDU/
-            )
+            expect(run_service.content["subject"]).to include("We’re processing your waste carrier registration CBDU")
           end
 
           it_behaves_like "can create a communication record", "email"

--- a/spec/services/waste_carriers_engine/notify/registration_pending_payment_email_service_spec.rb
+++ b/spec/services/waste_carriers_engine/notify/registration_pending_payment_email_service_spec.rb
@@ -52,9 +52,7 @@ module WasteCarriersEngine
           it "sends an email" do
             expect(run_service).to be_a(Notifications::Client::ResponseNotification)
             expect(run_service.template["id"]).to eq(template_id)
-            expect(run_service.content["subject"]).to match(
-              /Payment needed for waste carrier registration CBDU/
-            )
+            expect(run_service.content["subject"]).to include("Payment needed for waste carrier registration CBDU")
           end
 
           it_behaves_like "can create a communication record", "email"

--- a/spec/services/waste_carriers_engine/notify/renewal_pending_payment_email_service_spec.rb
+++ b/spec/services/waste_carriers_engine/notify/renewal_pending_payment_email_service_spec.rb
@@ -50,9 +50,7 @@ module WasteCarriersEngine
           it "sends an email" do
             expect(run_service).to be_a(Notifications::Client::ResponseNotification)
             expect(run_service.template["id"]).to eq(template_id)
-            expect(run_service.content["subject"]).to match(
-              /Payment needed for waste carrier registration CBDU/
-            )
+            expect(run_service.content["subject"]).to include("Payment needed for waste carrier registration CBDU")
           end
 
           it_behaves_like "can create a communication record", "email"


### PR DESCRIPTION
Enable Bundler and Dependbot Cooldown
https://eaflood.atlassian.net/browse/RUBY-4335

 - Enable dependabot cooldown to allow new gems a few days for vetting
 - Enable Bundler cooldown for new gems versions
 - Updated gem dependencies