### PR TITLE
Chore/changelog 07 07 2026

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,8 @@
 
 **Merged pull requests:**
 
+- Feature/ruby 4356 wcr remove deregistration functionality [\#1725](https://github.com/DEFRA/waste-carriers-engine/pull/1725) ([brujeo](https://github.com/brujeo))
+- changelog update 29/06/2026 [\#1724](https://github.com/DEFRA/waste-carriers-engine/pull/1724) ([brujeo](https://github.com/brujeo))
 - Feature/ruby 4335 wcr security enable bundler cooldown give new gems a few days to be vetted [\#1723](https://github.com/DEFRA/waste-carriers-engine/pull/1723) ([brujeo](https://github.com/brujeo))
 - RUBY-4265 Update Ruby to 3.4.6 [\#1712](https://github.com/DEFRA/waste-carriers-engine/pull/1712) ([jjromeo](https://github.com/jjromeo))
 - Chore/changelog 08/05/2026 [\#1709](https://github.com/DEFRA/waste-carriers-engine/pull/1709) ([brujeo](https://github.com/brujeo))
@@ -260,8 +262,6 @@
 - Feature/ruby 2128 wcr accessibility missing autocomplete [\#1359](https://github.com/DEFRA/waste-carriers-engine/pull/1359) ([brujeo](https://github.com/brujeo))
 - remove downgrade to  os\_map\_ref gem [\#1357](https://github.com/DEFRA/waste-carriers-engine/pull/1357) ([jjromeo](https://github.com/jjromeo))
 - Add code to assign an area to an address through postcode [\#1355](https://github.com/DEFRA/waste-carriers-engine/pull/1355) ([jjromeo](https://github.com/jjromeo))
-- Bump defra\_ruby\_alert from 2.1.1 to 2.2.1 [\#1354](https://github.com/DEFRA/waste-carriers-engine/pull/1354) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Update CHANGELOG [\#1351](https://github.com/DEFRA/waste-carriers-engine/pull/1351) ([PaulDoyle-EA](https://github.com/PaulDoyle-EA))
 
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ GEM
     bson (5.2.0)
     builder (3.3.0)
     byebug (11.1.3)
-    cgi (0.5.1)
+    cgi (0.5.2)
     coderay (1.1.3)
     concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
@@ -124,7 +124,7 @@ GEM
     crack (1.0.1)
       bigdecimal
       rexml
-    crass (1.0.6)
+    crass (1.0.7)
     database_cleaner-core (2.0.1)
     database_cleaner-mongoid (2.0.1)
       database_cleaner-core (~> 2.0.0)
@@ -190,7 +190,7 @@ GEM
       rainbow (>= 2.2.1)
       rake (>= 10.0)
       retriable (~> 3.0)
-    globalid (1.3.0)
+    globalid (1.4.0)
       activesupport (>= 6.1)
     govuk_design_system_formbuilder (5.13.0)
       actionview (>= 6.1)
@@ -215,7 +215,7 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
-    json (2.19.9)
+    json (2.20.0)
     jwt (2.10.3)
       base64
     language_server-protocol (3.17.0.5)
@@ -292,9 +292,6 @@ GEM
     pry-byebug (3.10.1)
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
-    psych (5.4.0)
-      date
-      stringio
     public_suffix (7.0.5)
     racc (1.8.1)
     rack (3.2.6)
@@ -342,10 +339,15 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.4.2)
+    rbs (4.0.3)
+      logger
+      prism (>= 1.6.0)
+      tsort
     rbtree3 (0.7.1)
-    rdoc (7.2.0)
+    rdoc (8.0.0)
       erb
-      psych (>= 4.0.0)
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
       tsort
     regexp_parser (2.12.0)
     reline (0.6.3)
@@ -444,7 +446,6 @@ GEM
     stateoscope (0.1.3)
       activesupport
       ruby-graphviz
-    stringio (3.2.0)
     thor (1.5.0)
     tilt (2.7.0)
     timecop (0.9.11)
@@ -475,7 +476,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    websocket-driver (0.8.1)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
- Update CHANGELOG.md
- Updated gems:
      - cgi: 0.5.1 -> 0.5.2
      - crass: 1.0.6 -> 1.0.7
      - globalid: 1.3.0 -> 1.4.0
      - json: 2.19.9 -> 2.20.0
      - rdoc: 7.2.0 -> 8.0.0
      - websocket-driver: 0.8.1 -> 0.8.2