### PR TITLE
Feature/ruby 4339 wcr implement message delivery status call back

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,10 @@ export WCRS_TEST_USERSDB_URI="mongodb://mongoAdmin:password1234@127.0.0.1:27017,
 WCRS_COMPANIES_HOUSE_URL=
 WCRS_COMPANIES_HOUSE_API_KEY=
 
+# GOV.UK Notify
+# Bearer token Notify sends to authenticate delivery status callbacks
+NOTIFY_CALLBACK_BEARER_TOKEN=
+
 # Should we use XVFB when rendering PDFs? The reason for asking this is local
 # development environments. If you're working in an environment without a GUI
 # then you want this set to true. However if you are working locally directly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       ENV_VARIABLE_TEST_FEATURE: true
       WCRS_GOVPAY_CALLBACK_WEBHOOK_SIGNING_SECRET: foo
       WCRS_GOVPAY_BACK_OFFICE_CALLBACK_WEBHOOK_SIGNING_SECRET: foo2
+      NOTIFY_CALLBACK_BEARER_TOKEN: test-notify-bearer-token
 
     steps:
       # Downloads a copy of the code in your repository

--- a/app/controllers/waste_carriers_engine/notify_callbacks_controller.rb
+++ b/app/controllers/waste_carriers_engine/notify_callbacks_controller.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class NotifyCallbacksController < ::WasteCarriersEngine::ApplicationController
+    class TokenNotConfiguredError < StandardError; end
+    class MissingAuthorizationError < StandardError; end
+    class InvalidTokenError < StandardError; end
+
+    protect_from_forgery with: :null_session
+
+    def process_callback
+      validate_bearer_token!
+
+      # need to rewind in case already read
+      request.body.rewind
+      body = request.body.read
+      payload = JSON.parse(body)
+
+      NotifyCallbackJob.perform_later(payload)
+    rescue StandardError => e
+      Rails.logger.error "Notify callback error: #{e}"
+      Airbrake.notify(e)
+    ensure
+      # always return 200 to Notify even if validation fails
+      head :ok
+    end
+
+    private
+
+    def validate_bearer_token!
+      expected_token = ENV.fetch("NOTIFY_CALLBACK_BEARER_TOKEN", nil)
+      raise TokenNotConfiguredError, "Notify callback bearer token not configured" if expected_token.blank?
+
+      auth_header = request.headers["Authorization"]
+      raise MissingAuthorizationError, "Missing Authorization header" if auth_header.blank?
+
+      token = auth_header.sub(/\ABearer\s+/, "")
+      return if ActiveSupport::SecurityUtils.secure_compare(token, expected_token)
+
+      raise InvalidTokenError, "Invalid bearer token"
+    end
+  end
+end

--- a/app/jobs/waste_carriers_engine/notify_callback_job.rb
+++ b/app/jobs/waste_carriers_engine/notify_callback_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class NotifyCallbackJob < ApplicationJob
+    self.log_arguments = false
+
+    def perform(callback_payload)
+      result = NotifyCallbackHandlerService.run(callback_payload)
+
+      Rails.logger.info "Processed Notify callback for notification_id: #{result[:notification_id]}, " \
+                        "status: #{result[:status]}"
+    rescue StandardError => e
+      notification_id = callback_payload["id"] || callback_payload["notification_id"]
+      Rails.logger.error "Error running NotifyCallbackJob for notification_id #{notification_id}: #{e}"
+      Airbrake.notify(e, notification_id: notification_id)
+    end
+  end
+end

--- a/app/models/waste_carriers_engine/communication_record.rb
+++ b/app/models/waste_carriers_engine/communication_record.rb
@@ -6,6 +6,7 @@ module WasteCarriersEngine
 
     field :registration_id, type: BSON::ObjectId
     field :notify_template_id, type: String
+    field :notification_id, type: String
     field :notification_type, type: String
     field :comms_label, type: String
     field :sent_at, type: DateTime
@@ -14,5 +15,7 @@ module WasteCarriersEngine
     field :delivery_status, type: String
 
     belongs_to :registration
+
+    index({ notification_id: 1 }, { background: true })
   end
 end

