### PR TITLE
[RUBY-4340] Capture the message subject on communication records

### DIFF
--- a/app/models/waste_carriers_engine/communication_record.rb
+++ b/app/models/waste_carriers_engine/communication_record.rb
@@ -11,6 +11,7 @@ module WasteCarriersEngine
     field :comms_label, type: String
     field :sent_at, type: DateTime
     field :sent_to, type: String
+    field :subject, type: String
     field :content, type: String
     field :delivery_status, type: String
 

--- a/app/services/concerns/waste_carriers_engine/can_record_communication.rb
+++ b/app/services/concerns/waste_carriers_engine/can_record_communication.rb
@@ -28,6 +28,7 @@ module WasteCarriersEngine
         comms_label: comms_label,
         sent_at: Time.now.utc,
         sent_to: recipient,
+        subject: response&.content&.fetch("subject", nil),
         content: response&.content&.fetch("body", nil),
         delivery_status: delivery_status || (DEFAULT_DELIVERY_STATUS if response)
       }

--- a/spec/support/shared_examples/can_create_communication_record.rb
+++ b/spec/support/shared_examples/can_create_communication_record.rb
@@ -24,14 +24,15 @@ RSpec.shared_examples "can create a communication record" do |notification_type|
     Timecop.freeze(time_sent) do
       response = nil
       expect { response = run_service }.to change { registration.communication_records.count }.by(1)
-      expect(registration.communication_records.last[:notify_template_id]).to eq(expected_communication_record_attrs[:notify_template_id])
-      expect(registration.communication_records.last[:notification_type]).to eq(expected_communication_record_attrs[:notification_type])
-      expect(registration.communication_records.last[:comms_label]).to eq(expected_communication_record_attrs[:comms_label])
-      expect(registration.communication_records.last[:sent_at]).to eq(expected_communication_record_attrs[:sent_at])
-      expect(registration.communication_records.last[:sent_to]).to eq(expected_communication_record_attrs[:sent_to])
-      expect(registration.communication_records.last[:content]).to eq(response.content["body"])
-      expect(registration.communication_records.last[:delivery_status]).to eq("sent")
-      expect(registration.communication_records.last[:notification_id]).to eq(response.id)
+
+      expect(registration.communication_records.last).to have_attributes(
+        expected_communication_record_attrs.merge(
+          notification_id: response.id,
+          subject: response.content["subject"],
+          content: response.content["body"],
+          delivery_status: "sent"
+        )
+      )
     end
   end
 
@@ -61,6 +62,7 @@ RSpec.shared_examples "can create a communication record" do |notification_type|
 
       record = registration.communication_records.last
       expect(record[:delivery_status]).to eq("BadRequestError: Can't send to this recipient")
+      expect(record[:subject]).to be_nil
       expect(record[:content]).to be_nil
       expect(record[:notification_id]).to be_nil
       expect(record[:notify_template_id]).to eq(template_id)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-4340

Stores the message subject from the Notify response on communication records, so the back office can display it in the communication history detail page.