--- a/app/services/concerns/waste_carriers_engine/can_record_communication.rb
+++ b/app/services/concerns/waste_carriers_engine/can_record_communication.rb
@@ -23,6 +23,7 @@ module WasteCarriersEngine
     def communication_record_attributes(response: nil, delivery_status: nil)
       {
         notify_template_id: template_id,
+        notification_id: response&.id,
         notification_type: notification_type,
         comms_label: comms_label,
         sent_at: Time.now.utc,

--- a/app/services/waste_carriers_engine/notify_callback_handler_service.rb
+++ b/app/services/waste_carriers_engine/notify_callback_handler_service.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class NotifyCallbackHandlerService < BaseService
+    TERMINAL_STATUSES = %w[delivered permanent-failure technical-failure returned].freeze
+
+    def run(callback_payload)
+      @payload = callback_payload.deep_symbolize_keys
+
+      if @payload.key?(:notification_type)
+        process_delivery_receipt
+      elsif @payload.key?(:notification_id) && !@payload.key?(:status)
+        process_returned_letter
+      else
+        raise ArgumentError, "Unrecognised Notify callback payload"
+      end
+    end
+
+    private
+
+    def process_delivery_receipt
+      notification_id = @payload[:id]
+      new_status = @payload[:status]
+
+      raise ArgumentError, "Missing id in delivery receipt" if notification_id.blank?
+      raise ArgumentError, "Missing status in delivery receipt" if new_status.blank?
+
+      update_communication_record(notification_id, new_status)
+    end
+
+    def process_returned_letter
+      notification_id = @payload[:notification_id]
+
+      raise ArgumentError, "Missing notification_id in returned letter" if notification_id.blank?
+
+      update_communication_record(notification_id, "returned")
+    end
+
+    def update_communication_record(notification_id, new_status)
+      communication_record = CommunicationRecord.where(notification_id: notification_id).first
+
+      unless communication_record
+        Rails.logger.warn "CommunicationRecord not found for notification_id: #{notification_id}"
+        return { notification_id: notification_id, status: "not_found" }
+      end
+
+      if TERMINAL_STATUSES.include?(communication_record.delivery_status)
+        Rails.logger.info "Ignoring Notify callback for notification_id #{notification_id}: " \
+                          "already in terminal status '#{communication_record.delivery_status}'"
+        return { notification_id: notification_id, status: communication_record.delivery_status }
+      end
+
+      # Atomic $set, skipping validations: avoids loading the parent
+      # registration and still records the status if it has been deleted
+      communication_record.set(delivery_status: new_status)
+
+      { notification_id: notification_id, status: new_status }
+    end
+  end
+end

--- a/config/initializers/suppress_parameter_logging.rb
+++ b/config/initializers/suppress_parameter_logging.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 SENSITIVE_ROUTES = [
-  %r{/govpay_payment_update$}
+  %r{/govpay_payment_update$},
+  %r{/notify_callback$}
 ].freeze
 
 LOG_FORMAT = "Processing by %s#%s as %s"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -329,6 +329,9 @@ WasteCarriersEngine::Engine.routes.draw do
   # GOV.uk pay webhook callback route
   post "/govpay_payment_update", to: "govpay_webhook_callbacks#process_webhook", as: "process_govpay_webhook"
 
+  # GOV.UK Notify callback route
+  post "/notify_callback", to: "notify_callbacks#process_callback", as: "notify_callback"
+
   get "/unsubscribe/:unsubscribe_token", to: "unsubscribe#unsubscribe", as: "unsubscribe"
   get "/unsubscribe_successful", to: "unsubscribe#unsubscribe_successful", as: "unsubscribe_successful"
   get "/unsubscribe_failed", to: "unsubscribe#unsubscribe_failed", as: "unsubscribe_failed"

--- a/lib/tasks/create_communication_records_indexes.rake
+++ b/lib/tasks/create_communication_records_indexes.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# one-off task to create db index for notification_id on the communication_records collection
+namespace :one_off do
+  desc "Create the notification_id index on the communication_records collection"
+  task create_communication_records_indexes: :environment do
+    WasteCarriersEngine::CommunicationRecord.collection.indexes.create_one(
+      { notification_id: 1 },
+      background: true
+    )
+  end
+end

--- a/spec/fixtures/files/notify/delivery_receipt_callback.json
+++ b/spec/fixtures/files/notify/delivery_receipt_callback.json
@@ -1,0 +1,12 @@
+{
+  "id": "740e5834-3a29-46b4-9a6f-16142fde533a",
+  "reference": "CBDU999999",
+  "to": "recipient@example.com",
+  "status": "delivered",
+  "created_at": "2026-07-08T12:15:30.000000Z",
+  "completed_at": "2026-07-08T12:15:30.000000Z",
+  "sent_at": "2026-07-08T12:15:30.000000Z",
+  "notification_type": "email",
+  "template_id": "f33517ff-2a88-4f6e-b855-c550268ce08a",
+  "template_version": 1
+}

--- a/spec/fixtures/files/notify/returned_letter_callback.json
+++ b/spec/fixtures/files/notify/returned_letter_callback.json
@@ -1,0 +1,12 @@
+{
+  "notification_id": "740e5834-3a29-46b4-9a6f-16142fde533a",
+  "reference": "CBDU999999",
+  "date_sent": "2026-07-08T12:15:30.000000Z",
+  "sent_by": "sender@example.com",
+  "template_name": "confirmation_letter",
+  "template_id": "f33517ff-2a88-4f6e-b855-c550268ce08a",
+  "template_version": 1,
+  "spreadsheet_file_name": null,
+  "spreadsheet_row_number": null,
+  "upload_letter_file_name": null
+}

--- a/spec/jobs/waste_carriers_engine/notify_callback_job_spec.rb
+++ b/spec/jobs/waste_carriers_engine/notify_callback_job_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NotifyCallbackJob do
+    describe ".perform_later" do
+      subject(:perform_later) { described_class.perform_later(callback_payload) }
+
+      let(:callback_payload) { { "id" => "test-uuid", "status" => "delivered", "notification_type" => "email" } }
+
+      it { expect { perform_later }.not_to raise_error }
+
+      it { expect { perform_later }.to have_enqueued_job(described_class).exactly(:once) }
+    end
+
+    describe ".perform_now" do
+      subject(:perform_now) { described_class.perform_now(callback_payload) }
+
+      let(:callback_payload) { { "id" => "test-uuid", "status" => "delivered", "notification_type" => "email" } }
+      let(:service_result) { { notification_id: "test-uuid", status: "delivered" } }
+
+      before do
+        allow(NotifyCallbackHandlerService).to receive(:run).and_return(service_result)
+        allow(Rails.logger).to receive(:info)
+      end
+
+      it "calls NotifyCallbackHandlerService with the payload" do
+        perform_now
+
+        expect(NotifyCallbackHandlerService).to have_received(:run).with(callback_payload)
+      end
+
+      it "logs the result" do
+        perform_now
+
+        expect(Rails.logger).to have_received(:info).with(/notification_id: test-uuid, status: delivered/)
+      end
+
+      context "when the handler raises an error" do
+        before do
+          allow(NotifyCallbackHandlerService).to receive(:run).and_raise(StandardError.new("Test error"))
+          allow(Airbrake).to receive(:notify)
+          allow(Rails.logger).to receive(:error)
+        end
+
+        context "with a delivery receipt callback payload" do
+          it "notifies Airbrake" do
+            perform_now
+
+            expect(Airbrake).to have_received(:notify).with(
+              an_instance_of(StandardError),
+              hash_including(notification_id: "test-uuid")
+            )
+          end
+
+          it "logs the error" do
+            perform_now
+
+            expect(Rails.logger).to have_received(:error).with(/Error running NotifyCallbackJob/)
+          end
+        end
+
+        context "with a returned letter callback payload" do
+          let(:callback_payload) { { "notification_id" => "letter-uuid", "template_name" => "confirmation" } }
+
+          it "extracts notification_id from the returned letter payload" do
+            perform_now
+
+            expect(Airbrake).to have_received(:notify).with(
+              an_instance_of(StandardError),
+              hash_including(notification_id: "letter-uuid")
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/waste_carriers_engine/notify_callbacks_spec.rb
+++ b/spec/requests/waste_carriers_engine/notify_callbacks_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "NotifyCallbacks" do
+
+    describe "POST /notify_callback" do
+      subject(:callback_request) { post "/notify_callback", headers: headers, params: callback_body }
+
+      let(:callback_body) { file_fixture("notify/delivery_receipt_callback.json").read }
+      let(:bearer_token) { "test-bearer-token-123" }
+      let(:valid_headers) do
+        {
+          "Authorization" => "Bearer #{bearer_token}",
+          "Content-Type" => "application/json"
+        }
+      end
+
+      before do
+        allow(Airbrake).to receive(:notify)
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with("NOTIFY_CALLBACK_BEARER_TOKEN", nil).and_return(bearer_token)
+      end
+
+      shared_examples "fails validation" do
+        it { expect { callback_request }.not_to have_enqueued_job(NotifyCallbackJob) }
+
+        it "notifies Airbrake" do
+          callback_request
+
+          expect(Airbrake).to have_received(:notify)
+        end
+
+        it "returns HTTP 200" do
+          callback_request
+
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      context "with no Authorization header" do
+        let(:headers) { { "Content-Type" => "application/json" } }
+
+        it_behaves_like "fails validation"
+      end
+
+      context "with an invalid bearer token" do
+        let(:headers) do
+          {
+            "Authorization" => "Bearer wrong-token",
+            "Content-Type" => "application/json"
+          }
+        end
+
+        it_behaves_like "fails validation"
+      end
+
+      context "with no configured bearer token" do
+        let(:headers) { valid_headers }
+
+        before do
+          allow(ENV).to receive(:fetch).with("NOTIFY_CALLBACK_BEARER_TOKEN", nil).and_return(nil)
+        end
+
+        it_behaves_like "fails validation"
+      end
+
+      context "with a valid bearer token" do
+        let(:headers) { valid_headers }
+
+        it "returns HTTP 200" do
+          callback_request
+
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "does not notify Airbrake" do
+          callback_request
+
+          expect(Airbrake).not_to have_received(:notify)
+        end
+
+        it "enqueues a NotifyCallbackJob" do
+          expect { callback_request }.to have_enqueued_job(NotifyCallbackJob).exactly(:once)
+        end
+
+        context "with a returned letter callback body" do
+          let(:callback_body) { file_fixture("notify/returned_letter_callback.json").read }
+
+          it "returns HTTP 200 and enqueues a NotifyCallbackJob" do
+            expect { callback_request }.to have_enqueued_job(NotifyCallbackJob).exactly(:once)
+
+            expect(response).to have_http_status(:ok)
+          end
+        end
+
+        context "with an invalid JSON body" do
+          let(:callback_body) { "not-json" }
+
+          it_behaves_like "fails validation"
+        end
+      end
+    end
+  end
+end

--- a/spec/services/waste_carriers_engine/notify/certificate_renewal_email_service_spec.rb
+++ b/spec/services/waste_carriers_engine/notify/certificate_renewal_email_service_spec.rb
@@ -27,7 +27,11 @@ module WasteCarriersEngine
         end
         let(:notifications_client) { instance_double(Notifications::Client) }
         let(:notifications_client_response_notification) do
-          instance_double(Notifications::Client::ResponseNotification, content: { "body" => "Email content" })
+          instance_double(
+            Notifications::Client::ResponseNotification,
+            id: "740e5834-3a29-46b4-9a6f-16142fde533a",
+            content: { "body" => "Email content" }
+          )
         end
 
         subject(:run_service) { described_class.run(registration: registration) }

--- a/spec/services/waste_carriers_engine/notify_callback_handler_service_spec.rb
+++ b/spec/services/waste_carriers_engine/notify_callback_handler_service_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe NotifyCallbackHandlerService do
+    let(:registration) { create(:registration, :has_required_data) }
+    let(:notification_id) { "740e5834-3a29-46b4-9a6f-16142fde533a" }
+    let(:communication_record) do
+      registration.communication_records.create(
+        notify_template_id: "f33517ff-2a88-4f6e-b855-c550268ce08a",
+        notification_id: notification_id,
+        notification_type: "email",
+        comms_label: "Test email",
+        sent_at: Time.now.utc,
+        sent_to: "recipient@example.com",
+        delivery_status: "sent"
+      )
+    end
+
+    describe ".run" do
+      context "with a delivery receipt callback" do
+        let(:payload) do
+          {
+            "id" => notification_id,
+            "reference" => "CBDU999999",
+            "to" => "recipient@example.com",
+            "status" => "delivered",
+            "notification_type" => "email"
+          }
+        end
+
+        before { communication_record }
+
+        it "updates the communication record delivery status" do
+          expect { described_class.run(payload) }
+            .to change { communication_record.reload.delivery_status }
+            .from("sent")
+            .to("delivered")
+        end
+
+        it "returns the notification_id and new status" do
+          result = described_class.run(payload)
+
+          expect(result).to eq(notification_id: notification_id, status: "delivered")
+        end
+
+        %w[permanent-failure temporary-failure technical-failure].each do |status|
+          context "when status is #{status}" do
+            let(:payload) do
+              {
+                "id" => notification_id,
+                "status" => status,
+                "notification_type" => "email"
+              }
+            end
+
+            it "updates the communication record delivery status to #{status}" do
+              expect { described_class.run(payload) }
+                .to change { communication_record.reload.delivery_status }
+                .from("sent")
+                .to(status)
+            end
+          end
+        end
+
+        context "when the communication record is not found" do
+          let(:payload) do
+            {
+              "id" => "unknown-uuid",
+              "status" => "delivered",
+              "notification_type" => "email"
+            }
+          end
+
+          it "returns not_found status" do
+            result = described_class.run(payload)
+
+            expect(result).to eq(notification_id: "unknown-uuid", status: "not_found")
+          end
+
+          it "logs a warning" do
+            allow(Rails.logger).to receive(:warn)
+
+            described_class.run(payload)
+
+            expect(Rails.logger).to have_received(:warn).with(/not found/)
+          end
+        end
+
+        context "when the communication record already has a terminal delivery status" do
+          before { communication_record.update!(delivery_status: "delivered") }
+
+          it "does not change the delivery status" do
+            expect { described_class.run(payload) }
+              .not_to change { communication_record.reload.delivery_status }
+          end
+
+          it "returns the existing terminal status" do
+            result = described_class.run(payload)
+
+            expect(result).to eq(notification_id: notification_id, status: "delivered")
+          end
+        end
+
+        context "when id is missing" do
+          let(:payload) { { "status" => "delivered", "notification_type" => "email" } }
+
+          it "raises an ArgumentError" do
+            expect { described_class.run(payload) }.to raise_error(ArgumentError, /Missing id/)
+          end
+        end
+
+        context "when status is missing" do
+          let(:payload) { { "id" => notification_id, "notification_type" => "email" } }
+
+          it "raises an ArgumentError" do
+            expect { described_class.run(payload) }.to raise_error(ArgumentError, /Missing status/)
+          end
+        end
+      end
+
+      context "with a returned letter callback" do
+        let(:payload) do
+          {
+            "notification_id" => notification_id,
+            "reference" => "CBDU999999",
+            "date_sent" => "2026-07-08T12:15:30.000000Z",
+            "template_name" => "confirmation_letter",
+            "template_id" => "f33517ff-2a88-4f6e-b855-c550268ce08a",
+            "template_version" => 1
+          }
+        end
+
+        before { communication_record }
+
+        it "updates the communication record delivery status to returned" do
+          expect { described_class.run(payload) }
+            .to change { communication_record.reload.delivery_status }
+            .from("sent")
+            .to("returned")
+        end
+
+        it "returns the notification_id and returned status" do
+          result = described_class.run(payload)
+
+          expect(result).to eq(notification_id: notification_id, status: "returned")
+        end
+
+        context "when notification_id is blank" do
+          let(:payload) { { "notification_id" => "", "template_name" => "confirmation_letter" } }
+
+          it "raises an ArgumentError" do
+            expect { described_class.run(payload) }.to raise_error(ArgumentError, /Missing notification_id/)
+          end
+        end
+      end
+
+      context "with an unrecognised payload" do
+        let(:payload) { { "foo" => "bar" } }
+
+        it "raises an ArgumentError" do
+          expect { described_class.run(payload) }.to raise_error(ArgumentError, /Unrecognised/)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/can_create_communication_record.rb
+++ b/spec/support/shared_examples/can_create_communication_record.rb
@@ -31,6 +31,7 @@ RSpec.shared_examples "can create a communication record" do |notification_type|
       expect(registration.communication_records.last[:sent_to]).to eq(expected_communication_record_attrs[:sent_to])
       expect(registration.communication_records.last[:content]).to eq(response.content["body"])
       expect(registration.communication_records.last[:delivery_status]).to eq("sent")
+      expect(registration.communication_records.last[:notification_id]).to eq(response.id)
     end
   end
 
@@ -61,6 +62,7 @@ RSpec.shared_examples "can create a communication record" do |notification_type|
       record = registration.communication_records.last
       expect(record[:delivery_status]).to eq("BadRequestError: Can't send to this recipient")
       expect(record[:content]).to be_nil
+      expect(record[:notification_id]).to be_nil
       expect(record[:notify_template_id]).to eq(template_id)
     end
   end


### PR DESCRIPTION
WCR - Implement message delivery status call back
https://eaflood.atlassian.net/browse/RUBY-4339


- add notification ID to communication records
- add NotifyCallbackHandlerService for handling delivery and returned letter callbacks
- add NotifyCallbackJob and specs
- add NotifyCallbacksController and specs
- add Notify callback route and update parameter logging for sensitive routes
- add one-off task to create notification_id index
- update CI env variables